### PR TITLE
Integrate codecov with cloudbuild to publish coverage report

### DIFF
--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -388,6 +388,26 @@
           </configuration>
         </plugin>
 
+        <plugin>
+          <!-- This is added for Codecov. -->
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.9</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <phase>prepare-package</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
 
     </pluginManagement>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,14 +34,16 @@ steps:
   - mvn --no-transfer-progress -e install -Dlicense.skip=true -Dspotless.apply.skip=true
   waitFor: ['-']
 
-- name: 'gcr.io/cloud-builders/docker'
+- name: 'gcr.io/cloud-builders/curl'
   id: 'Upload coverage reports to codecov.io'
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - curl -Os https://uploader.codecov.io/latest/linux/codecov;
-  - chmod u+x codecov;
-  - ./codecov -t 9bd99f32-01bd-4c60-9581-a522a752c75d;
+  entrypoint: bash
+  args: ['-c', 'bash <(curl -s https://codecov.io/bash)']
+  env:
+    - 'VCS_COMMIT_ID=$COMMIT_SHA'
+    - 'VCS_BRANCH_NAME=$BRANCH_NAME'
+    - 'VCS_PULL_REQUEST=$_PR_NUMBER'
+    - 'CI_BUILD_ID=$BUILD_ID'
+    - 'CODECOV_TOKEN=$_CODECOV_TOKEN'
 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build Uploader Image'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,7 +43,7 @@ steps:
     - 'VCS_BRANCH_NAME=$BRANCH_NAME'
     - 'VCS_PULL_REQUEST=$_PR_NUMBER'
     - 'CI_BUILD_ID=$BUILD_ID'
-    - 'CODECOV_TOKEN=$_CODECOV_TOKEN'
+    - 'CODECOV_TOKEN=$_CODECOV_TOKEN' # This token is generated when you setup your repo on codecov: https://docs.codecov.com/docs
 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build Uploader Image'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,16 @@ steps:
   args:
   - -c
   - mvn --no-transfer-progress -e install -Dlicense.skip=true -Dspotless.apply.skip=true
-  waitFor: ['-'] 
+  waitFor: ['-']
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Upload coverage reports to codecov.io'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - curl -Os https://uploader.codecov.io/latest/linux/codecov;
+  - chmod u+x codecov;
+  - ./codecov -t 9bd99f32-01bd-4c60-9581-a522a752c75d;
 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build Uploader Image'
@@ -46,7 +55,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - -c
-  - cd /uploader; python -m unittest discover  -p '*_test.py' 
+  - cd /uploader; python -m unittest discover  -p '*_test.py'
 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build E2E Image'
@@ -70,9 +79,9 @@ steps:
   entrypoint: /bin/bash
   args:
   - -c
-  - cd pipelines/batch; 
+  - cd pipelines/batch;
     docker build -t ${_REPOSITORY}/batch-pipeline:${_TAG} .;
-    cd ../streaming-binlog; 
+    cd ../streaming-binlog;
     docker build -t ${_REPOSITORY}/streaming-pipeline:${_TAG} .;
 
 - name: '${_REPOSITORY}/batch-pipeline:${_TAG}'

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -368,7 +368,7 @@
               <goals>
                 <goal>report</goal>
               </goals>
-              <phase>test</phase>
+              <phase>prepare-package</phase>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
## Description of what I changed

Added jococo plugin to create local coverage report.
Added a step in cloudbuild which will publish the created report to codecove.io.

When each pull request is created, upon run of cloudbuild step, when the report gets uploaded to codecov.io, developers can view the report on their website like this: https://app.codecov.io/gh/google/fhir-data-pipes/tree/codecov

It shows coverage on bunsen and pipeline modules. Clicking deep into folders, they can see coverage line-byline as well.

Codecov also generated report to be displayed in github as its been shown in this pull request.

Codecov needs a token for uploading coverage reports. I have added this token in cloud build as Substitution variable. And I am using that substitution variable in cloudbuild.

Fixes https://github.com/google/fhir-data-pipes/issues/666

## E2E test

Tested. Verified that code coverage step runs successfully. 

TESTED:

Tested for coverage report on codecov and github.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
