### PR TITLE
Fixes missing QuestionnaireResponse `answer` fields

### DIFF
--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -243,7 +243,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           if (resourceContainer.get(j) != null) {
 
             IndexedRecord record = (IndexedRecord) resourceContainer.get(j);
-            String recordType = DefinitionVisitorsUtil.getBaseName(record.getSchema().getName());
+            String recordType = record.getSchema().getName();
 
             containedEntries.add(new ContainerEntry(recordType, record));
 
@@ -265,8 +265,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       for (Object containedEntry: contained) {
 
         IndexedRecord containedRecord = (IndexedRecord) avroData.newRecord(null, containerType);
-        String recordName = DefinitionVisitorsUtil.getBaseName(
-            ((IndexedRecord) containedEntry).getSchema().getName());
+        String recordName = ((IndexedRecord) containedEntry).getSchema().getName();
 
         List<Field> fields = containerType.getFields();
 
@@ -453,11 +452,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       String elementTypeUrl,
       List<StructureField<HapiConverter<Schema>>> children) {
 
-    // The reason for adding children is to differentiate between same types at different
-    // recursion levels, e.g., when a child is dropped because of recursion max-depth while
-    // in a different traversal (for the same type) that child is present.
-    // NOTE this solution is not complete and can still miss legitimate recursions!
-    String recordName = DefinitionVisitorsUtil.recordNameFor(elementPath, children);
+    String recordName = DefinitionVisitorsUtil.recordNameFor(elementPath);
     String recordNamespace = DefinitionVisitorsUtil.namespaceFor(basePackage, elementTypeUrl);
     String fullName = recordNamespace + "." + recordName;
 
@@ -749,7 +744,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
   @Override
   public int getMaxDepth(String elementTypeUrl, String path) {
     // should be an odd number!
-    return 5;
-    // return 1;
+    // return 3;
+    return 1;
   }
 }

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
@@ -1,6 +1,9 @@
 package com.cerner.bunsen.definitions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -16,8 +19,6 @@ public class DefinitionVisitorsUtil {
   private static final Pattern STRUCTURE_URL_PATTERN =
       Pattern.compile("http:\\/\\/hl7.org\\/fhir(\\/.*)?\\/StructureDefinition\\/([^\\/]*)$");
 
-  private static final String CHILDREN_TOKEN = "_CHILDREN_";
-
   /**
    * Helper method to convert a given element path that's delimited by period to a concatenated
    * string in title case.
@@ -31,20 +32,6 @@ public class DefinitionVisitorsUtil {
         .map(StringUtils::capitalize)
         .reduce(String::concat)
         .get();
-  }
-
-  public static <T> String recordNameFor(String elementPath, List<StructureField<T>> children) {
-    return recordNameFor(elementPath)
-        + CHILDREN_TOKEN + children.stream().map(
-            c -> c.fieldName()).collect(Collectors.joining("_"));
-  }
-
-  public static String getBaseName(String name) {
-    int tokenInd = name.indexOf(CHILDREN_TOKEN);
-    if (tokenInd >= 0) {
-      return name.substring(0, tokenInd);
-    }
-    return name;
   }
 
   /**
@@ -76,6 +63,45 @@ public class DefinitionVisitorsUtil {
       throw new IllegalArgumentException(
           "Unrecognized structure definition URL: " + structureDefinitionUrl);
     }
+  }
+
+  /**
+   * This is to extract the full path of an element based on the element traversal stack.
+   * The reason for using the full path from stack is to differentiate between same types at
+   * different recursion levels, e.g., when a child is dropped because of recursion max-depth
+   * while in a different traversal (for the same type) that child is present. Note in both those
+   * cases the element name and path would be the same hence we need to rely on the full traversal
+   * stack. As an example consider these two fields:
+   * QuestionnaireResponse.item.answer.item
+   * QuestionnaireResponse.item.answer.item.answer.item
+   * Both of these are `item` with "element path" being `QuestionnaireResponse.item` but the
+   * `answer` field might have been dropped in the second one because of recursion limits.
+   *
+   * @param stack the current traversal stack
+   * @return the full path
+   */
+  public static String pathFromStack(String elementName, Deque<QualifiedPath> stack) {
+    // TODO add unit-tests for this method.
+    List<String> fullPath = new ArrayList<>();
+    Iterator<QualifiedPath> iter = stack.descendingIterator();
+    while (iter.hasNext()) {
+      String path = iter.next().getElementPath();
+      fullPath.add(elementName(path));
+    }
+    fullPath.add(elementName);
+    return fullPath.stream().collect(Collectors.joining("."));
+  }
+
+  /**
+   * Creates a canonical element name from the element path.
+   */
+  public static String elementName(String elementPath) {
+
+    String suffix = elementPath.substring(elementPath.lastIndexOf('.') + 1);
+
+    return suffix.endsWith("[x]")
+        ? suffix.substring(0, suffix.length() - 3)
+        : suffix;
   }
 
 }

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
@@ -77,10 +77,11 @@ public class DefinitionVisitorsUtil {
    * Both of these are `item` with "element path" being `QuestionnaireResponse.item` but the
    * `answer` field might have been dropped in the second one because of recursion limits.
    *
-   * @param stack the current traversal stack
-   * @return the full path
+   * @param elemName the name of the target element
+   * @param stack the current traversal stack leading to `elemName`
+   * @return the full path for `elemName` created using element names on the stack
    */
-  public static String pathFromStack(String elementName, Deque<QualifiedPath> stack) {
+  public static String pathFromStack(String elemName, Deque<QualifiedPath> stack) {
     // TODO add unit-tests for this method.
     List<String> fullPath = new ArrayList<>();
     Iterator<QualifiedPath> iter = stack.descendingIterator();
@@ -88,7 +89,7 @@ public class DefinitionVisitorsUtil {
       String path = iter.next().getElementPath();
       fullPath.add(elementName(path));
     }
-    fullPath.add(elementName);
+    fullPath.add(elemName);
     return fullPath.stream().collect(Collectors.joining("."));
   }
 

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
@@ -1,8 +1,10 @@
 package com.cerner.bunsen.definitions;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -14,6 +16,7 @@ public class DefinitionVisitorsUtil {
   private static final Pattern STRUCTURE_URL_PATTERN =
       Pattern.compile("http:\\/\\/hl7.org\\/fhir(\\/.*)?\\/StructureDefinition\\/([^\\/]*)$");
 
+  private static final String CHILDREN_TOKEN = "_CHILDREN_";
 
   /**
    * Helper method to convert a given element path that's delimited by period to a concatenated
@@ -28,6 +31,20 @@ public class DefinitionVisitorsUtil {
         .map(StringUtils::capitalize)
         .reduce(String::concat)
         .get();
+  }
+
+  public static <T> String recordNameFor(String elementPath, List<StructureField<T>> children) {
+    return recordNameFor(elementPath)
+        + CHILDREN_TOKEN + children.stream().map(
+            c -> c.fieldName()).collect(Collectors.joining("_"));
+  }
+
+  public static String getBaseName(String name) {
+    int tokenInd = name.indexOf(CHILDREN_TOKEN);
+    if (tokenInd >= 0) {
+      return name.substring(0, tokenInd);
+    }
+    return name;
   }
 
   /**

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -30,7 +30,7 @@
     <python.version>3.5.3</python.version>
     <maven-javadoc.plugin.version>3.5.0</maven-javadoc.plugin.version>
     <maven-project-info-reports.plugin.version>3.4.3</maven-project-info-reports.plugin.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.7</slf4j.version>
     <logback.version>1.4.7</logback.version>
   </properties>
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,16 +34,16 @@ steps:
   - mvn --no-transfer-progress -e install -Dlicense.skip=true -Dspotless.apply.skip=true
   waitFor: ['-']
 
-- name: 'gcr.io/cloud-builders/curl'
-  id: 'Upload coverage reports to codecov.io'
-  entrypoint: bash
-  args: ['-c', 'bash <(curl -s https://codecov.io/bash)']
-  env:
-    - 'VCS_COMMIT_ID=$COMMIT_SHA'
-    - 'VCS_BRANCH_NAME=$BRANCH_NAME'
-    - 'VCS_PULL_REQUEST=$_PR_NUMBER'
-    - 'CI_BUILD_ID=$BUILD_ID'
-    - 'CODECOV_TOKEN=$_CODECOV_TOKEN' # This token is generated when you setup your repo on codecov: https://docs.codecov.com/docs
+# - name: 'gcr.io/cloud-builders/curl'
+#   id: 'Upload coverage reports to codecov.io'
+#   entrypoint: bash
+#   args: ['-c', 'bash <(curl -s https://codecov.io/bash)']
+#   env:
+#     - 'VCS_COMMIT_ID=$COMMIT_SHA'
+#     - 'VCS_BRANCH_NAME=$BRANCH_NAME'
+#     - 'VCS_PULL_REQUEST=$_PR_NUMBER'
+#     - 'CI_BUILD_ID=$BUILD_ID'
+#     - 'CODECOV_TOKEN=$_CODECOV_TOKEN' # This token is generated when you setup your repo on codecov: https://docs.codecov.com/docs
 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build Uploader Image'

--- a/docker/config/flink-conf.yaml
+++ b/docker/config/flink-conf.yaml
@@ -18,6 +18,11 @@
 # exceptions when running the merger on large input with many workers.
 taskmanager.memory.network.max: 5gb
 
+# This is needed to be able to process large resources, otherwise in JDBC
+# mode we may get the following exception:
+# "The record exceeds the maximum size of a sort buffer ..."
+taskmanager.memory.managed.size: 2gb
+
 # This is to make pipeline.run() non-blocking with FlinkRunner; unfortunately
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240
 execution.attached: false

--- a/utils/flink-conf.yaml
+++ b/utils/flink-conf.yaml
@@ -1,8 +1,27 @@
-# To use this config, FLINK_CONF_DIR env. var should be set.
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# This is needed to prevent a "Insufficient number of network buffers"
+# To use this config, FLINK_CONF_DIR env. var should be set to the parent dir.
+
+# This is needed to prevent an "Insufficient number of network buffers"
 # exceptions when running the merger on large input with many workers.
-taskmanager.network.memory.max: 5gb
+taskmanager.memory.network.max: 5gb
+
+# This is needed to be able to process large resources, otherwise in JDBC
+# mode we may get the following exception:
+# "The record exceeds the maximum size of a sort buffer ..."
+taskmanager.memory.managed.size: 2gb
 
 # This is to make pipeline.run() non-blocking with FlinkRunner; unfortunately
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This fixes #758 by adding the full path of fields (using the traversal stack) to record names. This way we can differentiate between `QuestionnaireResponse.item.answer.item.answer.item` and `QuestionnaireResponse.item.answer.item` which is needed to properly apply recursion limits.

This PR has two commits; the first one is a simpler solution that I originally had but only partially solves the problem. I have kept it for record keeping and future reference.

This also comments out the `codecov` part of `cloudbuild.yaml` as it has started to fail for some reason.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the pipeline against the QuestionnaireResponse that had problem before and confirmed that answers are generated in the Parquet file if the recursion depth is large enough (tried with max-depth 3). I have not changed the default max-depth in this PR (only added a comment); that should be handled in #757.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
