### PR TITLE
Add auto-table generation to single-machine docker compose config.

### DIFF
--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -16,9 +16,10 @@
 
 # This config is meant to work with `compose-controller-spark-sql.yaml`.
 fhirdata:
-  fhirServerUrl: "http://172.17.0.1:8091/fhir"
+  fhirServerUrl: "http://hapi-server:8080/fhir"
   dbConfig: "config/hapi-postgres-config_local.json"
   dwhRootPrefix: "/dwh/controller_DWH"
+  thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   # The schedule format is similar to Spring's CronExpression, i.e.,
   # "second minute hour day-of-the-month month day-of-the-week", e.g.,
   # "0 0 * * * *" means top of every hour;
@@ -28,7 +29,5 @@ fhirdata:
   # Comma separated list of resources to fetch/monitor.
   resourceList: "Patient,Encounter,Observation"
   maxWorkers: 10
-
-
-
-
+  createHiveResourceTables: true
+  hiveJdbcDriver: "org.apache.hive.jdbc.HiveDriver"

--- a/docker/config/hapi-postgres-config_local.json
+++ b/docker/config/hapi-postgres-config_local.json
@@ -1,6 +1,6 @@
 {
   "databaseService" : "postgresql",
-  "databaseHostName" : "172.17.0.1",
+  "databaseHostName" : "hapi-fhir-db",
   "databasePort" : "5432",
   "databaseUser" : "admin",
   "databasePassword" : "admin",

--- a/docker/config/thriftserver-hive-config_local.json
+++ b/docker/config/thriftserver-hive-config_local.json
@@ -1,0 +1,8 @@
+{
+  "databaseService" : "hive2",
+  "databaseHostName" : "spark-thriftserver",
+  "databasePort" : "10000",
+  "databaseUser" : "hive",
+  "databasePassword" : "",
+  "databaseName" : "default"
+}

--- a/docker/hapi-compose.yml
+++ b/docker/hapi-compose.yml
@@ -26,6 +26,9 @@ services:
       POSTGRES_PASSWORD: 'admin'
     volumes:
       - hapi-fhir-db:/var/lib/postgresql/data
+    networks:
+      - cloudbuild
+      - default
     
   hapi-server:
     # Using an older version as the latest image broke our build.
@@ -44,12 +47,15 @@ services:
     restart: unless-stopped
     ports:
       - 8091:8080
+    networks:
+      - cloudbuild
+      - default
       
 volumes:
   hapi-fhir-db:
   hapi-server:
 
 networks:
-  default:
-    external:
-      name: cloudbuild # Needed for Continuous integration
+  cloudbuild:
+    external: true
+    name: cloudbuild # Needed for Continuous integration


### PR DESCRIPTION
## Description of what I changed

Add auto-table generation to single-machine docker compose config.

Also adjusts network settings to allow single-machine docker compose to connect to the test hapi-fhir server using default values. This leverages the fact that docker-compose creates a default network based on the folder the config file is in (in this case, the network is `docker_default`) and connects all containers to it. A side effect is that if you have multiple docker-compose configs in the same directory, they have the same default network name and will connect to it. Because of that, you can reference services by hostname and the container's port number.

After the changes hapi-fhir-server still connects to an external network named `cloudbuild`, but I was not sure how/what to test to make sure the tests that leverage this image continue to work correctly.

## E2E test

TESTED:

Manually brought up a `hapi-compose` and `compose-controller-spark-sql`, ran everything with default values, confirmed that expected tables were auto-generated.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
