### PR TITLE
Fixes incorrect primitive type comparison in Bunsen

### DIFF
--- a/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
+++ b/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
@@ -328,9 +328,9 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
       for (TypeRefComponent typeRef: element.getType()) {
 
-        if (PRIMITIVE_TYPES.contains(typeRef.getCode().toLowerCase())) {
+        if (PRIMITIVE_TYPES.contains(typeRef.getCode())) {
 
-          T child = visitor.visitPrimitive(elementName, typeRef.getCode().toLowerCase());
+          T child = visitor.visitPrimitive(elementName, typeRef.getCode());
           choiceTypes.put(typeRef.getCode(), child);
 
         } else {

--- a/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -300,9 +300,9 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
       for (TypeRefComponent typeRef: element.getType()) {
 
-        if (PRIMITIVE_TYPES.contains(typeRef.getCode().toLowerCase())) {
+        if (PRIMITIVE_TYPES.contains(typeRef.getCode())) {
 
-          T child = visitor.visitPrimitive(elementName, typeRef.getCode().toLowerCase());
+          T child = visitor.visitPrimitive(elementName, typeRef.getCode());
           choiceTypes.put(typeRef.getCode(), child);
 
         } else {


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #556 

The root cause of the failure for Immunization was the `doseNumber[x]` field of `protocolApplied` in Immunization(https://hl7.org/fhir/immunization.html). And the reason that failed was because of `positiveInt` primitive datatype. In the code that is fixed now, we were using `toLowerCase()` when comparing the types which was failing for `positiveInt`. This does not seem to be a new regression and/or caused by R4 migration. It has been in Bunsen code since a long time ago and even in STU3 we have `positiveInt` (and it is suspicious why it was not discovered before).

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:
I ran this command before and after this fix:
```
java -cp ./pipelines/batch/target/batch-bundled-0.1.0-SNAPSHOT.jar \
  org.openmrs.analytics.FhirEtl --fhirServerUrl=http://localhost:9001/fhir \
  --resourceList=Immunization --outputParquetPath=[PATH]
```
Before the fix it was failing with a Bunsen exception; after it worked fine.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
