### PR TITLE
Added equals method to ResourceTag to avoid Beam mutation warning

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
@@ -20,6 +20,8 @@ import lombok.Builder;
 import lombok.Data;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Coding;
 
 @DefaultCoder(SerializableCoder.class)
@@ -44,8 +46,22 @@ public class ResourceTag implements Serializable {
     }
 
     ResourceTag resourceTag = (ResourceTag) other;
-    return coding.equalsDeep(resourceTag.coding)
-        && resourceId.equals(resourceTag.resourceId)
-        && tagType.equals((resourceTag.tagType));
+
+    return coding != null
+        && coding.equalsDeep(resourceTag.coding)
+        && StringUtils.compare(resourceId, resourceTag.getResourceId()) == 0
+        && ObjectUtils.compare(tagType, resourceTag.getTagType()) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int h$ = 1;
+    h$ *= 1000003;
+    h$ ^= coding.hashCode();
+    h$ *= 1000003;
+    h$ ^= resourceId.hashCode();
+    h$ *= 1000003;
+    h$ ^= tagType.hashCode();
+    return h$;
   }
 }

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
@@ -29,6 +29,8 @@ import org.hl7.fhir.r4.model.Coding;
 @Builder
 public class ResourceTag implements Serializable {
 
+  private static final int prime = 1000003;
+
   private static final long serialVersionUID = 1L;
 
   Coding coding;
@@ -55,13 +57,13 @@ public class ResourceTag implements Serializable {
 
   @Override
   public int hashCode() {
-    int h$ = 1;
-    h$ *= 1000003;
-    h$ ^= coding.hashCode();
-    h$ *= 1000003;
-    h$ ^= resourceId.hashCode();
-    h$ *= 1000003;
-    h$ ^= tagType.hashCode();
-    return h$;
+    int hash = 1;
+    hash *= prime;
+    hash ^= coding.hashCode();
+    hash *= prime;
+    hash ^= resourceId.hashCode();
+    hash *= prime;
+    hash ^= tagType.hashCode();
+    return hash;
   }
 }

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ResourceTag.java
@@ -32,4 +32,20 @@ public class ResourceTag implements Serializable {
   Coding coding;
   String resourceId;
   Integer tagType;
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof ResourceTag)) {
+      return false;
+    }
+
+    ResourceTag resourceTag = (ResourceTag) other;
+    return coding.equalsDeep(resourceTag.coding)
+        && resourceId.equals(resourceTag.resourceId)
+        && tagType.equals((resourceTag.tagType));
+  }
 }

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmrs.analytics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.Test;
+
+public class ResourceTagTest {
+
+  @Test
+  public void testResourceTagSerialization() {
+    Coding coding = new Coding();
+    coding.setId("123");
+    coding.setDisplay("display123");
+    coding.setSystem("system123");
+    ResourceTag resourceTag = new ResourceTag(coding, "resourceId", 1);
+
+    byte[] bytes = SerializationUtils.serialize(resourceTag);
+    ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
+
+    assertThat(
+        resourceTag.getCoding().getId(), equalTo(deserializedResourceTag.getCoding().getId()));
+    assertThat(
+        resourceTag.getCoding().getDisplay(),
+        equalTo(deserializedResourceTag.getCoding().getDisplay()));
+    assertThat(
+        resourceTag.getCoding().getSystem(),
+        equalTo(deserializedResourceTag.getCoding().getSystem()));
+    assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
+    assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
+  }
+}

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.apache.commons.lang3.SerializationUtils;
 import org.hl7.fhir.r4.model.Coding;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ResourceTagTest {
@@ -97,12 +98,27 @@ public class ResourceTagTest {
   @Test
   public void testResourceTagSerializationWithoutCoding() {
 
-    ResourceTag resourceTag = ResourceTag.builder().resourceId("resourceId").build();
+    ResourceTag resourceTag = ResourceTag.builder().resourceId("resourceId").tagType(1).build();
 
     byte[] bytes = SerializationUtils.serialize(resourceTag);
     ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
 
     assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
     assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
+  }
+
+  @Test
+  public void testResourceTagEqualsAndHashCode() {
+    Coding coding = new Coding();
+    coding.setId("123");
+    coding.setDisplay("display123");
+    coding.setSystem("system123");
+    ResourceTag resourceTag1 =
+        ResourceTag.builder().coding(coding).resourceId("resourceId").tagType(1).build();
+    ResourceTag resourceTag2 =
+        ResourceTag.builder().coding(coding).resourceId("resourceId").tagType(1).build();
+
+    Assert.assertTrue(resourceTag1.equals(resourceTag2) && resourceTag2.equals(resourceTag1));
+    Assert.assertTrue(resourceTag1.hashCode() == resourceTag2.hashCode());
   }
 }

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ResourceTagTest.java
@@ -30,7 +30,8 @@ public class ResourceTagTest {
     coding.setId("123");
     coding.setDisplay("display123");
     coding.setSystem("system123");
-    ResourceTag resourceTag = new ResourceTag(coding, "resourceId", 1);
+    ResourceTag resourceTag =
+        ResourceTag.builder().coding(coding).resourceId("resourceId").tagType(1).build();
 
     byte[] bytes = SerializationUtils.serialize(resourceTag);
     ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
@@ -43,6 +44,64 @@ public class ResourceTagTest {
     assertThat(
         resourceTag.getCoding().getSystem(),
         equalTo(deserializedResourceTag.getCoding().getSystem()));
+    assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
+    assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
+  }
+
+  @Test
+  public void testResourceTagSerializationWithoutResourceId() {
+    Coding coding = new Coding();
+    coding.setId("123");
+    coding.setDisplay("display123");
+    coding.setSystem("system123");
+    ResourceTag resourceTag = ResourceTag.builder().coding(coding).tagType(1).build();
+
+    byte[] bytes = SerializationUtils.serialize(resourceTag);
+    ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
+
+    assertThat(
+        resourceTag.getCoding().getId(), equalTo(deserializedResourceTag.getCoding().getId()));
+    assertThat(
+        resourceTag.getCoding().getDisplay(),
+        equalTo(deserializedResourceTag.getCoding().getDisplay()));
+    assertThat(
+        resourceTag.getCoding().getSystem(),
+        equalTo(deserializedResourceTag.getCoding().getSystem()));
+    assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
+    assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
+  }
+
+  @Test
+  public void testResourceTagSerializationWithoutTagType() {
+    Coding coding = new Coding();
+    coding.setId("123");
+    coding.setDisplay("display123");
+    coding.setSystem("system123");
+    ResourceTag resourceTag = ResourceTag.builder().coding(coding).resourceId("resourceId").build();
+
+    byte[] bytes = SerializationUtils.serialize(resourceTag);
+    ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
+
+    assertThat(
+        resourceTag.getCoding().getId(), equalTo(deserializedResourceTag.getCoding().getId()));
+    assertThat(
+        resourceTag.getCoding().getDisplay(),
+        equalTo(deserializedResourceTag.getCoding().getDisplay()));
+    assertThat(
+        resourceTag.getCoding().getSystem(),
+        equalTo(deserializedResourceTag.getCoding().getSystem()));
+    assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
+    assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
+  }
+
+  @Test
+  public void testResourceTagSerializationWithoutCoding() {
+
+    ResourceTag resourceTag = ResourceTag.builder().resourceId("resourceId").build();
+
+    byte[] bytes = SerializationUtils.serialize(resourceTag);
+    ResourceTag deserializedResourceTag = SerializationUtils.deserialize(bytes);
+
     assertThat(resourceTag.getResourceId(), equalTo(deserializedResourceTag.getResourceId()));
     assertThat(resourceTag.getTagType(), equalTo(deserializedResourceTag.getTagType()));
   }


### PR DESCRIPTION
## Description of what I changed

ResourceTag was not getting serialised appropriately as it has a member Coding which does not implement equals method which in turn throws warning while running the pipeline. Added equals override method to ResourceTag method which takes care of Coding equals and other properties as well.

Fixes https://github.com/google/fhir-data-pipes/issues/646

## E2E test

Tested.

TESTED:

Tested on local and made sure pipeline is exporting output with DirectRunner without any warnings.
Also, tested with unit test case.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
