### PR TITLE
Added the new search by ID stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # This creates a docker image for running the controller web-app. It is expected
 # that in real use-cases, the config dir will be mounted to the host machine.
 
-FROM maven:3.8.5-openjdk-11 as build
+FROM maven:3.8.7-eclipse-temurin-17-focal as build
 
 RUN apt-get update && apt-get install -y nodejs npm
 RUN npm cache clean -f && npm install -g n && n stable
@@ -31,7 +31,7 @@ COPY ./utils ./utils
 # Note this build can be faster by excluding some uber-jars we don't copy.
 RUN mvn --batch-mode clean package -Dlicense.skip=true
 
-FROM eclipse-temurin:11-jdk-focal as main
+FROM eclipse-temurin:17-jdk-focal as main
 
 WORKDIR /app
 

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -21,7 +21,7 @@
 
     <compile.source>11</compile.source>
 
-    <hapi.fhir.version>6.4.3</hapi.fhir.version>
+    <hapi.fhir.version>6.4.4</hapi.fhir.version>
     <avro.version>1.11.1</avro.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>2.2</hamcrest.version>

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -208,7 +208,7 @@
 
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -236,7 +236,7 @@
 
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0</version>
           <configuration>
               <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -651,7 +651,7 @@
       <dependency>
         <groupId> org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
-        <version>3.3.4</version>
+        <version>3.3.5</version>
       </dependency>
 
     </dependencies>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
 # Note license checking will fail on Cloud Build because of .git dependencies
 # and there is not much point updating license headers at this stage anyway.
 # Ditto for Spotless (fails because of NPM dep).
-- name: 'adoptopenjdk/maven-openjdk11'
+- name: 'maven:3.8.5-openjdk-17'
   id: 'Compile Bunsen and Pipeline'
   entrypoint: /bin/bash
   args:

--- a/pipelines/batch/Dockerfile
+++ b/pipelines/batch/Dockerfile
@@ -17,7 +17,7 @@
 # and run the docker image for you.  
 
 
-FROM adoptopenjdk/maven-openjdk11
+FROM eclipse-temurin:17-jdk-focal
 
 # TODO: Investigate why switching to the next base image, breaks the e2e in a
 # strange way, i.e., in one of the last steps, when running JDBC version of the

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FetchResourceIds.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FetchResourceIds.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.cerner.bunsen.FhirContexts;
+import java.io.IOException;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This is a DoFn for fetching resource IDs for given search URLs. */
+class FetchResourceIds extends DoFn<SearchSegmentDescriptor, String> {
+  private static final Logger log = LoggerFactory.getLogger(FetchResourceIds.class);
+  private final String stageIdentifier;
+  protected FhirSearchUtil fhirSearchUtil;
+  private FhirClientUtil fhirClientUtil;
+  private final String sourceUrl;
+  private final String sourceUser;
+  private final String sourcePw;
+  protected FhirContext fhirContext;
+  private final Counter totalIdFetchTimeMillis;
+
+  FetchResourceIds(FhirEtlOptions options, String stageIdentifier) {
+    this.stageIdentifier = stageIdentifier;
+    this.totalIdFetchTimeMillis =
+        Metrics.counter(EtlUtils.METRICS_NAMESPACE, "totalIdFetchTimeMillis_" + stageIdentifier);
+    this.sourceUrl = options.getFhirServerUrl();
+    this.sourceUser = options.getFhirServerUserName();
+    this.sourcePw = options.getFhirServerPassword();
+  }
+
+  @Setup
+  public void setup() {
+    fhirContext = FhirContexts.forR4();
+    fhirClientUtil = new FhirClientUtil(sourceUrl, sourceUser, sourcePw, fhirContext);
+    fhirSearchUtil = new FhirSearchUtil(fhirClientUtil);
+  }
+
+  @ProcessElement
+  public void processElement(@Element SearchSegmentDescriptor segment, OutputReceiver<String> out)
+      throws IOException {
+    String searchUrl = segment.searchUrl();
+    log.info(
+        String.format(
+            "Fetching %d resource IDs for stage %s; URL= %s",
+            segment.count(),
+            this.stageIdentifier,
+            searchUrl.substring(0, Math.min(200, searchUrl.length()))));
+    long fetchStartTime = System.currentTimeMillis();
+    Bundle bundle = fhirSearchUtil.searchByUrl(searchUrl, segment.count(), null);
+    totalIdFetchTimeMillis.inc(System.currentTimeMillis() - fetchStartTime);
+    if (bundle == null || bundle.getEntry() == null) {
+      log.error("This search returned no results: {}", searchUrl);
+      return;
+    }
+    for (BundleEntryComponent entry : bundle.getEntry()) {
+      Resource resource = entry.getResource();
+      out.output(resource.getIdPart());
+    }
+  }
+}

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FetchResources.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FetchResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public class FetchResources
       String searchUrl = segment.searchUrl();
       log.info(
           String.format(
-              "Fetching %d resources for state %s; URL= %s",
+              "Fetching %d resources for stage %s; URL= %s",
               segment.count(),
               this.stageIdentifier,
               searchUrl.substring(0, Math.min(200, searchUrl.length()))));

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FetchSearchPageFn.java
@@ -95,7 +95,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   @VisibleForTesting protected ParquetUtil parquetUtil;
 
-  protected OpenmrsUtil openmrsUtil;
+  protected FhirClientUtil fhirClientUtil;
 
   protected FhirSearchUtil fhirSearchUtil;
 
@@ -179,8 +179,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     fhirStoreUtil =
         FhirStoreUtil.createFhirStoreUtil(
             sinkPath, sinkUsername, sinkPassword, fhirContext.getRestfulClientFactory());
-    openmrsUtil = new OpenmrsUtil(sourceUrl, sourceUser, sourcePw, fhirContext);
-    fhirSearchUtil = new FhirSearchUtil(openmrsUtil);
+    fhirClientUtil = new FhirClientUtil(sourceUrl, sourceUser, sourcePw, fhirContext);
+    fhirSearchUtil = new FhirSearchUtil(fhirClientUtil);
     parquetUtil =
         new ParquetUtil(
             fhirContext.getVersion().getVersion(),

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/FhirSearchUtilTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/FhirSearchUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class FhirSearchUtilTest {
 
   private static final String SEARCH_URL = "Patient?given=TEST";
 
-  @Mock private OpenmrsUtil openmrsUtil;
+  @Mock private FhirClientUtil fhirClientUtil;
 
   @Mock private IGenericClient genericClient;
 
@@ -74,9 +74,9 @@ public class FhirSearchUtilTest {
     String bundleStr = Resources.toString(url, StandardCharsets.UTF_8);
     IParser parser = fhirContext.newJsonParser();
     bundle = parser.parseResource(Bundle.class, bundleStr);
-    fhirSearchUtil = new FhirSearchUtil(openmrsUtil);
-    when(openmrsUtil.getSourceFhirUrl()).thenReturn(BASE_URL);
-    when(openmrsUtil.getSourceClient()).thenReturn(genericClient);
+    fhirSearchUtil = new FhirSearchUtil(fhirClientUtil);
+    when(fhirClientUtil.getSourceFhirUrl()).thenReturn(BASE_URL);
+    when(fhirClientUtil.getSourceClient()).thenReturn(genericClient);
     when(genericClient.search()).thenReturn(untypedQuery);
     when(untypedQuery.byUrl(SEARCH_URL)).thenReturn(query);
     when(query.count(anyInt())).thenReturn(query);

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/JdbcFetchOpenMrsTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/JdbcFetchOpenMrsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,13 +130,13 @@ public class JdbcFetchOpenMrsTest extends TestCase {
     String resourceType = "Encounter";
     String baseBundleUrl = "https://test.com/" + resourceType;
     int batchSize = 2;
+    int numWorkers = 3;
     String[] uuIds = {"<uuid>", "<uuid>", "<uuid>", "<uuid>", "<uuid>", "<uuid>"};
     PCollection<SearchSegmentDescriptor> createdSegments =
         testPipeline
             .apply("Create input", Create.of(Arrays.asList(uuIds)))
             // Inject
-            .apply(
-                new JdbcFetchOpenMrs.CreateSearchSegments(resourceType, baseBundleUrl, batchSize));
+            .apply(new JdbcFetchOpenMrs.CreateSearchSegments(numWorkers, baseBundleUrl, batchSize));
     // create expected output
     List<SearchSegmentDescriptor> segments = new ArrayList<>();
     // first batch

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>3.3.4</version>
+      <version>3.3.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-app</artifactId>
-      <version>3.3.4</version>
+      <version>3.3.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-healthcare</artifactId>
-      <version>v1-rev20230207-2.0.0</version>
+      <version>v1-rev20230321-2.0.0</version>
     </dependency>
 
     <dependency>

--- a/pipelines/common/src/main/java/org/openmrs/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/org/openmrs/analytics/DwhFiles.java
@@ -129,7 +129,9 @@ public class DwhFiles {
     return incPath;
   }
 
-  /** @return true iff there is already an incremental run subdirectory in this DWH. */
+  /**
+   * @return true iff there is already an incremental run subdirectory in this DWH.
+   */
   public boolean hasIncrementalDir() throws IOException {
     List<MatchResult> matches =
         FileSystems.matchResources(Collections.singletonList(getIncrementalRunPath()));

--- a/pipelines/common/src/main/java/org/openmrs/analytics/FhirClientUtil.java
+++ b/pipelines/common/src/main/java/org/openmrs/analytics/FhirClientUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openmrs.analytics;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -26,9 +25,9 @@ import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class OpenmrsUtil {
+public class FhirClientUtil {
 
-  private static final Logger log = LoggerFactory.getLogger(OpenmrsUtil.class);
+  private static final Logger log = LoggerFactory.getLogger(FhirClientUtil.class);
 
   private final String fhirUrl;
 
@@ -38,7 +37,7 @@ public class OpenmrsUtil {
 
   private final FhirContext fhirContext;
 
-  OpenmrsUtil(String sourceFhirUrl, String sourceUser, String sourcePw, FhirContext fhirContext)
+  FhirClientUtil(String sourceFhirUrl, String sourceUser, String sourcePw, FhirContext fhirContext)
       throws IllegalArgumentException {
     this.fhirUrl = sourceFhirUrl;
     this.sourceUser = sourceUser;

--- a/pipelines/common/src/main/java/org/openmrs/analytics/model/DatabaseConfiguration.java
+++ b/pipelines/common/src/main/java/org/openmrs/analytics/model/DatabaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,8 @@ public class DatabaseConfiguration {
     Preconditions.checkNotNull(getDatabasePort());
     Preconditions.checkNotNull(getDatabaseName());
     return String.format(
-        "jdbc:%s://%s:%s/%s",
+        // For the TLS see: https://stackoverflow.com/questions/67332909
+        "jdbc:%s://%s:%s/%s?enabledTLSProtocols=TLSv1.2",
         getDatabaseService(), getDatabaseHostName(), getDatabasePort(), getDatabaseName());
   }
 

--- a/pipelines/common/src/test/java/org/openmrs/analytics/OpenmrsUtilTest.java
+++ b/pipelines/common/src/test/java/org/openmrs/analytics/OpenmrsUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,11 +47,11 @@ public class OpenmrsUtilTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   IGenericClient client;
 
-  OpenmrsUtil openmrsUtil;
+  FhirClientUtil fhirClientUtil;
 
   @Before
   public void setUp() throws Exception {
-    openmrsUtil = new OpenmrsUtil(SOURCE_FHIR_URL, "someuser", "somepw", fhirContext);
+    fhirClientUtil = new FhirClientUtil(SOURCE_FHIR_URL, "someuser", "somepw", fhirContext);
 
     doNothing().when(clientFactory).setSocketTimeout(any(Integer.class));
     when(fhirContext.getRestfulClientFactory()).thenReturn(clientFactory);
@@ -71,14 +71,14 @@ public class OpenmrsUtilTest {
     when(client.read().resource(resourceType).withId(RESOURCE_ID).execute())
         .thenReturn(testResource);
 
-    Patient result = (Patient) openmrsUtil.fetchFhirResource(resourceUrl);
+    Patient result = (Patient) fhirClientUtil.fetchFhirResource(resourceUrl);
 
     assertThat(result, equalTo(testResource));
   }
 
   @Test
   public void shouldGetSourceClient() {
-    IGenericClient result = openmrsUtil.getSourceClient();
+    IGenericClient result = fhirClientUtil.getSourceClient();
 
     assertThat(result, equalTo(client));
   }

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <java.version>11</java.version>
-    <spring-boot.version>2.7.5</spring-boot.version>
+    <spring-boot.version>3.0.5</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -29,7 +29,7 @@
   <description>A Spring Boot based controller for FHIR Analytics pipelines</description>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <spring-boot.version>3.0.5</spring-boot.version>
   </properties>
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -38,13 +38,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.2</junit.version>
-    <!-- We use an older version of logback because that is needed for
-      spring-boot-starter-logging; it uses org.slf4j.impl.StaticLoggerBinder
-      which was removed in 1.3 https://stackoverflow.com/questions/67082351
-      For the same reason, we use an older version of SLF4J too. -->
-    <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.11</logback.version>
-    <hapifhirVersion>6.4.2</hapifhirVersion>
+    <slf4j.version>2.0.7</slf4j.version>
+    <logback.version>1.4.6</logback.version>
+    <hapifhirVersion>6.4.4</hapifhirVersion>
     <hamcrest.version>2.2</hamcrest.version>
     <openmrsPlatformVersion>2.6.0-SNAPSHOT</openmrsPlatformVersion>
     <mockito.version>5.2.0</mockito.version>
@@ -263,7 +259,7 @@
 
               <!-- apply a specific flavor of google-java-format and reflow long strings -->
               <googleJavaFormat>
-                <version>1.11.0</version>
+                <version>1.15.0</version>
                 <style>GOOGLE</style>
                 <reflowLongStrings>true</reflowLongStrings>
               </googleJavaFormat>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -182,7 +182,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -49,7 +49,7 @@
     <openmrsPlatformVersion>2.6.0-SNAPSHOT</openmrsPlatformVersion>
     <mockito.version>5.2.0</mockito.version>
     <jcommander.version>1.82</jcommander.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <license-maven-plugin.version>4.2</license-maven-plugin.version>
     <beam.version>2.45.0</beam.version>
   </properties>
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -186,7 +186,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -158,7 +158,7 @@
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/pipelines/streaming/src/main/java/org/openmrs/analytics/DebeziumListener.java
+++ b/pipelines/streaming/src/main/java/org/openmrs/analytics/DebeziumListener.java
@@ -68,8 +68,8 @@ public class DebeziumListener extends RouteBuilder {
   FhirConverter createFhirConverter(CamelContext camelContext) throws Exception {
     FhirContext fhirContext = FhirContexts.forR4();
     String fhirBaseUrl = params.fhirServerUrl;
-    OpenmrsUtil openmrsUtil =
-        new OpenmrsUtil(
+    FhirClientUtil fhirClientUtil =
+        new FhirClientUtil(
             fhirBaseUrl, params.fhirServerUserName, params.fhirServerPassword, fhirContext);
     FhirStoreUtil fhirStoreUtil =
         FhirStoreUtil.createFhirStoreUtil(
@@ -102,7 +102,7 @@ public class DebeziumListener extends RouteBuilder {
     statusServer.setVar(
         "start", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     return new FhirConverter(
-        openmrsUtil,
+        fhirClientUtil,
         fhirStoreUtil,
         parquetUtil,
         params.fhirDebeziumConfigPath,

--- a/pipelines/streaming/src/main/java/org/openmrs/analytics/FhirConverter.java
+++ b/pipelines/streaming/src/main/java/org/openmrs/analytics/FhirConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openmrs.analytics;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -40,7 +39,7 @@ public class FhirConverter implements Processor {
 
   private static final Logger log = LoggerFactory.getLogger(FhirConverter.class);
 
-  private final OpenmrsUtil openmrsUtil;
+  private final FhirClientUtil fhirClientUtil;
 
   private final FhirStoreUtil fhirStoreUtil;
 
@@ -54,7 +53,7 @@ public class FhirConverter implements Processor {
 
   @VisibleForTesting
   FhirConverter() {
-    this.openmrsUtil = null;
+    this.fhirClientUtil = null;
     this.fhirStoreUtil = null;
     this.parquetUtil = null;
     this.databaseConfiguration = null;
@@ -63,7 +62,7 @@ public class FhirConverter implements Processor {
   }
 
   public FhirConverter(
-      OpenmrsUtil openmrsUtil,
+      FhirClientUtil fhirClientUtil,
       FhirStoreUtil fhirStoreUtil,
       ParquetUtil parquetUtil,
       String configFileName,
@@ -71,7 +70,7 @@ public class FhirConverter implements Processor {
       StatusServer statusServer)
       throws IOException {
     // TODO add option for switching to Parquet-file outputs.
-    this.openmrsUtil = openmrsUtil;
+    this.fhirClientUtil = fhirClientUtil;
     this.fhirStoreUtil = fhirStoreUtil;
     this.parquetUtil = parquetUtil;
     this.databaseConfiguration = DatabaseConfiguration.createConfigFromFile(configFileName);
@@ -132,7 +131,7 @@ public class FhirConverter implements Processor {
     }
     final String fhirUrl = config.getLinkTemplates().get("fhir").replace("{uuid}", uuid);
     log.info("Fetching FHIR resource at " + fhirUrl);
-    Resource resource = openmrsUtil.fetchFhirResource(fhirUrl);
+    Resource resource = fhirClientUtil.fetchFhirResource(fhirUrl);
     if (resource == null) {
       // TODO: check how this can be signalled to Camel to be retried.
       return;

--- a/pipelines/streaming/src/test/java/org/openmrs/analytics/FhirConverterTest.java
+++ b/pipelines/streaming/src/test/java/org/openmrs/analytics/FhirConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Google LLC
+ * Copyright 2020-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openmrs.analytics;
 
 import io.debezium.data.Envelope.Operation;
@@ -47,7 +46,7 @@ public class FhirConverterTest extends CamelTestSupport {
   @Produce(TEST_ROUTE)
   protected ProducerTemplate eventsProducer;
 
-  @Mock private OpenmrsUtil openmrsUtil;
+  @Mock private FhirClientUtil fhirClientUtil;
 
   @Mock private FhirStoreUtil fhirStoreUtil;
 
@@ -71,7 +70,7 @@ public class FhirConverterTest extends CamelTestSupport {
         String fhirDebeziumEventConfigPath = "../../utils/dbz_event_to_fhir_config.json";
         fhirConverter =
             new FhirConverter(
-                openmrsUtil,
+                fhirClientUtil,
                 fhirStoreUtil,
                 parquetUtil,
                 fhirDebeziumEventConfigPath,
@@ -91,7 +90,7 @@ public class FhirConverterTest extends CamelTestSupport {
         DebeziumTestUtil.genExpectedHeaders(Operation.UPDATE, "encounter");
     resource = new Encounter();
     resource.setId(TEST_ID);
-    Mockito.when(openmrsUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
+    Mockito.when(fhirClientUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
     Mockito.when(fhirStoreUtil.getSinkUrl()).thenReturn("sinkPath");
     // empty parquet File Path
     Mockito.when(parquetUtil.getParquetPath()).thenReturn("");
@@ -99,7 +98,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will trigger process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil).fetchFhirResource(Mockito.anyString());
     Mockito.verify(fhirStoreUtil).uploadResource(resource);
     Mockito.verify(parquetUtil, Mockito.never()).write(Mockito.<Resource>any());
   }
@@ -115,7 +114,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will trigger process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil).fetchFhirResource("/Patient/UUID");
+    Mockito.verify(fhirClientUtil).fetchFhirResource("/Patient/UUID");
     Mockito.verify(uuidUtil).getUuid("person", "person_id", "1");
   }
 
@@ -127,7 +126,7 @@ public class FhirConverterTest extends CamelTestSupport {
     resource = new Encounter();
     resource.setId(TEST_ID);
     final String testPath = "some_test_path";
-    Mockito.when(openmrsUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
+    Mockito.when(fhirClientUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
     Mockito.when(parquetUtil.getParquetPath()).thenReturn(testPath);
     // empty fhir sink path
     Mockito.when(fhirStoreUtil.getSinkUrl()).thenReturn("");
@@ -135,7 +134,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will trigger process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil).fetchFhirResource(Mockito.anyString());
     Mockito.verify(fhirStoreUtil, Mockito.never()).uploadResource(Mockito.<Resource>any());
     Mockito.verify(parquetUtil, Mockito.times(1)).write(Mockito.<Resource>any());
   }
@@ -148,14 +147,14 @@ public class FhirConverterTest extends CamelTestSupport {
     resource = new Encounter();
     resource.setId(TEST_ID);
     final String testPath = "some_test_path";
-    Mockito.when(openmrsUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
+    Mockito.when(fhirClientUtil.fetchFhirResource(Mockito.anyString())).thenReturn(resource);
     Mockito.when(parquetUtil.getParquetPath()).thenReturn(testPath);
     Mockito.when(fhirStoreUtil.getSinkUrl()).thenReturn("someFhirSink");
 
     // Actual event that will trigger process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil).fetchFhirResource(Mockito.anyString());
     Mockito.verify(fhirStoreUtil).uploadResource(Mockito.<Resource>any());
     Mockito.verify(parquetUtil, Mockito.times(1)).write(Mockito.<Resource>any());
   }
@@ -169,7 +168,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will tripper process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
   }
 
   @Test
@@ -179,7 +178,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will tripper process().
     eventsProducer.sendBody(messageBody);
 
-    Mockito.verify(openmrsUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
   }
 
   @Test
@@ -191,7 +190,7 @@ public class FhirConverterTest extends CamelTestSupport {
     // Actual event that will tripper process().
     eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
 
-    Mockito.verify(openmrsUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
   }
 
   @Test
@@ -221,7 +220,7 @@ public class FhirConverterTest extends CamelTestSupport {
       eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
     }
 
-    Mockito.verify(openmrsUtil, Mockito.times(tables.length))
+    Mockito.verify(fhirClientUtil, Mockito.times(tables.length))
         .fetchFhirResource(Mockito.anyString());
   }
 
@@ -240,7 +239,7 @@ public class FhirConverterTest extends CamelTestSupport {
       eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
     }
 
-    Mockito.verify(openmrsUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
   }
 
   @Test
@@ -258,6 +257,6 @@ public class FhirConverterTest extends CamelTestSupport {
       eventsProducer.sendBodyAndHeaders(messageBody, messageHeaders);
     }
 
-    Mockito.verify(openmrsUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
+    Mockito.verify(fhirClientUtil, Mockito.times(0)).fetchFhirResource(Mockito.anyString());
   }
 }


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This was an attempt to fix #533; in particular by implementing the decision documented in [this comment](https://github.com/google/fhir-data-pipes/issues/533#issuecomment-1504542439), i.e., fetching the resource IDs first then fetch resource content. This work is complete but we don't want to merge this because of the timing results below:

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Beside the e2e tests I also ran this for a dataset with 8661 Patients (436K Encounters and 1.4M Observations) and compared the runtime with the old one. The old approach (which fetches the resource contents in the first search) took ~670 seconds while the new one took ~725 seconds; this was with 10 workers on my dev machine (Flink flags: `--maxParallelism=20 --parallelism=10`). The difference is not huge and a slight increase is expected. But the main issue is that this approach does not really address the **expiry** problem (and it failed like before when trying a dataset with 80138 Patients). Here is why:

The initial fetch by ID stage actually takes the majority of the run-time. For example, in the above run (i.e., 725 seconds total), fetching Observation IDs took ~590 seconds (wall time) and fetching Observation resource content took ~123 seconds. In the old approach, direct fetching of full Observation resources took ~659 seconds. This is unexpected as fetching just IDs is not much faster. I also confirmed this with removing parallelism.

The reason is probably in the way that `elements=_id` search feature is implemented by HAPI JPA server. So although the ID list is materialized in a DB table, but perhaps for returning results the full resource is reconstructed and then is trimmed (the results also include `meta` fields). There is probably some caching effect that makes the second stage of fetching resource content much faster (I have not investigated the details).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
