### PR TITLE
Fixed bug in auto resource tables creation upon pipeline restart

### DIFF
--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -78,7 +78,7 @@ services:
       thriftserver:
         condition: service_healthy
 
-  spark:
+  spark-master:
     image: docker.io/bitnami/spark:3.3
     container_name: spark-master
     environment:
@@ -90,7 +90,7 @@ services:
       # The data for temporary tables, ends up in the spark-warehouse sub-dir of
       # this volume. This needs to be shared between all spark nodes if temp
       # tables are needed.
-      - spark:/opt/bitnami/spark
+      - spark_vol:/opt/bitnami/spark
 
       # NON-EMBEDDED METASTORE CONFIG:
       # If you want to persist the Metastore data, e.g., table and view
@@ -107,13 +107,13 @@ services:
     container_name: spark-worker
     environment:
       - SPARK_MODE=worker
-      - SPARK_MASTER_URL=spark://spark:7077
+      - SPARK_MASTER_URL=spark://spark-master:7077
       - SPARK_WORKER_MEMORY=20G
       - SPARK_WORKER_CORES=20
     volumes:
       - ${DWH_ROOT}:/dwh
     volumes_from:
-      - spark
+      - spark-master
     networks:
       - cloudbuild
       - default
@@ -122,11 +122,11 @@ services:
     image: docker.io/bitnami/spark:3.3
     container_name: spark-thriftserver
     depends_on:
-      - spark
+      - spark-master
     command:
       - sbin/start-thriftserver.sh
       - --master
-      - spark://spark:7077
+      - spark://spark-master:7077
     environment:
       - HIVE_SERVER2_THRIFT_PORT=10000
     ports:
@@ -135,7 +135,7 @@ services:
     volumes:
       - ${DWH_ROOT}:/dwh
     volumes_from:
-      - spark
+      - spark-master
     networks:
       - cloudbuild
       - default
@@ -147,7 +147,7 @@ services:
       timeout: 60s
 
 volumes:
-  spark:
+  spark_vol:
 
 networks:
   cloudbuild:

--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -121,6 +121,8 @@ services:
   thriftserver:
     image: docker.io/bitnami/spark:3.3
     container_name: spark-thriftserver
+    depends_on:
+      - spark
     command:
       - sbin/start-thriftserver.sh
       - --master

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/PipelineManager.java
@@ -311,6 +311,10 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
             dwhFilesManager.getAllChildDirectories(baseDir + "/" + path.getFilename());
         for (ResourceId resourceId : childPaths) {
           String resource = resourceId.getFilename();
+          // Ignore if you encounter folders like incremental_run.
+          if (dataProperties.getResourceList().indexOf(resourceId.getFilename()) == -1)  {
+            continue;
+          }
           String[] tokens = path.getFilename().split(prefix + DataProperties.TIMESTAMP_PREFIX);
           if (tokens.length > 1) {
             String timestamp = tokens[1];


### PR DESCRIPTION
## Description of what I changed

Upon pipeline restart, application scans snapshots directories and creates tables per resource. With incremental run, there is a folder created incremental_run which should be skipped by the application while doing this scan. Added the fix.

Fixes https://github.com/google/fhir-data-pipes/issues/689

## E2E test

Tested.

TESTED:

Verified that pipeline controller starts up without any issues. Earlier this was not coming up because it used to fail with exception saying that encountered text files instead of parquet files.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
