### PR TITLE
Add user name and password to controller config

### DIFF
--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -91,6 +91,10 @@ public class DataProperties {
 
   private boolean createHiveResourceTables;
 
+  private String fhirServerPassword;
+
+  private String fhirServerUserName;
+
   @PostConstruct
   void validateProperties() throws ClassNotFoundException {
     CronExpression.parse(incrementalSchedule);
@@ -131,6 +135,8 @@ public class DataProperties {
       options.setFhirDatabaseConfigPath(dbConfig);
     } else {
       options.setFhirServerUrl(fhirServerUrl);
+      options.setFhirServerPassword(fhirServerPassword);
+      options.setFhirServerUserName(fhirServerUserName);
     }
     options.setResourceList(resourceList);
 

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/DataPropertiesTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/DataPropertiesTest.java
@@ -67,6 +67,13 @@ public class DataPropertiesTest {
     Assert.assertTrue(pipelineConfig.getThriftServerParquetPath().contains(timestampSuffix));
   }
 
+  @Test
+  void fhirCredentials_are_set() {
+    PipelineConfig pipelineConfig = dataProperties.createBatchOptions();
+    Assert.assertEquals(pipelineConfig.getFhirEtlOptions().getFhirServerPassword(), "Admin123");
+    Assert.assertEquals(pipelineConfig.getFhirEtlOptions().getFhirServerUserName(), "Admin");
+  }
+
   @AfterAll
   public static void tearDown() throws IOException {
     mockFhirServer.shutdown();

--- a/pipelines/controller/src/test/resources/application-test.properties
+++ b/pipelines/controller/src/test/resources/application-test.properties
@@ -20,3 +20,5 @@ fhirdata.resourceList=Patient,Encounter,Observation
 fhirdata.dwhRootPrefix=config/controller_DWH
 fhirdata.purgeSchedule=0 30 * * * *
 fhirdata.numOfDwhSnapshotsToRetain=3
+fhirdata.fhirServerPassword=Admin123
+fhirdata.fhirServerUserName=Admin


### PR DESCRIPTION
## Description of what I changed

Added user name and password to the controller configuration for better FHIR search support. Fixes #677.
## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Added the `fhirServerPassword` and `fhirServerUserName` properties to the controller `application.yaml` and ensured the properties were set and fetching to a FHIR server worked.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [X] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [X] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [X] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [X] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [X] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [X] All new and existing **tests passed**.
- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
