### PR TITLE
Implemented a purge policy for Old DWH snapshots

### DIFF
--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -27,7 +27,7 @@ fhirdata:
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
   # cron expression to trigger the purge job which handles the ttl of dwh snapshots
-  purgeSchedule: "0 0 * * * *"
+  purgeSchedule: "0 30 * * * *"
   # The number of dwh snapshots to be retained when the purge job runs
   numOfDwhSnapshotsToRetain: 2
   # Comma separated list of resources to fetch/monitor.

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -26,6 +26,10 @@ fhirdata:
   # "*/30 * * * * *" means in the middle of each minute;
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
+  # cron expression to trigger the purge job which handles the ttl of dwh snapshots
+  purgeSchedule: "0 0 * * * *"
+  # The number of dwh snapshots to be retained when the purge job runs
+  numOfDwhSnapshotsToRetain: 2
   # Comma separated list of resources to fetch/monitor.
   resourceList: "Patient,Encounter,Observation"
   maxWorkers: 10

--- a/pipelines/common/src/main/java/org/openmrs/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/org/openmrs/analytics/DwhFiles.java
@@ -56,7 +56,9 @@ public class DwhFiles {
 
   private static final Logger log = LoggerFactory.getLogger(DwhFiles.class);
 
-  private static final String TIMESTAMP_FILE = "timestamp.txt";
+  public static final String TIMESTAMP_FILE_START = "timestamp_start.txt";
+
+  public static final String TIMESTAMP_FILE_END = "timestamp_end.txt";
 
   private static final String INCREMENTAL_DIR = "incremental_run";
 
@@ -229,14 +231,14 @@ public class DwhFiles {
     FileSystems.copy(sourceResourceIdList, destResourceIdList);
   }
 
-  public void writeTimestampFile() throws IOException {
-    writeTimestampFile(Instant.now());
+  public void writeTimestampFile(String fileName) throws IOException {
+    writeTimestampFile(Instant.now(), fileName);
   }
 
-  public void writeTimestampFile(Instant instant) throws IOException {
+  public void writeTimestampFile(Instant instant, String fileName) throws IOException {
     ResourceId resourceId =
         FileSystems.matchNewResource(getRoot(), true)
-            .resolve(TIMESTAMP_FILE, StandardResolveOptions.RESOLVE_FILE);
+            .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
     List<MatchResult> matches = FileSystems.matchResources(Collections.singletonList(resourceId));
     MatchResult matchResult = Iterables.getOnlyElement(matches);
 
@@ -244,7 +246,7 @@ public class DwhFiles {
       String errorMessage =
           String.format(
               "Attempting to write to the timestamp file %s which already exists",
-              getRoot() + "/" + TIMESTAMP_FILE);
+              getRoot() + "/" + fileName);
       log.error(errorMessage);
       throw new FileAlreadyExistsException(errorMessage);
     } else if (matchResult.status() == Status.NOT_FOUND) {
@@ -256,16 +258,16 @@ public class DwhFiles {
       String errorMessage =
           String.format(
               "Error matching file spec %s: status %s",
-              getRoot() + "/" + TIMESTAMP_FILE, matchResult.status());
+              getRoot() + "/" + fileName, matchResult.status());
       log.error(errorMessage);
       throw new IOException(errorMessage);
     }
   }
 
-  public Instant readTimestampFile() throws IOException {
+  public Instant readTimestampFile(String fileName) throws IOException {
     ResourceId resourceId =
         FileSystems.matchNewResource(getRoot(), true)
-            .resolve(TIMESTAMP_FILE, StandardResolveOptions.RESOLVE_FILE);
+            .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
     List<String> result = new ArrayList<>();
     ReadableByteChannel channel = FileSystems.open(resourceId);
     try (InputStream stream = Channels.newInputStream(channel)) {
@@ -278,7 +280,7 @@ public class DwhFiles {
     }
     if (result.isEmpty()) {
       String errorMessage =
-          String.format("The timestamp file %s is empty", getRoot() + "/" + TIMESTAMP_FILE);
+          String.format("The timestamp file %s is empty", getRoot() + "/" + fileName);
       log.error(errorMessage);
       throw new IllegalStateException(errorMessage);
     }

--- a/pipelines/common/src/test/java/org/openmrs/analytics/GcsDwhFilesTest.java
+++ b/pipelines/common/src/test/java/org/openmrs/analytics/GcsDwhFilesTest.java
@@ -165,7 +165,7 @@ public class GcsDwhFilesTest {
 
   @Test
   public void writeTimestampFile_FileAlreadyExists_ThrowsError() throws IOException {
-    String gcsFileName = "gs://testbucket/testdirectory/timestamp.txt";
+    String gcsFileName = "gs://testbucket/testdirectory/timestamp_start.txt";
     List<StorageObjectOrIOException> items = new ArrayList<>();
     // Files within the directory
     items.add(
@@ -173,12 +173,14 @@ public class GcsDwhFilesTest {
     Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(gcsFileName)))).thenReturn(items);
 
     DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
-    Assert.assertThrows(FileAlreadyExistsException.class, () -> dwhFiles.writeTimestampFile());
+    Assert.assertThrows(
+        FileAlreadyExistsException.class,
+        () -> dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START));
   }
 
   @Test
   public void writeTimestampFile_FileDoesNotExist_CreatesFile() throws IOException {
-    String gcsFileName = "gs://testbucket/testdirectory/timestamp.txt";
+    String gcsFileName = "gs://testbucket/testdirectory/timestamp_start.txt";
     // Empty directory
     List<StorageObjectOrIOException> items = new ArrayList<>();
     items.add(StorageObjectOrIOException.create(new FileNotFoundException()));
@@ -192,7 +194,7 @@ public class GcsDwhFilesTest {
         .thenReturn(writableByteChannel);
 
     DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
-    dwhFiles.writeTimestampFile();
+    dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
 
     Mockito.verify(mockGcsUtil, Mockito.times(1)).getObjects(List.of(GcsPath.fromUri(gcsFileName)));
     Mockito.verify(mockGcsUtil, Mockito.times(1))
@@ -203,12 +205,12 @@ public class GcsDwhFilesTest {
 
   @Test
   public void readTimestampFile() throws IOException {
-    String gcsFileName = "gs://testbucket/testdirectory/timestamp.txt";
+    String gcsFileName = "gs://testbucket/testdirectory/timestamp_start.txt";
     Instant currentInstant = Instant.now();
     mockFileRead(gcsFileName, currentInstant);
 
     DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
-    Instant actualInstant = dwhFiles.readTimestampFile();
+    Instant actualInstant = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
 
     Assert.assertEquals(currentInstant.getEpochSecond(), actualInstant.getEpochSecond());
     Mockito.verify(mockGcsUtil, Mockito.times(1)).open(GcsPath.fromUri(gcsFileName));

--- a/pipelines/common/src/test/java/org/openmrs/analytics/LocalDwhFilesTest.java
+++ b/pipelines/common/src/test/java/org/openmrs/analytics/LocalDwhFilesTest.java
@@ -109,11 +109,13 @@ public class LocalDwhFilesTest {
   @Test
   public void writeTimestampFile_FileAlreadyExists_ThrowsError() throws IOException {
     Path root = Files.createTempDirectory("DWH_FILES_TEST");
-    Path timestampPath = Paths.get(root.toString(), "timestamp.txt");
+    Path timestampPath = Paths.get(root.toString(), "timestamp_start.txt");
     createFile(timestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
     DwhFiles dwhFiles = new DwhFiles(root.toString(), FhirContext.forR4Cached());
 
-    Assert.assertThrows(FileAlreadyExistsException.class, () -> dwhFiles.writeTimestampFile());
+    Assert.assertThrows(
+        FileAlreadyExistsException.class,
+        () -> dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START));
 
     Files.delete(timestampPath);
     Files.delete(root);
@@ -124,11 +126,12 @@ public class LocalDwhFilesTest {
     Path root = Files.createTempDirectory("DWH_FILES_TEST");
     DwhFiles dwhFiles = new DwhFiles(root.toString(), FhirContext.forR4Cached());
 
-    dwhFiles.writeTimestampFile();
+    dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
 
     List<Path> destFiles = Files.list(root).collect(Collectors.toList());
     assertThat(destFiles.size(), equalTo(1));
-    assertThat(destFiles.get(0).toString(), equalTo(root.resolve("timestamp.txt").toString()));
+    assertThat(
+        destFiles.get(0).toString(), equalTo(root.resolve("timestamp_start.txt").toString()));
 
     Files.delete(destFiles.get(0));
     Files.delete(root);
@@ -138,11 +141,11 @@ public class LocalDwhFilesTest {
   public void readTimestampFile() throws IOException {
     Path root = Files.createTempDirectory("DWH_FILES_TEST");
     Instant currentInstant = Instant.now();
-    Path timestampPath = Paths.get(root.toString(), "timestamp.txt");
+    Path timestampPath = Paths.get(root.toString(), "timestamp_start.txt");
     createFile(timestampPath, currentInstant.toString().getBytes(StandardCharsets.UTF_8));
     DwhFiles dwhFiles = new DwhFiles(root.toString(), FhirContext.forR4Cached());
 
-    Instant actualInstant = dwhFiles.readTimestampFile();
+    Instant actualInstant = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
 
     Assert.assertEquals(currentInstant.getEpochSecond(), actualInstant.getEpochSecond());
 

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -40,7 +40,7 @@ fhirdata:
   incrementalSchedule: "0 0 * * * *"
 
   # cron expression to trigger the purge job which handles the ttl of dwh snapshots
-  purgeSchedule: "0 0 * * * *"
+  purgeSchedule: "0 30 * * * *"
 
   # The number of dwh snapshots to be retained when the purge job runs
   numOfDwhSnapshotsToRetain: 2

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -36,6 +36,15 @@ fhirdata:
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
 
+  # The schedule format is similar to Spring's CronExpression, i.e.,
+  # "second minute hour day-of-the-month month day-of-the-week", e.g.,
+  # "0 0 * * * *" means top of every hour;
+  # "*/40 * * * * *" means every 40 seconds;
+  # Note a too frequent run might be too resource intensive.
+  purgeSchedule: "0 0 * * * *"
+
+  lastNDWHSnapshotsToRetain: 5
+
   # Comma separated list of resources to fetch/monitor.
   resourceList: "Patient,Encounter,Observation"
 

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -36,14 +36,11 @@ fhirdata:
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
 
-  # The schedule format is similar to Spring's CronExpression, i.e.,
-  # "second minute hour day-of-the-month month day-of-the-week", e.g.,
-  # "0 0 * * * *" means top of every hour;
-  # "*/40 * * * * *" means every 40 seconds;
-  # Note a too frequent run might be too resource intensive.
+  # cron expression to trigger the purge job which handles the ttl of dwh snapshots
   purgeSchedule: "0 0 * * * *"
 
-  lastNDWHSnapshotsToRetain: 5
+  # The number of dwh snapshots to be retained when the purge job runs
+  numOfDwhSnapshotsToRetain: 2
 
   # Comma separated list of resources to fetch/monitor.
   resourceList: "Patient,Encounter,Observation"

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DWHFilesManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DWHFilesManager.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
+import org.apache.beam.sdk.io.fs.MatchResult.Status;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is responsible for purging the DWH snapshots when they expire. It also exposes few
+ * helper methods to access the DWH files and directories.
+ */
+@EnableScheduling
+@Component
+public class DWHFilesManager {
+
+  @Autowired private DataProperties dataProperties;
+
+  private CronExpression purgeCron;
+
+  private LocalDateTime lastPurgeRunEnd;
+
+  private volatile boolean isPurgeJobRunning;
+
+  private static final Logger logger = LoggerFactory.getLogger(DWHFilesManager.class.getName());
+
+  @PostConstruct
+  public void init() {
+    purgeCron = CronExpression.parse(dataProperties.getPurgeSchedule());
+  }
+
+  private void setLastPurgeRunStatus(PurgeRunStatus status) {
+    if (status == PurgeRunStatus.SUCCESS) {
+      lastPurgeRunEnd = LocalDateTime.now();
+    }
+  }
+
+  private boolean isPurgeJobRunning() {
+    return isPurgeJobRunning;
+  }
+
+  private void setPurgeJobRunning(boolean isPurgeJobRunning) {
+    this.isPurgeJobRunning = isPurgeJobRunning;
+  }
+
+  private synchronized boolean lockPurgeJob() {
+    if (isPurgeJobRunning()) {
+      // Already the job is running so lock can't be acquired.
+      return false;
+    }
+    setPurgeJobRunning(true);
+    return true;
+  }
+
+  private synchronized void releasePurgeJob() {
+    setPurgeJobRunning(false);
+  }
+
+  /**
+   * @return the next scheduled time to run the purge job based on the previous run time.
+   */
+  LocalDateTime getNextPurgeTime() {
+    if (lastPurgeRunEnd == null) {
+      return LocalDateTime.now();
+    }
+    return purgeCron.next(lastPurgeRunEnd);
+  }
+
+  // Every 30 seconds, check if the purge job needs to be triggered.
+  @Scheduled(fixedDelay = 30000)
+  private void checkPurgeSchedule() {
+    try {
+      if (!lockPurgeJob()) {
+        return;
+      }
+      LocalDateTime next = getNextPurgeTime();
+      logger.info("Last purge run was at {} next run is at {}", lastPurgeRunEnd, next);
+      if (next.compareTo(LocalDateTime.now()) <= 0) {
+        logger.info("Purge run triggered at {}", LocalDateTime.now());
+        purgeDWHFiles();
+        logger.info("Purge run completed at {}", LocalDateTime.now());
+      }
+    } finally {
+      releasePurgeJob();
+    }
+  }
+
+  /**
+   * This method will scan the DWH base directory to check for any older DWH snapshots that needs to
+   * be purged. It will retain the most recent successfully completed snapshots and purge the older
+   * ones. Any incomplete snapshots will not be purged by this job and will have to be manually
+   * verified and acted upon.
+   */
+  private void purgeDWHFiles() {
+    String rootPrefix = dataProperties.getDwhRootPrefix();
+    Preconditions.checkState(rootPrefix != null && !rootPrefix.isEmpty());
+
+    int lastNSnapshotsToRetain = dataProperties.getLastNDWHSnapshotsToRetain();
+    Preconditions.checkState(
+        lastNSnapshotsToRetain > 0, "lastNSnapshotsToRetain should be positive value");
+    String baseDir = getBaseDir(rootPrefix);
+    try {
+      String prefix = getPrefix(rootPrefix);
+      List<ResourceId> paths =
+          getAllChildDirectories(baseDir).stream()
+              .filter(dir -> dir.getFilename().startsWith(prefix))
+              .collect(Collectors.toList());
+
+      TreeSet<String> recentSnapshotsToBeRetained =
+          getRecentSnapshots(paths, lastNSnapshotsToRetain);
+      deleteOlderSnapshots(paths, recentSnapshotsToBeRetained);
+      setLastPurgeRunStatus(PurgeRunStatus.SUCCESS);
+    } catch (IOException e) {
+      setLastPurgeRunStatus(PurgeRunStatus.FAILURE);
+      logger.error("Error occurred while purging older snapshots", e);
+    }
+  }
+
+  private void deleteOlderSnapshots(
+      List<ResourceId> allPaths, TreeSet<String> recentSnapshotsToBeRetained) throws IOException {
+    for (ResourceId path : allPaths) {
+      if (!recentSnapshotsToBeRetained.contains(path.getFilename()) && isDWHComplete(path)) {
+        deleteDirectoryAndFiles(path);
+      }
+    }
+  }
+
+  /**
+   * This method deletes all the files, directories and subdirectories under the given root
+   * directory. This is done by first deleting all the files under the root directory including
+   * under the subdirectories. Later the directories and the subdirectories are deleted.
+   *
+   * @param rootDirectory which needs to be deleted
+   * @throws IOException
+   */
+  public void deleteDirectoryAndFiles(ResourceId rootDirectory) throws IOException {
+    ResourceId filesResourceToBeMatched =
+        rootDirectory.resolve("**", StandardResolveOptions.RESOLVE_FILE);
+    List<MatchResult> matchedFilesResultList =
+        FileSystems.matchResources(Collections.singletonList(filesResourceToBeMatched));
+
+    // Collect the matched files which also includes the files under the subdirectories, at the same
+    // time collect the directories as well.
+    List<ResourceId> fileResources = new ArrayList<>();
+    Set<String> allDirectoryPathSet = new HashSet<>();
+    for (MatchResult matchResult : matchedFilesResultList) {
+      if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
+        for (Metadata metadata : matchResult.metadata()) {
+          fileResources.add(metadata.resourceId());
+          ResourceId currentDirectory = metadata.resourceId().getCurrentDirectory();
+          allDirectoryPathSet.add(currentDirectory.toString());
+          // Beam currently creates a temporary empty folder with name '.temp-beam' sometimes under
+          // the directories. These empty subdirectories could not be determined with the existing
+          // Beam file system apis, hence this is hard-coded here so that these empty directories
+          // and their parent directories can be successfully deleted.
+          allDirectoryPathSet.add(
+              currentDirectory
+                  .resolve(".temp-beam", StandardResolveOptions.RESOLVE_DIRECTORY)
+                  .toString());
+        }
+      } else if (matchResult.status() == Status.ERROR) {
+        String errorMessage =
+            String.format("Error matching files under directory %s", rootDirectory.getFilename());
+        logger.error(errorMessage);
+        throw new IOException(errorMessage);
+      }
+    }
+    List<String> allDirectoryPathList = new ArrayList<>(allDirectoryPathSet);
+    allDirectoryPathList.sort(Collections.reverseOrder());
+    List<ResourceId> directoryResourceIdList =
+        allDirectoryPathList.stream()
+            .map(directory -> FileSystems.matchNewResource(directory, true))
+            .collect(Collectors.toList());
+    directoryResourceIdList.add(rootDirectory);
+
+    // Delete the files and directories
+    try {
+      FileSystems.delete(fileResources);
+      FileSystems.delete(directoryResourceIdList);
+    } catch (DirectoryNotEmptyException e) {
+      logger.warn(
+          "Error while deleting a directory, ignoring this and resuming further. error={}",
+          e.getMessage());
+    }
+  }
+
+  private TreeSet<String> getRecentSnapshots(List<ResourceId> paths, int numberOfSnapshotsToReturn)
+      throws IOException {
+    TreeSet<String> treeSet = new TreeSet<>();
+    for (ResourceId resourceId : paths) {
+      // Ignore incomplete DWH snapshots
+      if (!isDWHComplete(resourceId)) {
+        continue;
+      }
+      // Keep only the recent snapshots
+      if (treeSet.size() < numberOfSnapshotsToReturn) {
+        treeSet.add(resourceId.getFilename());
+      } else if (resourceId.getFilename().compareTo(treeSet.first()) > 0) {
+        treeSet.add(resourceId.getFilename());
+        treeSet.pollFirst();
+      }
+    }
+    return treeSet;
+  }
+
+  /**
+   * This method tells us whether the DWH snapshot has been successfully completed by the pipeline.
+   * This is determined by checking the existence of both the timestamp files which needs to be
+   * created at the start and end of the pipeline runs.
+   *
+   * @param dwhResource The dwh resource path which needs to be checked for completeness
+   * @return the status of DWH completeness.
+   * @throws IOException
+   */
+  public boolean isDWHComplete(ResourceId dwhResource) throws IOException {
+    ResourceId startTimestampResource =
+        dwhResource.resolve(DwhFiles.TIMESTAMP_FILE_START, StandardResolveOptions.RESOLVE_FILE);
+    ResourceId endTimestampResource =
+        dwhResource.resolve(DwhFiles.TIMESTAMP_FILE_END, StandardResolveOptions.RESOLVE_FILE);
+    if (doesFileExist(startTimestampResource) && doesFileExist(endTimestampResource)) {
+      return true;
+    }
+    return false;
+  }
+
+  private boolean doesFileExist(ResourceId resourceId) throws IOException {
+    List<MatchResult> matchResultList =
+        FileSystems.matchResources(Collections.singletonList(resourceId));
+    MatchResult matchResult = Iterables.getOnlyElement(matchResultList);
+    if (matchResult.status() == Status.OK) {
+      return true;
+    } else if (matchResult.status() == Status.NOT_FOUND) {
+      return false;
+    } else {
+      String errorMessage =
+          String.format("Error matching file spec %s: status %s", resourceId, matchResult.status());
+      logger.error(errorMessage);
+      throw new IOException(errorMessage);
+    }
+  }
+
+  /**
+   * This method returns the base directory where the DWH snapshots needs to be created. This is
+   * determined by ignoring the prefix part in the given input format <baseDir></prefix> for the
+   * dwhRootPrefix
+   *
+   * @param dwhRootPrefix
+   * @return the base directory name
+   */
+  public String getBaseDir(String dwhRootPrefix) {
+    int index = dwhRootPrefix.lastIndexOf("/");
+    if (index <= 0) {
+      String errorMessage =
+          "dwhRootPrefix should be configured with a non-empty base directory. It should be of the"
+              + " format <baseDir>/<prefix>";
+      logger.error(errorMessage);
+      throw new IllegalArgumentException(errorMessage);
+    }
+    return dwhRootPrefix.substring(0, index);
+  }
+
+  /**
+   * This method returns the prefix name that needs to be applied to the DWH snapshot root folder
+   * name. This is determined by considering the prefix part in the given input format
+   * <baseDir></prefix> for the dwhRootPrefix
+   *
+   * @param dwhRootPrefix
+   * @return the prefix name
+   */
+  public String getPrefix(String dwhRootPrefix) {
+    int index = dwhRootPrefix.lastIndexOf("/");
+    String prefix = dwhRootPrefix.substring(index + 1);
+    if (prefix == null || prefix.isBlank()) {
+      String errorMessage =
+          "dwhRootPrefix should be configured with a non-empty suffix string after the last"
+              + " occurrence of the character '/'";
+      logger.error(errorMessage);
+      throw new IllegalArgumentException(errorMessage);
+    }
+    return prefix;
+  }
+
+  /**
+   * Returns all the child directories under the given base directory which are 1-level deep.
+   *
+   * @param baseDir
+   * @return The list of all child directories under the base directory
+   * @throws IOException
+   */
+  public Set<ResourceId> getAllChildDirectories(String baseDir) throws IOException {
+    ResourceId resourceId =
+        FileSystems.matchNewResource(baseDir, true)
+            .resolve("*/*", StandardResolveOptions.RESOLVE_FILE);
+    List<MatchResult> matchResultList =
+        FileSystems.matchResources(Collections.singletonList(resourceId));
+    Set<ResourceId> childDirectories = new HashSet<>();
+    for (MatchResult matchResult : matchResultList) {
+      if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
+        for (Metadata metadata : matchResult.metadata()) {
+          childDirectories.add(metadata.resourceId().getCurrentDirectory());
+        }
+      } else if (matchResult.status() == Status.ERROR) {
+        String errorMessage = String.format("Error matching files under directory %s", baseDir);
+        logger.error(errorMessage);
+        throw new IOException(errorMessage);
+      }
+    }
+    logger.info("Child directories : {}", childDirectories);
+    return childDirectories;
+  }
+
+  public enum PurgeRunStatus {
+    NOT_RUN,
+    SUCCESS,
+    FAILURE
+  }
+}

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
@@ -76,7 +76,7 @@ public class DataProperties {
 
   private String purgeSchedule;
 
-  private int lastNDWHSnapshotsToRetain;
+  private int numOfDwhSnapshotsToRetain;
 
   private String resourceList;
 
@@ -140,8 +140,8 @@ public class DataProperties {
         new ConfigFields("fhirdata.incrementalSchedule", incrementalSchedule, "", ""),
         new ConfigFields("fhirdata.purgeSchedule", purgeSchedule, "", ""),
         new ConfigFields(
-            "fhirdata.lastNDWHSnapshotsToRetain",
-            String.valueOf(lastNDWHSnapshotsToRetain),
+            "fhirdata.numOfDwhSnapshotsToRetain",
+            String.valueOf(numOfDwhSnapshotsToRetain),
             "",
             ""),
         new ConfigFields("fhirdata.resourceList", resourceList, "", ""),

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DataProperties.java
@@ -74,6 +74,10 @@ public class DataProperties {
 
   private String incrementalSchedule;
 
+  private String purgeSchedule;
+
+  private int lastNDWHSnapshotsToRetain;
+
   private String resourceList;
 
   private int maxWorkers;
@@ -134,6 +138,12 @@ public class DataProperties {
         new ConfigFields("fhirdata.fhirServerUrl", fhirServerUrl, "", ""),
         new ConfigFields("fhirdata.dwhRootPrefix", dwhRootPrefix, "", ""),
         new ConfigFields("fhirdata.incrementalSchedule", incrementalSchedule, "", ""),
+        new ConfigFields("fhirdata.purgeSchedule", purgeSchedule, "", ""),
+        new ConfigFields(
+            "fhirdata.lastNDWHSnapshotsToRetain",
+            String.valueOf(lastNDWHSnapshotsToRetain),
+            "",
+            ""),
         new ConfigFields("fhirdata.resourceList", resourceList, "", ""),
         new ConfigFields("fhirdata.maxWorkers", String.valueOf(maxWorkers), "", ""),
         new ConfigFields("fhirdata.dbConfig", dbConfig, "", ""));

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/DwhFilesManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/DwhFilesManager.java
@@ -362,9 +362,18 @@ public class DwhFilesManager {
         index = dwhRootPrefix.lastIndexOf("/");
         break;
       case GcsPath.SCHEME:
-        String gcsObject = GcsPath.fromUri(dwhRootPrefix).getObject();
+        // Fetch the last index position of the character '/' after the bucket name in the gcs path.
+        GcsPath gcsPath = GcsPath.fromUri(dwhRootPrefix);
+        String gcsObject = gcsPath.getObject();
+        if (Strings.isNullOrEmpty(gcsObject)) {
+          break;
+        }
         int position = gcsObject.lastIndexOf("/");
-        if (position != -1) index = dwhRootPrefix.indexOf(gcsObject) + position;
+        if (position == -1) {
+          index = dwhRootPrefix.lastIndexOf(gcsObject) - 1;
+        } else {
+          index = dwhRootPrefix.lastIndexOf(gcsObject) + position;
+        }
         break;
       default:
         String errorMessage = String.format("File system scheme=%s is not yet supported", scheme);

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
@@ -22,19 +22,13 @@ import java.beans.PropertyVetoException;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.FlinkRunner;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.io.fs.MatchResult;
-import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
-import org.apache.beam.sdk.io.fs.MatchResult.Status;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -65,6 +59,8 @@ public class PipelineManager {
   @Autowired private DataProperties dataProperties;
 
   @Autowired private PipelineMetricsFactory pipelineMetricsFactory;
+
+  @Autowired private DWHFilesManager dwhFilesManager;
 
   private PipelineThread currentPipeline;
 
@@ -108,17 +104,21 @@ public class PipelineManager {
     Preconditions.checkState(rootPrefix != null && !rootPrefix.isEmpty());
 
     String lastDwh = "";
-    String baseDir = getBaseDir(rootPrefix);
+    String baseDir = dwhFilesManager.getBaseDir(rootPrefix);
     try {
-      String prefix = getPrefix(rootPrefix);
+      String prefix = dwhFilesManager.getPrefix(rootPrefix);
       List<ResourceId> paths =
-          getAllChildDirectories(baseDir).stream()
+          dwhFilesManager.getAllChildDirectories(baseDir).stream()
               .filter(dir -> dir.getFilename().startsWith(prefix))
               .collect(Collectors.toList());
 
       Preconditions.checkState(paths != null, "Make sure DWH prefix is a valid path!");
 
       for (ResourceId path : paths) {
+        // Do not consider if the DWH is not completely created earlier.
+        if (!dwhFilesManager.isDWHComplete(path)) {
+          continue;
+        }
         if (!path.getFilename().startsWith(prefix + DataProperties.TIMESTAMP_PREFIX)) {
           // This is not necessarily an error; the user may want to bootstrap from an already
           // created DWH outside the control-panel framework, e.g., by running the batch pipeline
@@ -149,52 +149,6 @@ public class PipelineManager {
       // There exists a DWH from before, so we set the scheduler to continue updating the DWH.
       lastRunEnd = LocalDateTime.now();
     }
-  }
-
-  private Set<ResourceId> getAllChildDirectories(String baseDir) throws IOException {
-    ResourceId resourceId =
-        FileSystems.matchNewResource(baseDir, true)
-            .resolve("*/*", StandardResolveOptions.RESOLVE_FILE);
-    List<MatchResult> matchResultList =
-        FileSystems.matchResources(Collections.singletonList(resourceId));
-    Set<ResourceId> childDirectories = new HashSet<>();
-    for (MatchResult matchResult : matchResultList) {
-      if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
-        for (Metadata metadata : matchResult.metadata()) {
-          childDirectories.add(metadata.resourceId().getCurrentDirectory());
-        }
-      } else if (matchResult.status() == Status.ERROR) {
-        logger.error("Error matching resource types under {} ", baseDir);
-        throw new IOException(String.format("Error matching resource types under %s", baseDir));
-      }
-    }
-    logger.info("Child resources : {}", childDirectories);
-    return childDirectories;
-  }
-
-  private String getBaseDir(String dwhRootPrefix) {
-    int index = dwhRootPrefix.lastIndexOf("/");
-    if (index <= 0) {
-      String errorMessage =
-          "dwhRootPrefix should be configured with a non-empty base directory. It should be of the"
-              + " format <baseDir>/<prefix>";
-      logger.error(errorMessage);
-      throw new IllegalArgumentException(errorMessage);
-    }
-    return dwhRootPrefix.substring(0, index);
-  }
-
-  private String getPrefix(String dwhRootPrefix) {
-    int index = dwhRootPrefix.lastIndexOf("/");
-    String prefix = dwhRootPrefix.substring(index + 1);
-    if (prefix == null || prefix.isBlank()) {
-      String errorMessage =
-          "dwhRootPrefix should be configured with a non-empty suffix string after the last"
-              + " occurrence of the character '/'";
-      logger.error(errorMessage);
-      throw new IllegalArgumentException(errorMessage);
-    }
-    return prefix;
   }
 
   synchronized boolean isBatchRun() {
@@ -275,7 +229,7 @@ public class PipelineManager {
     // TODO move old incremental_run dir if there is one
     String incrementalDwhRoot = currentDwh.newIncrementalRunPath().toString();
     options.setOutputParquetPath(incrementalDwhRoot);
-    String since = currentDwh.readTimestampFile().toString();
+    String since = currentDwh.readTimestampFile(DwhFiles.TIMESTAMP_FILE_START).toString();
     options.setSince(since);
     options.setProcessDeletedRecords(Boolean.TRUE);
     Pipeline pipeline = buildJdbcPipeline(options);

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
@@ -60,7 +60,7 @@ public class PipelineManager {
 
   @Autowired private PipelineMetricsFactory pipelineMetricsFactory;
 
-  @Autowired private DWHFilesManager dwhFilesManager;
+  @Autowired private DwhFilesManager dwhFilesManager;
 
   private PipelineThread currentPipeline;
 
@@ -116,7 +116,7 @@ public class PipelineManager {
 
       for (ResourceId path : paths) {
         // Do not consider if the DWH is not completely created earlier.
-        if (!dwhFilesManager.isDWHComplete(path)) {
+        if (!dwhFilesManager.isDwhComplete(path)) {
           continue;
         }
         if (!path.getFilename().startsWith(prefix + DataProperties.TIMESTAMP_PREFIX)) {

--- a/pipelines/controller/src/main/resources/application.yaml
+++ b/pipelines/controller/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ data:
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
   # cron expression to trigger the purge job which handles the ttl of dwh snapshots
-  purgeSchedule: "0 0 * * * *"
+  purgeSchedule: "0 30 * * * *"
   # The number of dwh snapshots to be retained when the purge job runs
   numOfDwhSnapshotsToRetain: 2
   # Comma separated list of resources to fetch/monitor.

--- a/pipelines/controller/src/main/resources/application.yaml
+++ b/pipelines/controller/src/main/resources/application.yaml
@@ -28,6 +28,10 @@ data:
   # "*/30 * * * * *" means in the middle of each minute;
   # Note a too frequent run might be too resource intensive.
   incrementalSchedule: "0 0 * * * *"
+  # cron expression to trigger the purge job which handles the ttl of dwh snapshots
+  purgeSchedule: "0 0 * * * *"
+  # The number of dwh snapshots to be retained when the purge job runs
+  numOfDwhSnapshotsToRetain: 2
   # Comma separated list of resources to fetch/monitor.
   resourceList: "Patient,Encounter,Observation"
 

--- a/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
@@ -68,7 +68,7 @@ public class GcsDwhFilesManagerTest {
   }
 
   @Test
-  public void testIsDWHComplete_True() throws IOException {
+  public void testIsDwhComplete_True() throws IOException {
     String timestampStartFile = "gs://testbucket/testdirectory/timestamp_start.txt";
     List<StorageObjectOrIOException> startItems = new ArrayList<>();
     // Files within the directory
@@ -94,7 +94,7 @@ public class GcsDwhFilesManagerTest {
   }
 
   @Test
-  public void testIsDWHComplete_False() throws IOException {
+  public void testIsDwhComplete_False() throws IOException {
     String timestampStartFile = "gs://testbucket/testdirectory/timestamp_start.txt";
     List<StorageObjectOrIOException> startItems = new ArrayList<>();
     // Files within the directory
@@ -178,7 +178,8 @@ public class GcsDwhFilesManagerTest {
   @Test(expected = IllegalArgumentException.class)
   public void testPrefixForInvalidPath() {
     DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    dwhFilesManager.getPrefix("gs://test-bucket/");
+    // GCS path should be of the format gs://<bucket>/baseDir>/<prefix>
+    dwhFilesManager.getPrefix("gs://test-bucket/prefix");
   }
 
   private StorageObject createStorageObject(String gcsFilename, long fileSize) {

--- a/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
@@ -168,18 +168,23 @@ public class GcsDwhFilesManagerTest {
   @Test
   public void testPrefix() {
     DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    String prefix1 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/prefix");
+
+    String prefix1 = dwhFilesManager.getPrefix("gs://test-bucket/prefix");
     assertThat(prefix1, equalTo("prefix"));
 
-    String prefix2 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/childDir/prefix");
+    String prefix2 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/prefix");
     assertThat(prefix2, equalTo("prefix"));
+
+    String prefix3 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/childDir/prefix");
+    assertThat(prefix3, equalTo("prefix"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrefixForInvalidPath() {
     DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    // GCS path should be of the format gs://<bucket>/baseDir>/<prefix>
-    dwhFilesManager.getPrefix("gs://test-bucket/prefix");
+    // GCS Path should end with a non-empty suffix string after the last occurrence of the
+    // character '/'
+    dwhFilesManager.getPrefix("gs://test-bucket/baseDir/");
   }
 
   private StorageObject createStorageObject(String gcsFilename, long fileSize) {

--- a/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/org/openmrs/analytics/GcsDwhFilesManagerTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.api.services.storage.model.Objects;
+import com.google.api.services.storage.model.StorageObject;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.extensions.gcp.util.GcsUtil;
+import org.apache.beam.sdk.extensions.gcp.util.GcsUtil.StorageObjectOrIOException;
+import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class GcsDwhFilesManagerTest {
+
+  @Mock private GcsUtil mockGcsUtil;
+  private AutoCloseable closeable;
+
+  @Autowired private DataProperties dataProperties;
+
+  @Before
+  public void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+    GcsOptions gcsOptions = PipelineOptionsFactory.as(GcsOptions.class);
+    gcsOptions.setGcsUtil(mockGcsUtil);
+    FileSystems.setDefaultPipelineOptions(gcsOptions);
+  }
+
+  @After
+  public void closeService() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  public void testIsDWHComplete_True() throws IOException {
+    String timestampStartFile = "gs://testbucket/testdirectory/timestamp_start.txt";
+    List<StorageObjectOrIOException> startItems = new ArrayList<>();
+    // Files within the directory
+    startItems.add(
+        StorageObjectOrIOException.create(
+            createStorageObject(timestampStartFile, 1L /* fileSize */)));
+    Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(timestampStartFile))))
+        .thenReturn(startItems);
+
+    String timestampEndFile = "gs://testbucket/testdirectory/timestamp_end.txt";
+    List<StorageObjectOrIOException> endItems = new ArrayList<>();
+    // Files within the directory
+    endItems.add(
+        StorageObjectOrIOException.create(
+            createStorageObject(timestampEndFile, 1L /* fileSize */)));
+    Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(timestampEndFile))))
+        .thenReturn(endItems);
+
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+
+    ResourceId dwhRoot = FileSystems.matchNewResource("gs://testbucket/testdirectory", true);
+    assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(true));
+  }
+
+  @Test
+  public void testIsDWHComplete_False() throws IOException {
+    String timestampStartFile = "gs://testbucket/testdirectory/timestamp_start.txt";
+    List<StorageObjectOrIOException> startItems = new ArrayList<>();
+    // Files within the directory
+    startItems.add(
+        StorageObjectOrIOException.create(
+            createStorageObject(timestampStartFile, 1L /* fileSize */)));
+    Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(timestampStartFile))))
+        .thenReturn(startItems);
+
+    String timestampEndFile = "gs://testbucket/testdirectory/timestamp_end.txt";
+    List<StorageObjectOrIOException> items = new ArrayList<>();
+    items.add(StorageObjectOrIOException.create(new FileNotFoundException()));
+    Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(timestampEndFile))))
+        .thenReturn(items);
+
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+
+    ResourceId dwhRoot = FileSystems.matchNewResource("gs://testbucket/testdirectory", true);
+    assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(false));
+  }
+
+  @Test
+  public void testGetAllChildDirectoriesOneLevelDeep() throws IOException {
+    Objects modelObjects = new Objects();
+    List<StorageObject> items = new ArrayList<>();
+    // Files within the directory
+    items.add(
+        createStorageObject(
+            "gs://testbucket/testdirectory/Patient/patient.parquet", 1L /* fileSize */));
+    items.add(
+        createStorageObject(
+            "gs://testbucket/testdirectory/Observation/observation.parquet", 2L /* fileSize */));
+    modelObjects.setItems(items);
+
+    Mockito.when(
+            mockGcsUtil.listObjects(
+                Mockito.eq("testbucket"), Mockito.anyString(), Mockito.isNull()))
+        .thenReturn(modelObjects);
+
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+    Set<ResourceId> childDirectories =
+        dwhFilesManager.getAllChildDirectories("gs://testbucket/testdirectory");
+
+    assertThat(childDirectories.size(), equalTo(2));
+    assertThat(
+        childDirectories.contains(
+            FileSystems.matchNewResource("gs://testbucket/testdirectory/Patient", true)),
+        equalTo(true));
+    assertThat(
+        childDirectories.contains(
+            FileSystems.matchNewResource("gs://testbucket/testdirectory/Observation", true)),
+        equalTo(true));
+  }
+
+  @Test
+  public void testBaseDir() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+    String baseDir1 = dwhFilesManager.getBaseDir("gs://test-bucket/baseDir/prefix");
+    assertThat(baseDir1, equalTo("gs://test-bucket/baseDir"));
+
+    String baseDir2 = dwhFilesManager.getBaseDir("gs://test-bucket/baseDir/childDir/prefix");
+    assertThat(baseDir2, equalTo("gs://test-bucket/baseDir/childDir"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBaseDirForInvalidPath() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+    dwhFilesManager.getBaseDir("gs://test-bucket");
+  }
+
+  @Test
+  public void testPrefix() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+    String prefix1 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/prefix");
+    assertThat(prefix1, equalTo("prefix"));
+
+    String prefix2 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/childDir/prefix");
+    assertThat(prefix2, equalTo("prefix"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPrefixForInvalidPath() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+    dwhFilesManager.getPrefix("gs://test-bucket/");
+  }
+
+  private StorageObject createStorageObject(String gcsFilename, long fileSize) {
+    GcsPath gcsPath = GcsPath.fromUri(gcsFilename);
+    // Google APIs will use null for empty files.
+    @Nullable BigInteger size = (fileSize == 0) ? null : BigInteger.valueOf(fileSize);
+    return new StorageObject()
+        .setBucket(gcsPath.getBucket())
+        .setName(gcsPath.getObject())
+        .setSize(size);
+  }
+}

--- a/pipelines/controller/src/test/java/org/openmrs/analytics/LocalDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/org/openmrs/analytics/LocalDwhFilesManagerTest.java
@@ -76,7 +76,7 @@ public class LocalDwhFilesManagerTest {
   }
 
   @Test
-  public void testIsDWHComplete_True() throws IOException {
+  public void testIsDwhComplete_True() throws IOException {
     File root = testFolder.newFolder("DWH_SOURCE_TEST");
     Path startTimestampPath = Paths.get(root.getPath(), "timestamp_start.txt");
     createFile(startTimestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
@@ -88,7 +88,7 @@ public class LocalDwhFilesManagerTest {
   }
 
   @Test
-  public void testIsDWHComplete_False() throws IOException {
+  public void testIsDwhComplete_False() throws IOException {
     File root = testFolder.newFolder("DWH_SOURCE_TEST");
     Path startTimestampPath = Paths.get(root.getPath(), "timestamp_start.txt");
     createFile(startTimestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));

--- a/pipelines/controller/src/test/java/org/openmrs/analytics/LocalDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/org/openmrs/analytics/LocalDwhFilesManagerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Set;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.junit.Test;
+
+public class LocalDwhFilesManagerTest {
+
+  @Test
+  public void testIsDWHComplete_True() throws IOException {
+    Path root = Files.createTempDirectory("DWH_SOURCE_TEST");
+    Path startTimestampPath = Paths.get(root.toString(), "timestamp_start.txt");
+    createFile(startTimestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+    Path endTimestampPath = Paths.get(root.toString(), "timestamp_end.txt");
+    createFile(endTimestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    ResourceId dwhRoot = FileSystems.matchNewResource(root.toString(), true);
+
+    assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(true));
+
+    Files.delete(endTimestampPath);
+    Files.delete(startTimestampPath);
+    Files.delete(root);
+  }
+
+  @Test
+  public void testIsDWHComplete_False() throws IOException {
+    Path root = Files.createTempDirectory("DWH_SOURCE_TEST");
+    Path startTimestampPath = Paths.get(root.toString(), "timestamp_start.txt");
+    createFile(startTimestampPath, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    ResourceId dwhRoot = FileSystems.matchNewResource(root.toString(), true);
+
+    assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(false));
+
+    Files.delete(startTimestampPath);
+    Files.delete(root);
+  }
+
+  @Test
+  public void testGetAllChildDirectoriesOneLevelDeep() throws IOException {
+    Path rootDir = Files.createTempDirectory("rootDir");
+    Path childDir1 = Paths.get(rootDir.toString(), "childDir1");
+    Files.createDirectories(childDir1);
+    Path fileAtChildDir1 = Path.of(childDir1.toString(), "file1.txt");
+    createFile(fileAtChildDir1, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
+    Path childDir2 = Paths.get(rootDir.toString(), "childDir2");
+    Files.createDirectories(childDir2);
+    Path fileAtChildDir2 = Path.of(childDir2.toString(), "file2.txt");
+    createFile(fileAtChildDir2, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+
+    Set<ResourceId> childDirectories = dwhFilesManager.getAllChildDirectories(rootDir.toString());
+
+    assertThat(childDirectories.size(), equalTo(2));
+    assertThat(
+        childDirectories.contains(FileSystems.matchNewResource(childDir1.toString(), true)),
+        equalTo(true));
+    assertThat(
+        childDirectories.contains(
+            FileSystems.matchNewResource(childDir2.toString(), true)),
+        equalTo(true));
+
+    Files.delete(fileAtChildDir1);
+    Files.delete(childDir1);
+    Files.delete(fileAtChildDir2);
+    Files.delete(childDir2);
+    Files.delete(rootDir);
+  }
+
+  @Test
+  public void testBaseDir() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    String baseDir1 = dwhFilesManager.getBaseDir("/root/prefix");
+    assertThat(baseDir1, equalTo("/root"));
+
+    String baseDir2 = dwhFilesManager.getBaseDir("/root/child/prefix");
+    assertThat(baseDir2, equalTo("/root/child"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBaseDirForInvalidPath() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    dwhFilesManager.getBaseDir("/root");
+  }
+
+  @Test
+  public void testPrefix() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    String prefix1 = dwhFilesManager.getPrefix("/root/prefix");
+    assertThat(prefix1, equalTo("prefix"));
+
+    String prefix2 = dwhFilesManager.getPrefix("/root/child/prefix");
+    assertThat(prefix2, equalTo("prefix"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPrefixForInvalidPath() {
+    DwhFilesManager dwhFilesManager = new DwhFilesManager();
+    dwhFilesManager.getPrefix("/prefix/");
+  }
+
+  private void createFile(Path path, byte[] bytes) throws IOException {
+    Files.write(path, bytes);
+  }
+}

--- a/pipelines/controller/src/test/resources/application-test.properties
+++ b/pipelines/controller/src/test/resources/application-test.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2020-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+fhirdata.dwhRootPrefix=/tmp/controller_DWH
+fhirdata.purgeSchedule=0 0 * * * *
+fhirdata.numOfDwhSnapshotsToRetain=3


### PR DESCRIPTION
The following changes have been made 
 - Implemented a periodic purge scheduler
 - The purge job will scan for the DWH snapshots and retain only the last N successfully completed snapshots. The previously completed DWH snapshots will be deleted. Snapshots which are incomplete will be ignored by this job i.e. they wont be considered for deletion.
 - For successful state of a DWH snapshot we now create two timestamp files (1) timestamp_start.txt at the beginning of the pipeline run (2) timestamp_end.txt at the end of the pipeline run, as opposed to only one file (timestamp.txt) which we used to create earlier.
 - On start of the application we now initialise to the most recent successfully completed snapshot (which checks for the presence of both the timestamp files).

## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

The changes have been tested end to end locally for the below scenarios.
 1. Created few DWH snapshots by running the batch pipeline and incremental runs, checked for the trigger of the purge job and verified if only the last N runs are retained as per the configuration.
 2. On application restart checked if it is initialised to the most recent successfully completed snapshot which is the last-1 snapshot since the latest one was incomplete (had manually deleted the timestamp_end.txt file for the recent DWH).
 3. Also verified if the job ignores incomplete snapshots.

TESTED:

Tested the full runs and incremental runs for the Unix file systems as well as GCS file systems. The number of snapshots retained are manually verified after the purge job completions. 

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
