### PR TITLE
Fix resource ID's mismatch between original FHIR resource and the corresponding resource in the parquet file in HAPI JDBC mode.

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
@@ -91,6 +91,7 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
   public void writeResource(HapiRowDescriptor element)
       throws IOException, ParseException, SQLException {
     String resourceId = element.resourceId();
+    String forcedId = element.forcedId();
     String resourceType = element.resourceType();
     Meta meta =
         new Meta()
@@ -119,7 +120,11 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
       resource = (Resource) parser.parseResource(jsonResource);
     }
     totalParseTimeMillisMap.get(resourceType).inc(System.currentTimeMillis() - startTime);
-    resource.setId(resourceId);
+    if (forcedId == null || forcedId.equals("")) {
+      resource.setId(resourceId);
+    } else {
+      resource.setId(forcedId);
+    }
     resource.setMeta(meta);
 
     numFetchedResourcesMap.get(resourceType).inc(1);

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/HapiRowDescriptor.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/HapiRowDescriptor.java
@@ -18,6 +18,7 @@ package org.openmrs.analytics;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.Data;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -38,11 +39,18 @@ abstract class HapiRowDescriptor implements Serializable {
       String resourceVersion,
       String jsonResource) {
     return new AutoValue_HapiRowDescriptor(
-        resourceId, forcedId, resourceType, lastUpdated, fhirVersion, resourceVersion, jsonResource);
+        resourceId,
+        forcedId,
+        resourceType,
+        lastUpdated,
+        fhirVersion,
+        resourceVersion,
+        jsonResource);
   }
 
   abstract String resourceId();
 
+  @Nullable
   abstract String forcedId();
 
   abstract String resourceType();

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/HapiRowDescriptor.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/HapiRowDescriptor.java
@@ -31,16 +31,19 @@ abstract class HapiRowDescriptor implements Serializable {
 
   static HapiRowDescriptor create(
       String resourceId,
+      String forcedId,
       String resourceType,
       String lastUpdated,
       String fhirVersion,
       String resourceVersion,
       String jsonResource) {
     return new AutoValue_HapiRowDescriptor(
-        resourceId, resourceType, lastUpdated, fhirVersion, resourceVersion, jsonResource);
+        resourceId, forcedId, resourceType, lastUpdated, fhirVersion, resourceVersion, jsonResource);
   }
 
   abstract String resourceId();
+
+  abstract String forcedId();
 
   abstract String resourceType();
 

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/JdbcFetchHapi.java
@@ -160,7 +160,7 @@ public class JdbcFetchHapi {
                   + " res.res_version, ver.res_encoding, ver.res_text  FROM hfj_resource res JOIN"
                   + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver  "
                   + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid WHERE"
-                  + " res.res_type = ? AND res.res_id % ? = ? AND res.res_type = 'Patient' AND"
+                  + " res.res_type = ? AND res.res_id % ? = ? AND"
                   + " ver.res_encoding != 'DEL'");
       // TODO do date sanity-checking on `since` (note this is partly done by HAPI client call).
       if (since != null && !since.isEmpty()) {

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/JdbcFetchHapi.java
@@ -106,7 +106,13 @@ public class JdbcFetchHapi {
       String resourceVersion = resultSet.getString("res_ver");
       numMappedResourcesMap.get(resourceType).inc();
       return HapiRowDescriptor.create(
-          resourceId, forcedId, resourceType, lastUpdated, fhirVersion, resourceVersion, jsonResource);
+          resourceId,
+          forcedId,
+          resourceType,
+          lastUpdated,
+          fhirVersion,
+          resourceVersion,
+          jsonResource);
     }
   }
 
@@ -149,12 +155,13 @@ public class JdbcFetchHapi {
       this.dataSourceConfig = dataSourceConfig;
       // Note the constraint on `res.res_ver` ensures we only pick the latest version.
       StringBuilder builder =
-              new StringBuilder(
-                      "SELECT res.res_id, hfi.forced_id, res.res_type, res.res_updated, res.res_ver,"
-                              + " ver.res_encoding, ver.res_text FROM hfj_resource res, hfj_res_ver ver,"
-                              + " hfj_forced_id hfi WHERE res.res_type=? AND res.res_id = ver.res_id AND  "
-                              + " res.res_ver = ver.res_ver AND res.res_id % ? = ? AND hfi.resource_pid ="
-                              + " res.res_id AND ver.res_encoding != 'DEL'");
+          new StringBuilder(
+              "SELECT res.res_id, hfi.forced_id, res.res_type, res.res_updated, res.res_ver,"
+                  + " res.res_version, ver.res_encoding, ver.res_text  FROM hfj_resource res JOIN"
+                  + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver  "
+                  + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid WHERE"
+                  + " res.res_type = ? AND res.res_id % ? = ? AND res.res_type = 'Patient' AND"
+                  + " ver.res_encoding != 'DEL'");
       // TODO do date sanity-checking on `since` (note this is partly done by HAPI client call).
       if (since != null && !since.isEmpty()) {
         builder.append(" AND res.res_updated > '").append(since).append("'");

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
@@ -162,7 +162,11 @@ public class ConvertResourceFnTest {
         equalTo(org.hl7.fhir.r4.model.Patient.class.getName()));
   }
 
-  public void testResourceMetaTags() throws IOException, java.text.ParseException, SQLException {
+  @Test
+  public void testResourceMetaTags()
+      throws IOException, java.text.ParseException, SQLException, PropertyVetoException {
+    String[] args = {"--outputParquetPath=SOME_PATH", "--since="};
+    setUp(args);
     String patientResourceStr =
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
@@ -189,7 +193,7 @@ public class ConvertResourceFnTest {
     // Verify the resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("123"));
+    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
     assertThat(
         capturedResource.getMeta().getLastUpdated(),

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
@@ -68,7 +68,7 @@ public class ConvertResourceFnTest {
   }
 
   @Test
-  public void testProcessPatientResource()
+  public void testProcessPatientResource_withoutForcedId()
       throws IOException, java.text.ParseException, SQLException, PropertyVetoException {
     String[] args = {"--outputParquetPath=SOME_PATH"};
     setUp(args);
@@ -76,7 +76,7 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123","forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
+            "123", null, "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
     convertResourceFn.writeResource(element);
 
     // Verify the resource is sent to the writer.
@@ -92,13 +92,44 @@ public class ConvertResourceFnTest {
   }
 
   @Test
+  public void testProcessPatientResource_withForcedId()
+      throws IOException, java.text.ParseException, SQLException, PropertyVetoException {
+    String[] args = {"--outputParquetPath=SOME_PATH"};
+    setUp(args);
+    String patientResourceStr =
+        Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
+    HapiRowDescriptor element =
+        HapiRowDescriptor.create(
+            "123",
+            "forced-id-123",
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "1",
+            patientResourceStr);
+    convertResourceFn.writeResource(element);
+
+    // Verify the resource is sent to the writer.
+    verify(mockParquetUtil).write(resourceCaptor.capture());
+    Resource capturedResource = resourceCaptor.getValue();
+    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
+    assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
+    assertThat(
+        capturedResource.getMeta().getLastUpdated(),
+        equalTo(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2020-09-19 12:09:23")));
+    assertThat(capturedResource.getResourceType().toString(), equalTo("Patient"));
+    assertThat(((Patient) capturedResource).getGender().toString(), equalTo("MALE"));
+  }
+
+  @Test
   public void testProcessDeletedPatientResourceFullMode()
       throws SQLException, IOException, ParseException, PropertyVetoException {
     String[] args = {"--outputParquetPath=SOME_PATH", "--since="};
     setUp(args);
     // Deleted Patient resource
     HapiRowDescriptor element =
-        HapiRowDescriptor.create("123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+        HapiRowDescriptor.create(
+            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
     // Verify that the ParquetUtil writer is not invoked for the deleted resource.
     verify(mockParquetUtil, times(0)).write(Mockito.any());
@@ -111,13 +142,14 @@ public class ConvertResourceFnTest {
     setUp(args);
     // Deleted Patient resource
     HapiRowDescriptor element =
-        HapiRowDescriptor.create("123", "forced-id-123","Patient", "2020-09-19 12:09:23", "R4", "2", "");
+        HapiRowDescriptor.create(
+            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
 
     // Verify the deleted resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("123"));
+    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("2"));
     assertThat(
         capturedResource
@@ -135,7 +167,13 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "forced-id-123","Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
+            "123",
+            "forced-id-123",
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "1",
+            patientResourceStr);
     // Set Tag of HAPI FHIR tag type 0
     Coding coding0 = new Coding("system0", "code0", "display0");
     ResourceTag tag0 = new ResourceTag(coding0, "123", 0);

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/ConvertResourceFnTest.java
@@ -76,7 +76,7 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
+            "123","forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
     convertResourceFn.writeResource(element);
 
     // Verify the resource is sent to the writer.
@@ -98,7 +98,7 @@ public class ConvertResourceFnTest {
     setUp(args);
     // Deleted Patient resource
     HapiRowDescriptor element =
-        HapiRowDescriptor.create("123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+        HapiRowDescriptor.create("123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
     // Verify that the ParquetUtil writer is not invoked for the deleted resource.
     verify(mockParquetUtil, times(0)).write(Mockito.any());
@@ -111,7 +111,7 @@ public class ConvertResourceFnTest {
     setUp(args);
     // Deleted Patient resource
     HapiRowDescriptor element =
-        HapiRowDescriptor.create("123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+        HapiRowDescriptor.create("123", "forced-id-123","Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
 
     // Verify the deleted resource is sent to the writer.
@@ -135,7 +135,7 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
+            "123", "forced-id-123","Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
     // Set Tag of HAPI FHIR tag type 0
     Coding coding0 = new Coding("system0", "code0", "display0");
     ResourceTag tag0 = new ResourceTag(coding0, "123", 0);


### PR DESCRIPTION
## Description of what I changed

- Modified query in the `JdbcFetchHapi.java` to get the forcedId from the database.
- Used forced-id in the `HapiRowDescriptor`
- Used forcedId to as a resource id in `writeResource()` function in the `ConvertResourceFn`

**Issue**:
#752 

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the following command to transform the FHIR resources.

`java -cp ./pipelines/batch/target/batch-bundled-0.1.0-SNAPSHOT.jar org.openmrs.analytics.FhirEtl --fhirServerUrl=[FHIR-SERVER-RUL] --outputParquetPath=./docker/dwh/ --resourceList=Patient,Encounter,Observation  --fhirDatabaseConfigPath=./utils/hapi-postgres-config.json --jdbcModeEnabled=true --jdbcModeHapi=true --jdbcMaxPoolSize=50 --jdbcFetchSize=1000`

Verified that the id of the original FHIR resource match the resource id in transformed paquet file.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
