### PR TITLE
Upgrade mysql driver jar to fix the regression issue

### DIFF
--- a/pipelines/batch/pom.xml
+++ b/pipelines/batch/pom.xml
@@ -42,7 +42,7 @@
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <nemo.version>0.1</nemo.version>
     <flink.artifact.name>beam-runners-flink-1.14</flink.artifact.name>
-    <mysql.driver.version>8.0.16</mysql.driver.version>
+    <mysql.driver.version>8.0.33</mysql.driver.version>
     <postgresql.version>42.6.0</postgresql.version>
 
   </properties>

--- a/pipelines/batch/pom.xml
+++ b/pipelines/batch/pom.xml
@@ -77,6 +77,9 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>${mysql.driver.version}</version>
+      <!-- We need to exclude this to avoid the clash with the same dependency under the artifact
+      org.apache.beam:beam-sdks-java-io-google-cloud-platform so that it does not end up in
+      incompatible version with com.google.api.grpc:proto-google-common-proto -->
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>

--- a/pipelines/batch/pom.xml
+++ b/pipelines/batch/pom.xml
@@ -42,7 +42,7 @@
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <nemo.version>0.1</nemo.version>
     <flink.artifact.name>beam-runners-flink-1.14</flink.artifact.name>
-    <mysql.driver.version>8.0.33</mysql.driver.version>
+    <mysql.driver.version>8.0.16</mysql.driver.version>
     <postgresql.version>42.6.0</postgresql.version>
 
   </properties>
@@ -77,6 +77,12 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>${mysql.driver.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description of what I changed

Due to the recent upgrades made there is an regression issue introduced to the workflow of 'persisting the parquet files to the GCS file system'. This PR contains the change to upgrade the necessary jar so that this workflow runs correctly. 

## E2E test

TESTED:

Batch runs and incremental runs were made and checked for the successful creation of the parquet files in the GCS file system.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
