### PR TITLE
Added sleep to introduce delay between full and incremental runs.

### DIFF
--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -101,10 +101,19 @@ services:
     networks:
       - cloudbuild
       - default
+    healthcheck:
+      test: bin/spark-shell || exit 1
+      interval: 30s
+      retries: 10
+      start_period: 10s
+      timeout: 60s
 
   spark-worker:
     image: docker.io/bitnami/spark:3.3
     container_name: spark-worker
+    depends_on:
+      spark-master:
+        condition: service_healthy
     environment:
       - SPARK_MODE=worker
       - SPARK_MASTER_URL=spark://spark-master:7077
@@ -122,7 +131,8 @@ services:
     image: docker.io/bitnami/spark:3.3
     container_name: spark-thriftserver
     depends_on:
-      - spark-master
+      spark-master:
+        condition: service_healthy
     command:
       - sbin/start-thriftserver.sh
       - --master

--- a/e2e-tests/controller-spark/controller_spark_sql_validation.sh
+++ b/e2e-tests/controller-spark/controller_spark_sql_validation.sh
@@ -355,6 +355,7 @@ clear
 
 add_resource
 update_resource
+sleep 10
 # Incremental run.
 run_pipeline false
 check_parquet true


### PR DESCRIPTION
## Description of what I changed

Cloud build fails intermittently on dockerised pipeline's incremental run stage. Upon investigation, I found that the thread remains active after full run and when the controller receives request for incremental run, it throws error saying that A pipeline is still running. This can be because it is trying to create resource tables.

Introducing delay between the runs to see if this solves the problem.

## E2E test

Tested

TESTED:

N/A

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
