### PR TITLE
Thriftserver resources

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,4 +227,16 @@ public interface FhirEtlOptions extends PipelineOptions {
   String getSourceJsonFilePattern();
 
   void setSourceJsonFilePattern(String value);
+
+  @Description("Prefix required for Thrift Server Parquet files location.")
+  @Default.String("")
+  String getThriftServerParquetPath();
+
+  void setThriftServerParquetPath(String value);
+
+  @Description("Timestamp suffix to be used in Thrift Server Hive table name.")
+  @Default.String("")
+  String getTimestampSuffix();
+
+  void setTimestampSuffix(String value);
 }

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -71,6 +71,12 @@
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>
       <artifactId>hapi-fhir-base</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -40,4 +40,6 @@ fhirdata:
 
   maxWorkers: 10
 
+  createHiveResourceTables: true
+
   hiveJdbcDriver: "org.apache.hive.jdbc.HiveDriver"

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -40,6 +40,6 @@ fhirdata:
 
   maxWorkers: 10
 
-  createHiveResourceTables: true
+  createHiveResourceTables: false
 
   hiveJdbcDriver: "org.apache.hive.jdbc.HiveDriver"

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -23,6 +23,11 @@ fhirdata:
 
   dwhRootPrefix: "config/controller_DWH_ORIG"
 
+  # This should be exactly the same as used in dwhRootPrefix
+  thriftServerParquetPathPrefix: "controller_DWH_ORIG"
+
+  thriftserverHiveConfig: "config/thriftserver-hive-config.json"
+
   # The schedule format is similar to Spring's CronExpression, i.e.,
   # "second minute hour day-of-the-month month day-of-the-week", e.g.,
   # "0 0 * * * *" means top of every hour;
@@ -35,6 +40,4 @@ fhirdata:
 
   maxWorkers: 10
 
-
-
-
+  hiveJdbcDriver: "org.apache.hive.jdbc.HiveDriver"

--- a/pipelines/controller/config/thriftserver-hive-config.json
+++ b/pipelines/controller/config/thriftserver-hive-config.json
@@ -1,0 +1,8 @@
+{
+  "databaseService" : "hive2",
+  "databaseHostName" : "172.17.0.1",
+  "databasePort" : "10001",
+  "databaseUser" : "hive",
+  "databasePassword" : "",
+  "databaseName" : "default"
+}

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -58,7 +58,11 @@
         <!--exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-to-slf4j</artifactId>
-        </exclusion-->
+        </exclusion>-->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jul-to-slf4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -83,6 +87,39 @@
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>common</artifactId>
       <version>${project.parent.version}</version>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.apache.hive/hive-jdbc-->
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-jdbc</artifactId>
+      <version>3.1.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>javax.servlet.jsp-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-runner</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-hadoop-bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
@@ -78,6 +78,8 @@ public class DataProperties {
 
   private String thriftServerParquetPathPrefix;
 
+  private boolean createHiveResourceTables;
+
   private String incrementalSchedule;
 
   private String resourceList;

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,13 @@ public class DataProperties {
 
   private String dbConfig;
 
+  private String thriftserverHiveConfig;
+
+  private String hiveJdbcDriver;
+
   private String dwhRootPrefix;
+
+  private String thriftServerParquetPathPrefix;
 
   private String incrementalSchedule;
 
@@ -89,10 +95,15 @@ public class DataProperties {
     options.setFhirServerUrl(fhirServerUrl);
     options.setFhirDatabaseConfigPath(dbConfig);
     options.setResourceList(resourceList);
-    // Note we prefer to use a human-readable name but we do not rely on the timestamp being in
-    // the DWH name; the reason for replacing `:` is easier copy/paste from the UI to `bash`.
-    options.setOutputParquetPath(
-        dwhRootPrefix + TIMESTAMP_PREFIX + Instant.now().toString().replaceAll(":", "-"));
+
+    // Using underscore for suffix as hyphens are discouraged in hive table names.
+    String timestampSuffix =
+        Instant.now().toString().replaceAll(":", "-").replaceAll("-", "_").replaceAll("\\.", "_");
+    options.setOutputParquetPath(dwhRootPrefix + TIMESTAMP_PREFIX + timestampSuffix);
+    options.setThriftServerParquetPath(
+        thriftServerParquetPathPrefix + TIMESTAMP_PREFIX + timestampSuffix);
+    options.setTimestampSuffix(timestampSuffix);
+
     options.setRunner(FlinkRunner.class);
     FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);
     flinkOptions.setMaxParallelism(getMaxWorkers());

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
@@ -248,10 +248,12 @@ public class PipelineManager {
       try {
         FhirEtlOptions options = pipeline.getOptions().as(FhirEtlOptions.class);
         EtlUtils.runPipelineWithTimestamp(pipeline, options);
-        createHiveResources(
-            options.getResourceList(),
-            options.getTimestampSuffix(),
-            options.getThriftServerParquetPath());
+        if (dataProperties.isCreateHiveResourceTables()) {
+          createHiveResources(
+              options.getResourceList(),
+              options.getTimestampSuffix(),
+              options.getThriftServerParquetPath());
+        }
         if (mergerOptions == null) { // Do not update DWH yet if this was an incremental run.
           manager.updateDwh(options.getOutputParquetPath());
         } else {
@@ -259,10 +261,12 @@ public class PipelineManager {
           Pipeline mergerPipeline = ParquetMerger.createMergerPipeline(mergerOptions, fhirContext);
           logger.info("Merger options are {}", mergerOptions);
           EtlUtils.runMergerPipelineWithTimestamp(mergerPipeline, mergerOptions);
-          createHiveResources(
-              options.getResourceList(),
-              options.getTimestampSuffix(),
-              mergerOptions.getMergedDwh());
+          if (dataProperties.isCreateHiveResourceTables()) {
+            createHiveResources(
+                options.getResourceList(),
+                options.getTimestampSuffix(),
+                mergerOptions.getMergedDwh());
+          }
           manager.updateDwh(mergerOptions.getMergedDwh());
         }
         manager.setLastRunStatus(LastRunStatus.SUCCESS);

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/ThriftServerHiveResourceManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/ThriftServerHiveResourceManager.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This class manages to create resources on Thrift Server post each pipeline run. */
+public class ThriftServerHiveResourceManager {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ThriftServerHiveResourceManager.class.getName());
+  private final String jdbcDriverClass;
+  private final String jdbcUrl;
+  private final String user;
+  private final String password;
+
+  public ThriftServerHiveResourceManager(
+      String jdbcDriverClass, String jdbcUrl, String user, String password) {
+    this.jdbcDriverClass = jdbcDriverClass;
+    this.jdbcUrl = jdbcUrl;
+    this.user = user;
+    this.password = password;
+  }
+
+  /**
+   * Method to create resources on Thrift Server Hive.
+   *
+   * @param resourceList Comma separated list of resources such as Patient, Observation, Encounter
+   * @param timestamp Timestamp suffix to be used in table name.
+   * @param thriftServerParquetPath location of parquet files in Thrift Server
+   * @throws SQLException
+   */
+  public void createResources(String resourceList, String timestamp, String thriftServerParquetPath)
+      throws SQLException {
+    try {
+      Class.forName(jdbcDriverClass);
+    } catch (ClassNotFoundException e) {
+      logger.error("Unable to locate Hive JDBC driver.");
+      return;
+    }
+    if (resourceList == null || resourceList.isEmpty()) {
+      return;
+    }
+    String[] resources = resourceList.split(",");
+    if (resources == null || resources.length == 0) {
+      return;
+    }
+    try (Connection connection = DriverManager.getConnection(jdbcUrl)) {
+      for (String resource : resources) {
+        createResource(connection, resource, timestamp, thriftServerParquetPath);
+      }
+    }
+  }
+
+  /**
+   * This method will create table 'encounter_2023_01_24t18_42_54_302111z' if the given resource is
+   * Encounter and the timestamp suffix is 2023_01_24t18_42_54_302111z
+   *
+   * <p>wrt PARQUET LOCATION, /dwh is symlink for mounted volume defined in docker-compose and
+   * thriftServerParquetPath would be controller_DWH_ORIG_TIMESTAMP_2023_01_24T18_42_54_302111Z
+   */
+  private void createResource(
+      Connection connection, String resource, String timestamp, String thriftServerParquetPath)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      String sql =
+          String.format(
+              "CREATE TABLE IF NOT EXISTS default.%s_%s USING PARQUET LOCATION '/dwh/%s/%s'",
+              resource, timestamp, thriftServerParquetPath, resource);
+      statement.execute(sql);
+    }
+  }
+}

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -94,13 +94,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Add slf4j API frontend binding with JUL backend -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-
     <!-- Use logback as the logging framework. -->
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

Added mechanism to create resource tables on Hive behind Thrift Server. Whenever a full run or incremental run is started by user, the parquet files are generated in configured output folder which in turn is symlined to spark thriftserver container. Prior to this PR, users had to create tables manually: https://github.com/google/fhir-data-pipes/issues/447
Now, these tables will be created automatically. The table name would be of <resource-timestamp> format e.g. encounter_2023_01_24t18_42_54_302111z.

The creation of resource tables is controlled configurable parameter: createHiveResourceTables

## E2E test

Tested creation of tables on spark thriftserver using beeline cli and queried count of records in the tables as well.

TESTED:

Had to make lot of changes in pom.xml dependencies to make logging and other functionalities work.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
