### PR TITLE
Examples for remote Metastore and spark-warehouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ nb-configuration.xml
 .ipynb_checkpoints/
 **.pyc
 **__pycache__**
+##############################
+## Data-warehouse files.
+##############################
+docker/dwh/**

--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This docker-compose configuration is for bringing up a pipeline controller
-# along with a local Spark cluster and a SQL console.
+# along with a local Spark cluster with a JDBC endpoint.
 # The Spark part is partially based on:
 # https://github.com/bitnami/containers/blob/main/bitnami/spark/docker-compose.yml
 
@@ -25,8 +25,19 @@
 # DWH_ROOT: The directory where Parquet files are written. This is shared
 #   between all containers; the pipeline writes to it and Spark ones read.
 #
-# Note if local paths are used, they should start with `./ `or `../`
-
+# Note if local paths are used, they should start with `./ `or `../`. Also the
+# mounted files should be readable by containers, e.g., world-readable.
+#
+# This configuration uses the default embedded Derby database as Metastore for
+# the thriftserver. Some example config lines are provided but commented out
+# that show how to use an external DB instead.
+#
+# Also, in your SQL scripts, if you need to create temporary tables, you should
+# provide a shared directory for `spark-warehouse` as shown below (in comments).
+#
+# Finally, if you want to change Spark default configs, you can mount your
+# config files to /opt/bitnami/spark/conf/
+# https://spark.apache.org/docs/latest/configuration.html
 
 version: '2'
 
@@ -51,6 +62,10 @@ services:
       - '8082:8080'
     volumes:
       - ${DWH_ROOT}:/dwh
+      # If you want to create temporary tables, you need to have a common
+      # spark-warehouse location across Spark nodes; here is an example.
+      # Note this directory need to be writeable by Spark nodes.
+      # - /tmp/spark-warehouse:/opt/bitnami/spark/spark-warehouse
 
   spark-worker:
     image: docker.io/bitnami/spark:3.3
@@ -62,6 +77,8 @@ services:
       - SPARK_WORKER_CORES=20
     volumes:
       - ${DWH_ROOT}:/dwh
+      # See above.
+      # - /tmp/spark-warehouse:/opt/bitnami/spark/spark-warehouse
 
   thriftserver:
     image: docker.io/bitnami/spark:3.3
@@ -77,5 +94,14 @@ services:
       - '4041:4040'
     volumes:
       - ${DWH_ROOT}:/dwh
+      # See above.
+      # - /tmp/spark-warehouse:/opt/bitnami/spark/spark-warehouse
+
+      # NON-EMBEDDED METASTORE CONFIG:
+      # If you want to persist the Metastore data, e.g., table and view
+      # definitions, you can use an external database by adjusting hive-site.xml
+      # - ./hive-site_example.xml:/opt/bitnami/spark/conf/hive-site.xml
+      # Note to use an external DB, you need to provide its driver jar too:
+      # - ./postgresql-42.6.0.jar:/opt/bitnami/spark/jars/postgresql-42.6.0.jar
 
 # TODO add a link to a Jupyter notebook to show how to use JDBC.

--- a/docker/hive-site_example.xml
+++ b/docker/hive-site_example.xml
@@ -1,0 +1,43 @@
+<!--
+This is a sample for hive-site.xml configuration file. Any thriftserver
+config parameters that are related to the Metastore can be set here.
+For example, the following is a minimal set for using a remote database instead
+of the default embedded Derby. When using Bitnami docker images, this file needs
+to be mounted in the default conf dir at /opt/bitnami/spark/conf/hive-site.xml
+Note that extra driver jars need to be supplied to Spark nodes as well, e.g.,
+by placing them in the /opt/bitnami/spark/jars/ directory.
+
+For documentation of parameters see (TODO: find a thriftserver specific source):
+https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-MetaStore
+-->
+
+<configuration>
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <!-- This setup assumes that custom_metastore_db is already created. -->
+    <!-- The IP address should be adjusted based on how the thriftserver sees
+      the external DB; this example is for a docker image on Linux. -->
+    <value>jdbc:postgresql://172.18.0.2:5432/custom_metastore_db</value>
+    <!-- value>jdbc:postgresql://localhost:5432/custom_metastore_db</value -->
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value>org.postgresql.Driver</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value>admin</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>admin</value>
+  </property>
+  <property>
+    <name>datanucleus.schema.autoCreateTables</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.metastore.schema.verification</name>
+    <value>false</value>
+  </property>
+</configuration>


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This fixes #654 by providing working examples that shows how to:
- Use an external database for Metastore (instead of the default embedded Derby).
- How to mount shared volumes on Spark nodes for temporary tables.

All of the new examples are commented out as the original default/simple config is good enough for the main purpose these sample docker configs were provided for, i.e., querying generated Parquet files with Spark SQL.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

I tested all of the example configs in this PR and brought up a local version of spark master+worker+thriftserver that used a remote DB for Metastore. I also tested creating temporary tables and queried them successfully.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
