### PR TITLE
Revert spark image version back to 3.3

### DIFF
--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -42,10 +42,8 @@ services:
     ports:
       - '8090:8080'
 
-  # TODO: switch back to version 3.3 after the following issue is resolved:
-  # https://github.com/bitnami/containers/issues/19802
   spark:
-    image: docker.io/bitnami/spark:3.3.1-debian-11-r19
+    image: docker.io/bitnami/spark:3.3
     container_name: spark-master
     environment:
       - SPARK_MODE=master
@@ -55,7 +53,7 @@ services:
       - ${DWH_ROOT}:/dwh
 
   spark-worker:
-    image: docker.io/bitnami/spark:3.3.1-debian-11-r19
+    image: docker.io/bitnami/spark:3.3
     container_name: spark-worker
     environment:
       - SPARK_MODE=worker
@@ -66,7 +64,7 @@ services:
       - ${DWH_ROOT}:/dwh
 
   thriftserver:
-    image: docker.io/bitnami/spark:3.3.1-debian-11-r19
+    image: docker.io/bitnami/spark:3.3
     container_name: spark-thriftserver
     command:
       - sbin/start-thriftserver.sh


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

The issue we reported with the 3.3 version of the Bitnami Spark image is now fixed ([here](https://github.com/bitnami/containers/issues/19802#issuecomment-1381498714)); hence reverting to that version.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the HAPI server using `hapi-compose.yml` and the modified compose file `compose-controller-spark-sql.yaml` then ran a full-run of the pipeline and queried the created DWH.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
