### PR TITLE
Handling large resource parsing exception using DataFormatException

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
@@ -16,6 +16,7 @@
 package org.openmrs.analytics;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.parser.DataFormatException;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -116,7 +117,13 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
       meta.addTag(
           new Coding(removeAction.getSystem(), removeAction.toCode(), removeAction.getDisplay()));
     } else {
-      resource = (Resource) parser.parseResource(jsonResource);
+      try {
+        resource = (Resource) parser.parseResource(jsonResource);
+      }
+      catch (DataFormatException e) {
+        e.printStackTrace();
+        return;
+      }
     }
     totalParseTimeMillisMap.get(resourceType).inc(System.currentTimeMillis() - startTime);
     resource.setId(resourceId);

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
@@ -55,6 +55,8 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
 
   private final Boolean processDeletedRecords;
 
+  Counter counter = Metrics.counter(MetricsConstants.METRICS_NAMESPACE, MetricsConstants.DATA_FORMAT_EXCEPTION_ERROR);
+
   ConvertResourceFn(FhirEtlOptions options, String stageIdentifier) {
     super(options, stageIdentifier);
     this.numFetchedResourcesMap = new HashMap<String, Counter>();
@@ -121,7 +123,8 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
         resource = (Resource) parser.parseResource(jsonResource);
       }
       catch (DataFormatException e) {
-        e.printStackTrace();
+        log.error("DataFormatException Error occurred", e);
+        counter.inc();
         return;
       }
     }

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/MetricsConstants.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/MetricsConstants.java
@@ -21,6 +21,7 @@ public class MetricsConstants {
   public static final String NUM_FETCHED_RESOURCES = "numFetchedResources_";
   public static final String NUM_OUTPUT_RECORDS = "numOutputRecords";
   public static final String NUM_DUPLICATES = "numDuplicates";
+  public static final String DATA_FORMAT_EXCEPTION_ERROR = "numDataFormatExceptionErrors_";
   public static final String TOTAL_FETCH_TIME_MILLIS = "totalFetchTimeMillis_";
   public static final String TOTAL_GENERATE_TIME_MILLIS = "totalGenerateTimeMillis_";
   public static final String TOTAL_PUSH_TIME_MILLIS = "totalPushTimeMillis_";


### PR DESCRIPTION
## Description of what I changed

Handling large resource parsing exception using DataFormatException
I have used try/catch block to catch the DataFormatException while parsing JSON encoded FHIR content.
Issue : https://github.com/google/fhir-data-pipes/issues/755

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

After adding the try/catch block, I ran the Pipeline and it generated the Parquet files.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [ ] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
