### PR TITLE
Switched to alternate docker compose to fix build flakiness

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -125,7 +125,7 @@ steps:
   env:
     - PIPELINE_CONFIG=/workspace/docker/config
     - DWH_ROOT=/workspace/e2e-tests/controller-spark/dwh
-  args: [ '-f', './docker/compose-controller-spark-sql.yaml', 'up',
+  args: [ '-f', './docker/compose-controller-spark-sql-single.yaml', 'up',
           '--force-recreate', '-d' ]
 
 - name: '${_REPOSITORY}/e2e-tests/controller-spark:${_TAG}'
@@ -133,7 +133,7 @@ steps:
 
 - name: 'docker/compose'
   id: 'Bring down controller and Spark containers'
-  args: [ '-f', './docker/compose-controller-spark-sql.yaml', 'down' ]
+  args: [ '-f', './docker/compose-controller-spark-sql-single.yaml', 'down' ]
 
 - name: 'docker/compose'
   id: 'Turn down HAPI Source and Sink Servers'

--- a/docker/compose-controller-spark-sql-single.yaml
+++ b/docker/compose-controller-spark-sql-single.yaml
@@ -46,7 +46,7 @@
 # to /opt/bitnami/spark/conf/
 # https://spark.apache.org/docs/latest/configuration.html
 
-version: '2'
+version: '2.4'
 
 services:
   pipeline-controller:
@@ -59,6 +59,12 @@ services:
       - ${DWH_ROOT}:/dwh
     ports:
       - '8090:8080'
+    networks:
+      - cloudbuild
+      - default
+    depends_on:
+      spark:
+        condition: service_healthy
 
   spark:
     image: docker.io/bitnami/spark:3.3
@@ -78,3 +84,17 @@ services:
       #- ./hive-site_example.xml:/opt/bitnami/spark/conf/hive-site.xml
       # Note to use an external DB, you need to provide its driver jar too:
       #- ./postgresql-42.6.0.jar:/opt/bitnami/spark/jars/postgresql-42.6.0.jar
+    networks:
+      - cloudbuild
+      - default
+    healthcheck:
+      test: beeline -u jdbc:hive2://localhost:10000 -n hive -e 'show tables;' || exit 1
+      interval: 30s
+      retries: 10
+      start_period: 10s
+      timeout: 60s
+
+networks:
+  cloudbuild:
+    external: true
+    name: cloudbuild # Needed for Continuous integration

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -32,5 +32,5 @@ fhirdata:
   maxWorkers: 1
   numThreads: -1
   createHiveResourceTables: true
-  thriftserverHiveConfig: "config/thriftserver-hive-config.json"
+  thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   hiveJdbcDriver: "org.apache.hive.jdbc.HiveDriver"

--- a/e2e-tests/controller-spark/controller_spark_sql_validation.sh
+++ b/e2e-tests/controller-spark/controller_spark_sql_validation.sh
@@ -93,7 +93,7 @@ function setup() {
   if [[ $3 = "--use_docker_network" ]]; then
     SOURCE_FHIR_SERVER_URL='http://hapi-server:8080'
     PIPELINE_CONTROLLER_URL='http://pipeline-controller:8080'
-    THRIFTSERVER_URL='thriftserver:10000'
+    THRIFTSERVER_URL='spark:10000'
   fi
 }
 


### PR DESCRIPTION
## Description of what I changed

When I run docker compose using compose-controller-spark-sql.yaml then thriftserver intermittently fails to connect to spark master which results in cloud build failure sometimes.

Switched to compose-controller-spark-sql-single.yaml where there are no spark master and worker containers.

Fixes #708 

## E2E test

Tested

TESTED:

Tested on my local that containers are coming up correctly.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
