### PR TITLE
Fix for auto resource creation on incremental run

### DIFF
--- a/pipelines/controller/src/main/java/org/openmrs/analytics/HiveTableManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/HiveTableManager.java
@@ -86,6 +86,17 @@ public class HiveTableManager {
               thriftServerParquetPath,
               resource);
       statement.execute(sql);
+
+      // Drop canonical table if exists.
+      sql = String.format("DROP TABLE IF EXISTS default.%s", resource);
+      statement.execute(sql);
+
+      // Create canonical table with latest parquet files.
+      sql =
+          String.format(
+              "CREATE TABLE IF NOT EXISTS default.%s USING PARQUET LOCATION '%s/%s/%s'",
+              resource, THRIFT_CONTAINER_PARQUET_PATH_PREFIX, thriftServerParquetPath, resource);
+      statement.execute(sql);
     }
   }
 }

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
@@ -260,12 +260,6 @@ public class PipelineManager {
       try {
         FhirEtlOptions options = pipeline.getOptions().as(FhirEtlOptions.class);
         EtlUtils.runPipelineWithTimestamp(pipeline, options);
-        if (dataProperties.isCreateHiveResourceTables()) {
-          createHiveResourceTables(
-              options.getResourceList(),
-              pipelineConfig.getTimestampSuffix(),
-              pipelineConfig.getThriftServerParquetPath());
-        }
         if (mergerOptions == null) { // Do not update DWH yet if this was an incremental run.
           manager.updateDwh(options.getOutputParquetPath());
         } else {
@@ -273,13 +267,13 @@ public class PipelineManager {
           Pipeline mergerPipeline = ParquetMerger.createMergerPipeline(mergerOptions, fhirContext);
           logger.info("Merger options are {}", mergerOptions);
           EtlUtils.runMergerPipelineWithTimestamp(mergerPipeline, mergerOptions);
-          if (dataProperties.isCreateHiveResourceTables()) {
-            createHiveResourceTables(
-                options.getResourceList(),
-                pipelineConfig.getTimestampSuffix(),
-                mergerOptions.getMergedDwh());
-          }
           manager.updateDwh(mergerOptions.getMergedDwh());
+        }
+        if (dataProperties.isCreateHiveResourceTables()) {
+          createHiveResourceTables(
+              options.getResourceList(),
+              pipelineConfig.getTimestampSuffix(),
+              pipelineConfig.getThriftServerParquetPath());
         }
         manager.setLastRunStatus(LastRunStatus.SUCCESS);
       } catch (Exception e) {


### PR DESCRIPTION
## Description of what I changed
- Added fix for auto creation of resources upon incremental run. The output directory was not being set properly.
- Also added mechanism to create canonical table on each run. Be it full or incremental, the pipeline shall drop existing canonical tables if any and create new based on newly generated parquet files: https://github.com/google/fhir-data-pipes/issues/530


## E2E test

- I tested build locally and made sure nothing is breaking.
- I tested full batch run and verified that resources are being created.
- I tested incremental run and verified that resources are being created.

TESTED:

Tested locally for batch and incremental runs.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [ ] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
