### PR TITLE
Fixed bugs in recursion depth and added a path example

### DIFF
--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -452,6 +452,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       String elementTypeUrl,
       List<StructureField<HapiConverter<Schema>>> children) {
 
+    Preconditions.checkArgument(!children.isEmpty());
     String recordName = DefinitionVisitorsUtil.recordNameFor(elementPath);
     String recordNamespace = DefinitionVisitorsUtil.namespaceFor(basePackage, elementTypeUrl);
     String fullName = recordNamespace + "." + recordName;
@@ -743,8 +744,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
   @Override
   public int getMaxDepth(String elementTypeUrl, String path) {
-    // should be an odd number!
-    // return 3;
+    // return 2;
     return 1;
   }
 }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -488,7 +488,7 @@ public class R4AvroConverterTest {
 
     // Ensure common types were generated
     Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/Period.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/Coding.java"));
+    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/PatientCoding.java"));
     Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/ValueSet.java"));
 
     // The specific profile should be created in the expecter4b-package.

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
@@ -485,7 +485,7 @@ public class Stu3AvroConverterTest {
 
     // Ensure common types were generated
     Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/Period.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/Coding.java"));
+    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/PatientCoding.java"));
     Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/ValueSet.java"));
 
     // The specific profile should be created in the expected sub-package.

--- a/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
+++ b/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
@@ -8,6 +8,7 @@ import com.cerner.bunsen.definitions.FhirConversionSupport;
 import com.cerner.bunsen.definitions.QualifiedPath;
 import com.cerner.bunsen.definitions.StructureDefinitions;
 import com.cerner.bunsen.definitions.StructureField;
+import com.google.common.base.Verify;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent;
@@ -83,32 +85,23 @@ public class R4StructureDefinitions extends StructureDefinitions {
   }
 
   private <T> List<StructureField<T>> singleField(String elementName, T result) {
-
+    if (result == null) {
+      return Collections.emptyList();
+    }
     return Collections.singletonList(StructureField.property(elementName, result));
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      StructureDefinition structureDefinition,
-      Deque<QualifiedPath> stack) {
-
-    ElementDefinition definitionRootElement = structureDefinition.getSnapshot().getElement().get(0);
-
-    return shouldTerminateRecursive(visitor, structureDefinition, definitionRootElement, stack);
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition elementDefinition, Deque<QualifiedPath> stack) {
-
-
-    return shouldTerminateRecursive(visitor,
-        new QualifiedPath(rootDefinition.getUrl(), elementDefinition.getPath()),
-        stack);
   }
 
   private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
       QualifiedPath newPath,
       Deque<QualifiedPath> stack) {
+
+    // TODO we should add configuration parameters for exceptional paths
+    //  that require deeper recursion; this is where to apply that logic:
+    // String elementPath = DefinitionVisitorsUtil.pathFromStack(
+    //    DefinitionVisitorsUtil.elementName(newPath.getElementPath()), stack);
+    // if ("QuestionnaireResponse.item.item.item.item.item.item".startsWith(elementPath)) {
+    //   return false;
+    // }
 
     int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
 
@@ -149,26 +142,17 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
     if (definition != null) {
 
-      if (shouldTerminateRecursive(visitor,
-          new QualifiedPath(definition.getUrl(), element.getPath()),
-          stack)) {
+      List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
 
-        return Collections.emptyList();
+      ElementDefinition extensionRoot = extensionDefinitions.get(0);
 
-      } else {
-
-        List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
-
-        ElementDefinition extensionRoot = extensionDefinitions.get(0);
-
-        extensions = visitExtensionDefinition(visitor,
-            rootDefinition,
-            element.getSliceName(),
-            stack,
-            definition.getUrl(),
-            extensionDefinitions,
-            extensionRoot);
-      }
+      extensions = visitExtensionDefinition(visitor,
+          rootDefinition,
+          element.getSliceName(),
+          stack,
+          definition.getUrl(),
+          extensionDefinitions,
+          extensionRoot);
 
     } else {
 
@@ -286,11 +270,7 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
     String elementName = DefinitionVisitorsUtil.elementName(element.getPath());
 
-    if (shouldTerminateRecursive(visitor, rootDefinition, element, stack)) {
-
-      return Collections.emptyList();
-
-    } else if (element.getMax().equals("0")) {
+    if (element.getMax().equals("0")) {
 
       // Fields with max of zero are omitted.
       return Collections.emptyList();
@@ -338,8 +318,12 @@ public class R4StructureDefinitions extends StructureDefinitions {
               (StructureDefinition) validationSupport
                   .fetchStructureDefinition(typeRef.getCode());
 
+          // TODO document why we are resetting the stack here; it is not clear
+          //  why this cannot lead to infinite recursion for choice types. If
+          //  we don't reset the stack, then we should handle null returns.
           T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
-
+          Verify.verify(child != null,
+              "Unexpected null choice type {} for element {}", typeRef, element);
           choiceTypes.put(typeRef.getCode(), child);
         }
       }
@@ -360,22 +344,19 @@ public class R4StructureDefinitions extends StructureDefinitions {
         // Handle defined data types.
         StructureDefinition definition = getDefinition(element);
 
-        if (shouldTerminateRecursive(visitor, definition, stack)) {
+        T type = transform(visitor, element, definition, stack);
 
-          return Collections.emptyList();
-
-        } else {
-
-          T type = transform(visitor, element, definition, stack);
-
-          return singleField(elementName,
-              visitor.visitMultiValued(elementName, type));
-        }
+        return singleField(elementName,
+            visitor.visitMultiValued(elementName, type));
 
       } else {
 
         List<StructureField<T>> childElements = transformChildren(visitor,
             rootDefinition, definitions, stack, element);
+        if (childElements.isEmpty()) {
+          // All children were dropped because of recursion depth limit.
+          return  Collections.emptyList();
+        }
 
         T result = visitor.visitComposite(elementName,
             DefinitionVisitorsUtil.pathFromStack(elementName, stack),
@@ -399,27 +380,26 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
     } else if (getDefinition(element) != null) {
 
+      // TODO refactor this and the similar block above for handling defined data types.
       // Handle defined data types.
       StructureDefinition definition = getDefinition(element);
 
-      if (shouldTerminateRecursive(visitor, definition, stack)) {
+      T type = transform(visitor, element, definition, stack);
 
-        return Collections.emptyList();
-
-      } else {
-        T type = transform(visitor, element, definition, stack);
-
-        return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
-      }
+      return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
 
     } else {
 
       // Handle composite type
       List<StructureField<T>> childElements = transformChildren(visitor, rootDefinition,
           definitions, stack, element);
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return  Collections.emptyList();
+      }
 
       T result = visitor.visitComposite(elementName,
-          element.getPath(),
+          DefinitionVisitorsUtil.pathFromStack(elementName, stack),
           elementName,
           rootDefinition.getUrl(),
           childElements);
@@ -428,6 +408,12 @@ public class R4StructureDefinitions extends StructureDefinitions {
     }
   }
 
+  /**
+   * Goes through the list of children of the given `element` and convert each
+   * of those `ElementDefinision`s to `StructureField`s.
+   * NOTE: This is the only place where the traversal stack can grow. It is also
+   * best if this is the only place where `shouldTerminateRecursive` is called.
+   */
   private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
       StructureDefinition rootDefinition,
       List<ElementDefinition> definitions,
@@ -475,15 +461,13 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
       List<ElementDefinition> childDefinitions = containedDefinition.getSnapshot().getElement();
 
-      stack.push(new QualifiedPath(containedDefinition.getUrl(), containedRootElement.getPath()));
-
       List<StructureField<T>> childElements = transformChildren(visitor,
           containedDefinition,
           childDefinitions,
           stack,
           containedRootElement);
-
-      stack.pop();
+      // At this level no child should be dropped because of recursion limit.
+      Verify.verify(!childElements.isEmpty());
 
       String rootName = DefinitionVisitorsUtil.elementName(containedRootElement.getPath());
 
@@ -511,26 +495,7 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
   @Override
   public <T> T transform(DefinitionVisitor<T> visitor, String resourceTypeUrl) {
-
-    StructureDefinition definition = (StructureDefinition) context.getValidationSupport()
-        .fetchStructureDefinition(resourceTypeUrl);
-
-    if (definition == null) {
-
-      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
-    }
-
-    return transform(visitor, definition);
-  }
-
-  /**
-   * Returns the Spark struct type used to encode the given FHIR composite.
-   *
-   * @return The schema as a Spark StructType
-   */
-  public <T> T transform(DefinitionVisitor<T> visitor, StructureDefinition definition) {
-
-    return transform(visitor, null, definition, new ArrayDeque<>());
+    return transform(visitor, resourceTypeUrl, Collections.emptyList());
   }
 
   @Override
@@ -562,9 +527,10 @@ public class R4StructureDefinitions extends StructureDefinitions {
         })
         .collect(Collectors.toList());
 
-    return transformRoot(visitor, definition, containedDefinitions, new ArrayDeque<>());
+    return transformRoot(visitor, definition, containedDefinitions);
   }
 
+  // TODO make the separation between this and `elementToFields` more clear.
   /**
    * Transforms the given FHIR structure definition.
    *
@@ -576,6 +542,7 @@ public class R4StructureDefinitions extends StructureDefinitions {
    *
    * @return the transformed structure, or null if it should not be included in the parent.
    */
+  @Nullable
   private <T> T transform(DefinitionVisitor<T> visitor,
       ElementDefinition parentElement,
       StructureDefinition definition,
@@ -585,12 +552,8 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
     ElementDefinition root = definitions.get(0);
 
-    stack.push(new QualifiedPath(definition.getUrl(), root.getPath()));
-
     List<StructureField<T>> childElements = transformChildren(visitor, definition,
         definitions, stack, root);
-
-    stack.pop();
 
     if ("Reference".equals(definition.getType())) {
 
@@ -628,8 +591,12 @@ public class R4StructureDefinitions extends StructureDefinitions {
       // https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#id-fields-omitted
       childElements.removeIf(field -> field.fieldName().equals("id"));
 
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return null;
+      }
       return visitor.visitComposite(rootName,
-          rootName,
+          DefinitionVisitorsUtil.pathFromStack(root.getPath(), stack),
           rootName,
           definition.getUrl(),
           childElements);
@@ -638,22 +605,22 @@ public class R4StructureDefinitions extends StructureDefinitions {
 
   private <T> T transformRoot(DefinitionVisitor<T> visitor,
       StructureDefinition definition,
-      List<StructureDefinition> containedDefinitions,
-      Deque<QualifiedPath> stack) {
+      List<StructureDefinition> containedDefinitions) {
 
     ElementDefinition definitionRootElement = definition.getSnapshot().getElementFirstRep();
 
     List<ElementDefinition> definitions = definition.getSnapshot().getElement();
 
-    ElementDefinition root = definitions.get(0);
-
-    stack.push(new QualifiedPath(definition.getUrl(), definitionRootElement.getPath()));
+    Deque<QualifiedPath> stack = new ArrayDeque<>();
 
     List<StructureField<T>> childElements = transformChildren(visitor,
         definition,
         definitions,
         stack,
-        root);
+        definitionRootElement);
+    // At this level no child should be dropped because of recursion limit.
+    Verify.verify(!childElements.isEmpty());
+    Verify.verify(stack.isEmpty());
 
     // If there are contained definitions, create a Resource Container StructureField
     if (containedDefinitions.size() > 0) {
@@ -662,16 +629,14 @@ public class R4StructureDefinitions extends StructureDefinitions {
           definition,
           containedDefinitions,
           stack,
-          root);
+          definitionRootElement);
 
       // Replace default StructureField with constructed Resource Container StructureField
       // TODO make this future proof instead of using a hard-coded index for `contained`.
       childElements.set(5, containedElement);
     }
 
-    stack.pop();
-
-    String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+    String rootName = DefinitionVisitorsUtil.elementName(definitionRootElement.getPath());
 
     return visitor.visitComposite(rootName,
         rootName,

--- a/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -8,6 +8,7 @@ import com.cerner.bunsen.definitions.FhirConversionSupport;
 import com.cerner.bunsen.definitions.QualifiedPath;
 import com.cerner.bunsen.definitions.StructureDefinitions;
 import com.cerner.bunsen.definitions.StructureField;
+import com.google.common.base.Verify;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,14 +18,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.hl7.fhir.dstu3.model.ElementDefinition;
 import org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link StructureDefinitions} implementation for FHIR STU3.
  */
 public class Stu3StructureDefinitions extends StructureDefinitions {
+
+  private static final Logger log = LoggerFactory.getLogger(Stu3StructureDefinitions.class);
 
   private static final FhirConversionSupport CONVERSION_SUPPORT = new Stu3FhirConversionSupport();
 
@@ -73,27 +79,10 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
   }
 
   private <T> List<StructureField<T>> singleField(String elementName, T result) {
-
+    if (result == null) {
+      return Collections.emptyList();
+    }
     return Collections.singletonList(StructureField.property(elementName, result));
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      StructureDefinition structureDefinition,
-      Deque<QualifiedPath> stack) {
-
-    ElementDefinition definitionRootElement = structureDefinition.getSnapshot().getElement().get(0);
-
-    return shouldTerminateRecursive(visitor, structureDefinition, definitionRootElement, stack);
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition elementDefinition, Deque<QualifiedPath> stack) {
-
-
-    return shouldTerminateRecursive(visitor,
-        new QualifiedPath(rootDefinition.getUrl(), elementDefinition.getPath()),
-        stack);
   }
 
   private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
@@ -121,26 +110,17 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
     if (definition != null) {
 
-      if (shouldTerminateRecursive(visitor,
-          new QualifiedPath(definition.getUrl(), element.getPath()),
-          stack)) {
+      List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
 
-        return Collections.emptyList();
+      ElementDefinition extensionRoot = extensionDefinitions.get(0);
 
-      } else {
-
-        List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
-
-        ElementDefinition extensionRoot = extensionDefinitions.get(0);
-
-        extensions = visitExtensionDefinition(visitor,
-            rootDefinition,
-            element.getSliceName(),
-            stack,
-            definition.getUrl(),
-            extensionDefinitions,
-            extensionRoot);
-      }
+      extensions = visitExtensionDefinition(visitor,
+          rootDefinition,
+          element.getSliceName(),
+          stack,
+          definition.getUrl(),
+          extensionDefinitions,
+          extensionRoot);
 
     } else {
 
@@ -257,11 +237,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
     String elementName = DefinitionVisitorsUtil.elementName(element.getPath());
 
-    if (shouldTerminateRecursive(visitor, rootDefinition, element, stack)) {
-
-      return Collections.emptyList();
-
-    } else if (element.getMax().equals("0")) {
+    if (element.getMax().equals("0")) {
 
       // Fields with max of zero are omitted.
       return Collections.emptyList();
@@ -303,8 +279,12 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
               (StructureDefinition) validationSupport
                   .fetchStructureDefinition(typeRef.getCode());
 
+          // TODO document why we are resetting the stack here; it is not clear
+          //  why this cannot lead to infinite recursion for choice types. If
+          //  we don't reset the stack, then we should handle null returns.
           T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
-
+          Verify.verify(child != null,
+              "Unexpected null choice type {} for element {}", typeRef, element);
           choiceTypes.put(typeRef.getCode(), child);
         }
       }
@@ -325,25 +305,22 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
         // Handle defined data types.
         StructureDefinition definition = getDefinition(element);
 
-        if (shouldTerminateRecursive(visitor, definition, stack)) {
+        T type = transform(visitor, element, definition, stack);
 
-          return Collections.emptyList();
-
-        } else {
-
-          T type = transform(visitor, element, definition, stack);
-
-          return singleField(elementName,
-              visitor.visitMultiValued(elementName, type));
-        }
+        return singleField(elementName,
+            visitor.visitMultiValued(elementName, type));
 
       } else {
 
         List<StructureField<T>> childElements = transformChildren(visitor,
             rootDefinition, definitions, stack, element);
+        if (childElements.isEmpty()) {
+          // All children were dropped because of recursion depth limit.
+          return  Collections.emptyList();
+        }
 
         T result = visitor.visitComposite(elementName,
-            element.getPath(),
+            DefinitionVisitorsUtil.pathFromStack(elementName, stack),
             elementName,
             rootDefinition.getUrl(),
             childElements);
@@ -364,24 +341,23 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
     } else if (getDefinition(element) != null) {
 
+      // TODO refactor this and the similar block above for handling defined data types.
       // Handle defined data types.
       StructureDefinition definition = getDefinition(element);
 
-      if (shouldTerminateRecursive(visitor, definition, stack)) {
+      T type = transform(visitor, element, definition, stack);
 
-        return Collections.emptyList();
-
-      } else {
-        T type = transform(visitor, element, definition, stack);
-
-        return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
-      }
+      return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
 
     } else {
 
       // Handle composite type
       List<StructureField<T>> childElements = transformChildren(visitor, rootDefinition,
           definitions, stack, element);
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return  Collections.emptyList();
+      }
 
       T result = visitor.visitComposite(elementName,
           DefinitionVisitorsUtil.pathFromStack(elementName, stack),
@@ -393,6 +369,12 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
     }
   }
 
+  /**
+   * Goes through the list of children of the given `element` and convert each
+   * of those `ElementDefinision`s to `StructureField`s.
+   * NOTE: This is the only place where the traversal stack can grow. It is also
+   * best if this is the only place where `shouldTerminateRecursive` is called.
+   */
   private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
       StructureDefinition rootDefinition,
       List<ElementDefinition> definitions,
@@ -440,15 +422,13 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
       List<ElementDefinition> childDefinitions = containedDefinition.getSnapshot().getElement();
 
-      stack.push(new QualifiedPath(containedDefinition.getUrl(), containedRootElement.getPath()));
-
       List<StructureField<T>> childElements = transformChildren(visitor,
           containedDefinition,
           childDefinitions,
           stack,
           containedRootElement);
-
-      stack.pop();
+      // At this level no child should be dropped because of recursion limit.
+      Verify.verify(!childElements.isEmpty());
 
       String rootName = DefinitionVisitorsUtil.elementName(containedRootElement.getPath());
 
@@ -476,26 +456,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
   @Override
   public <T> T transform(DefinitionVisitor<T> visitor, String resourceTypeUrl) {
-
-    StructureDefinition definition = (StructureDefinition) context.getValidationSupport()
-        .fetchStructureDefinition(resourceTypeUrl);
-
-    if (definition == null) {
-
-      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
-    }
-
-    return transform(visitor, definition);
-  }
-
-  /**
-   * Returns the Spark struct type used to encode the given FHIR composite.
-   *
-   * @return The schema as a Spark StructType
-   */
-  public <T> T transform(DefinitionVisitor<T> visitor, StructureDefinition definition) {
-
-    return transform(visitor, null, definition, new ArrayDeque<>());
+    return transform(visitor, resourceTypeUrl, Collections.emptyList());
   }
 
   @Override
@@ -527,7 +488,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
         })
         .collect(Collectors.toList());
 
-    return transformRoot(visitor, definition, containedDefinitions, new ArrayDeque<>());
+    return transformRoot(visitor, definition, containedDefinitions);
   }
 
   /**
@@ -541,6 +502,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
    *
    * @return the transformed structure, or null if it should not be included in the parent.
    */
+  @Nullable
   private <T> T transform(DefinitionVisitor<T> visitor,
       ElementDefinition parentElement,
       StructureDefinition definition,
@@ -550,12 +512,8 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
     ElementDefinition root = definitions.get(0);
 
-    stack.push(new QualifiedPath(definition.getUrl(), root.getPath()));
-
     List<StructureField<T>> childElements = transformChildren(visitor, definition,
         definitions, stack, root);
-
-    stack.pop();
 
     if ("Reference".equals(definition.getType())) {
 
@@ -588,8 +546,12 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
       // https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#id-fields-omitted
       childElements.removeIf(field -> field.fieldName().equals("id"));
 
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return null;
+      }
       return visitor.visitComposite(rootName,
-          rootName,
+          DefinitionVisitorsUtil.pathFromStack(root.getPath(), stack),
           rootName,
           definition.getUrl(),
           childElements);
@@ -598,22 +560,22 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
   private <T> T transformRoot(DefinitionVisitor<T> visitor,
       StructureDefinition definition,
-      List<StructureDefinition> containedDefinitions,
-      Deque<QualifiedPath> stack) {
+      List<StructureDefinition> containedDefinitions) {
 
     ElementDefinition definitionRootElement = definition.getSnapshot().getElementFirstRep();
 
     List<ElementDefinition> definitions = definition.getSnapshot().getElement();
 
-    ElementDefinition root = definitions.get(0);
-
-    stack.push(new QualifiedPath(definition.getUrl(), definitionRootElement.getPath()));
+    Deque<QualifiedPath> stack = new ArrayDeque<>();
 
     List<StructureField<T>> childElements = transformChildren(visitor,
         definition,
         definitions,
         stack,
-        root);
+        definitionRootElement);
+    // At this level no child should be dropped because of recursion limit.
+    Verify.verify(!childElements.isEmpty());
+    Verify.verify(stack.isEmpty());
 
     // If there are contained definitions, create a Resource Container StructureField
     if (containedDefinitions.size() > 0) {
@@ -622,15 +584,13 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
           definition,
           containedDefinitions,
           stack,
-          root);
+          definitionRootElement);
 
       // Replace default StructureField with constructed Resource Container StructureField
       childElements.set(5, containedElement);
     }
 
-    stack.pop();
-
-    String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+    String rootName = DefinitionVisitorsUtil.elementName(definitionRootElement.getPath());
 
     return visitor.visitComposite(rootName,
         rootName,

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiCompositeConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiCompositeConverter.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.RuntimeElemContainedResourceList;
+import com.google.common.base.Preconditions;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +145,8 @@ public abstract class HapiCompositeConverter<T> extends HapiConverter<T> {
       T structType,
       FhirConversionSupport fhirSupport,
       String extensionUrl) {
-
+    // A composite type should have at least one child.
+    Preconditions.checkArgument(!children.isEmpty());
     this.elementType = elementType;
     this.children = children;
     this.structType = structType;

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ConvertResourceFn.java
@@ -55,7 +55,9 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
 
   private final Boolean processDeletedRecords;
 
-  Counter counter = Metrics.counter(MetricsConstants.METRICS_NAMESPACE, MetricsConstants.DATA_FORMAT_EXCEPTION_ERROR);
+  Counter counter =
+      Metrics.counter(
+          MetricsConstants.METRICS_NAMESPACE, MetricsConstants.DATA_FORMAT_EXCEPTION_ERROR);
 
   ConvertResourceFn(FhirEtlOptions options, String stageIdentifier) {
     super(options, stageIdentifier);
@@ -121,8 +123,7 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
     } else {
       try {
         resource = (Resource) parser.parseResource(jsonResource);
-      }
-      catch (DataFormatException e) {
+      } catch (DataFormatException e) {
         log.error("DataFormatException Error occurred", e);
         counter.inc();
         return;

--- a/pipelines/batch/src/test/java/org/openmrs/analytics/JdbcFetchHapiTest.java
+++ b/pipelines/batch/src/test/java/org/openmrs/analytics/JdbcFetchHapiTest.java
@@ -111,8 +111,8 @@ public class JdbcFetchHapiTest extends TestCase {
     Mockito.when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
     Mockito.when(
             mockedConnection.prepareStatement(
-                "SELECT count(*) as count FROM hfj_resource res where res.res_type = ? AND res.res_updated >"
-                    + " '"
+                "SELECT count(*) as count FROM hfj_resource res where res.res_type = ? AND"
+                    + " res.res_updated > '"
                     + since
                     + "'"))
         .thenReturn(mockedPreparedStatement);


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This fixes some of the issues mentioned in #757. It also adds a path example where the recursion depth limit is disabled. The example is commented out until we decide we really want to support this pattern. If we do, then those exceptional paths should be exposed as configuration parameters.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the pipeline with a sample QuestionnaireResponse that had deep `item.item.item...` recursions and confirmed that all of the `answer` fields are transformed into the Parquet file without increasing the general recursion max-depth, if that path is provided as an exception.

Also tested the same scenario by increasing max-depth and no exceptional paths; at levels 1, 2, 3, etc. the expected fields were present.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
