### PR TITLE
Updated thiriftserver healthcheck test condition in docker compose files

### DIFF
--- a/docker/compose-controller-spark-sql-single.yaml
+++ b/docker/compose-controller-spark-sql-single.yaml
@@ -90,10 +90,10 @@ services:
       - cloudbuild
       - default
     healthcheck:
-      test: beeline -u jdbc:hive2://localhost:10000 -n hive -e 'show tables;' || exit 1
-      interval: 30s
+      test: beeline help || exit 1
+      interval: 10s
       retries: 10
-      start_period: 10s
+      start_period: 5s
       timeout: 60s
 
 

--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -152,10 +152,10 @@ services:
       - cloudbuild
       - default
     healthcheck:
-      test: beeline -u jdbc:hive2://localhost:10000 -n hive -e 'show tables;' || exit 1
-      interval: 30s
+      test: beeline help || exit 1
+      interval: 10s
       retries: 10
-      start_period: 10s
+      start_period: 5s
       timeout: 60s
 
 volumes:


### PR DESCRIPTION
## Description of what I changed

Thriftserver healthcheck's test was opening hive database connection every "interval" seconds and was populating exception logs.

Changed the test condition to just "beeline help" .

Fixes https://github.com/google/fhir-data-pipes/issues/714

## E2E test

Tested

TESTED:

Verified that both the docker compose are bringing containers up properly. Verified multiple times to make sure there is no intermittent behaviour.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
