### PR TITLE
Fixed the flink job listener which tracks the pipeline metrics for docker

### DIFF
--- a/docker/config/flink-conf.yaml
+++ b/docker/config/flink-conf.yaml
@@ -21,3 +21,6 @@ taskmanager.memory.network.max: 5gb
 # This is to make pipeline.run() non-blocking with FlinkRunner; unfortunately
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240
 execution.attached: false
+
+# This is required to track the pipeline metrics when FlinkRunner is used.
+execution.job-listeners: org.openmrs.analytics.metrics.FlinkJobListener

--- a/pipelines/controller/config/flink-conf.yaml
+++ b/pipelines/controller/config/flink-conf.yaml
@@ -8,4 +8,5 @@ taskmanager.memory.network.max: 5gb
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240
 execution.attached: false
 
+# This is required to track the pipeline metrics when FlinkRunner is used.
 execution.job-listeners: org.openmrs.analytics.metrics.FlinkJobListener


### PR DESCRIPTION
## Description of what I changed

Fixed the flink job listener which tracks the pipeline metrics for docker

## E2E test

TESTED:

Started the docker compose `compose-controller-spark-sql-single.yaml` and tested for the Batch run to see if the metrics are collected properly.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
