### PR TITLE
Refactored common parts of R4 and STU3 StructureDefinitions

### DIFF
--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
@@ -11,6 +11,7 @@ import java.util.StringJoiner;
 import org.junit.Assert;
 import org.junit.Test;
 
+// TODO duplicate these tests for R4 as well.
 public class GenerateSchemasTest {
 
   private static final String BASE_TEST_URL = "http://test.org/test_resource";

--- a/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
+++ b/bunsen/bunsen-core-r4/src/main/java/com/cerner/bunsen/definitions/r4/R4StructureDefinitions.java
@@ -1,28 +1,15 @@
 package com.cerner.bunsen.definitions.r4;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.support.IValidationSupport;
-import com.cerner.bunsen.definitions.DefinitionVisitor;
-import com.cerner.bunsen.definitions.DefinitionVisitorsUtil;
 import com.cerner.bunsen.definitions.FhirConversionSupport;
-import com.cerner.bunsen.definitions.QualifiedPath;
+import com.cerner.bunsen.definitions.IElementDefinition;
+import com.cerner.bunsen.definitions.IStructureDefinition;
 import com.cerner.bunsen.definitions.StructureDefinitions;
-import com.cerner.bunsen.definitions.StructureField;
-import com.google.common.base.Verify;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.ElementDefinition;
-import org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,448 +32,6 @@ public class R4StructureDefinitions extends StructureDefinitions {
     super(context);
   }
 
-  private List<ElementDefinition> getChildren(ElementDefinition parent,
-      List<ElementDefinition> definitions) {
-
-    if (parent.getContentReference() != null) {
-
-      if (!parent.getContentReference().startsWith("#")) {
-
-        throw new IllegalStateException("Non-local references are not yet supported");
-      }
-
-      // Remove the leading hash (#) to get the referenced type.
-      String referencedType = parent.getContentReference().substring(1);
-
-      // Find the actual type to use.
-      parent = definitions.stream()
-          .filter(definition -> definition.getPath().equals(referencedType))
-          .findFirst()
-          .orElseThrow(() -> new IllegalArgumentException("Expected a reference type"));
-    }
-
-    String startsWith = parent.getId() + ".";
-
-    return definitions.stream()
-        .filter(definition -> definition.getId().startsWith(startsWith)
-            && definition.getId().indexOf('.', startsWith.length()) < 0)
-        .collect(Collectors.toList());
-  }
-
-  private StructureDefinition getDefinition(ElementDefinition element) {
-
-    return element.getTypeFirstRep() == null
-        || element.getTypeFirstRep().getCode() == null
-        || element.getTypeFirstRep().getCode().equals("BackboneElement")
-        || element.getTypeFirstRep().getCode().equals("Element")
-        ? null
-        : (StructureDefinition) validationSupport.fetchStructureDefinition(
-            element.getTypeFirstRep().getCode());
-  }
-
-  private <T> List<StructureField<T>> singleField(String elementName, T result) {
-    if (result == null) {
-      return Collections.emptyList();
-    }
-    return Collections.singletonList(StructureField.property(elementName, result));
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      QualifiedPath newPath,
-      Deque<QualifiedPath> stack) {
-
-    // TODO we should add configuration parameters for exceptional paths
-    //  that require deeper recursion; this is where to apply that logic:
-    // String elementPath = DefinitionVisitorsUtil.pathFromStack(
-    //    DefinitionVisitorsUtil.elementName(newPath.getElementPath()), stack);
-    // if ("QuestionnaireResponse.item.item.item.item.item.item".startsWith(elementPath)) {
-    //   return false;
-    // }
-
-    int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
-
-    return stack.stream().filter(path -> path.equals(newPath)).count() > maxDepth;
-  }
-
-  /**
-   * This is a helper to address differences of `ElementDefinition.TypeRefComponent.getProfile()` in
-   * R4 vs. STU3 versions which returns a {@code List<CanonicalType>} in the former but a String
-   * in the latter. This is due to the difference between how `Reference` types are represented
-   * in R4 vs STU3; in R4 all "target profiles" (i.e., reference's target type) are under the same
-   * `type` while in STU3 we have multiple `type` each with a single target-profile.
-   *
-   * @return
-   */
-  private String getFirstTypeProfile(ElementDefinition element) {
-    List<CanonicalType> profiles = element.getTypeFirstRep().getProfile();
-    if (profiles == null || profiles.isEmpty()) {
-      return  null;
-    }
-    return profiles.get(0).getValue();
-  }
-
-  private <T> List<StructureField<T>> extensionElementToFields(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition element,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack) {
-
-    // FIXME: extension is a type rather than an external structure....
-    StructureDefinition definition = null;
-    String profileUrl = getFirstTypeProfile(element);
-    if (profileUrl != null) {
-      definition = (StructureDefinition) validationSupport.fetchStructureDefinition(profileUrl);
-    }
-
-    List<StructureField<T>> extensions;
-
-    if (definition != null) {
-
-      List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
-
-      ElementDefinition extensionRoot = extensionDefinitions.get(0);
-
-      extensions = visitExtensionDefinition(visitor,
-          rootDefinition,
-          element.getSliceName(),
-          stack,
-          definition.getUrl(),
-          extensionDefinitions,
-          extensionRoot);
-
-    } else {
-
-      if (element.getSliceName() == null) {
-        return Collections.emptyList();
-      }
-
-      extensions = visitExtensionDefinition(visitor,
-          rootDefinition,
-          element.getSliceName(),
-          stack,
-          getFirstTypeProfile(element),
-          definitions,
-          element);
-    }
-
-    if (!element.getMax().equals("1") && extensions.size() > 0) {
-      // the nested extension element has max: *
-      return Collections.singletonList(StructureField.extension(
-          extensions.get(0).fieldName(),
-          extensions.get(0).extensionUrl(),
-          extensions.get(0).isModifier(),
-          visitor.visitMultiValued(extensions.get(0).fieldName(), extensions.get(0).result())));
-
-    } else {
-
-      return extensions;
-    }
-  }
-
-  private <T> List<StructureField<T>> visitExtensionDefinition(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      String sliceName,
-      Deque<QualifiedPath> stack,
-      String url,
-      List<ElementDefinition> extensionDefinitions,
-      ElementDefinition extensionRoot) {
-
-    // For extensions, we need to process slices to separate them into individual fields.
-    List<ElementDefinition> children = getChildren(extensionRoot, extensionDefinitions);
-
-    // Extensions may contain either additional extensions or a value field, but not both.
-    // So if it has a child element with a slice name, it has additional extensions.
-    List<ElementDefinition> childExtensions = children.stream()
-        .filter(element -> element.getSliceName() != null)
-        .collect(Collectors.toList());
-
-    if (!childExtensions.isEmpty()) {
-
-      List<StructureField<T>> childFields = new ArrayList<>();
-
-      for (ElementDefinition childExtension: childExtensions) {
-
-        List<StructureField<T>> childField = extensionElementToFields(visitor,
-            rootDefinition, childExtension, extensionDefinitions, stack);
-
-        childFields.addAll(childField);
-      }
-
-      T result = visitor.visitParentExtension(sliceName,
-          url,
-          childFields);
-
-      if (result == null) {
-        return Collections.emptyList();
-      } else {
-        return Collections.singletonList(
-            StructureField.extension(sliceName,
-                url,
-                extensionRoot.getIsModifier(),
-                result));
-      }
-
-    } else {
-
-      // The extension has no children, so produce its value.
-
-      Optional<ElementDefinition> valueElement = children.stream()
-          .filter(e -> e.getPath().contains("value"))
-          .findFirst();
-
-      // FIXME: get the extension URL.
-      Optional<ElementDefinition> urlElement = children.stream()
-          .filter(e -> e.getPath().endsWith("url"))
-          .findFirst();
-
-      String extensionUrl = urlElement.get().getFixed().primitiveValue();
-
-      List<StructureField<T>> childField = elementToFields(visitor, rootDefinition,
-          valueElement.get(), extensionDefinitions, stack);
-
-      T result = visitor.visitLeafExtension(sliceName,
-          extensionUrl,
-          childField.iterator().next().result());
-
-      return Collections.singletonList(
-          StructureField.extension(sliceName,
-              extensionUrl,
-              extensionRoot.getIsModifier(),
-              result));
-
-    }
-  }
-
-  /**
-   * Returns the fields for the given element. The returned stream can be empty
-   * (e.g., for elements with max of zero), or have multiple values (for elements
-   * that generate fields with additional data in siblings.)
-   */
-  private <T> List<StructureField<T>> elementToFields(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition element,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack) {
-
-    String elementName = DefinitionVisitorsUtil.elementName(element.getPath());
-
-    if (element.getMax().equals("0")) {
-
-      // Fields with max of zero are omitted.
-      return Collections.emptyList();
-
-    } else if ("Extension".equals(element.getTypeFirstRep().getCode())) {
-
-      return extensionElementToFields(visitor, rootDefinition, element, definitions, stack);
-
-    } else if (element.getSliceName() != null) {
-
-      // Drop slices for non-extension fields; otherwise we will end up with duplicated fields.
-      return Collections.emptyList();
-
-    } else if (element.getType().size() == 1
-        && PRIMITIVE_TYPES.contains(element.getTypeFirstRep().getCode())) {
-
-      T primitiveConverter = visitor
-          .visitPrimitive(elementName, element.getTypeFirstRep().getCode());
-
-      if (!element.getMax().equals("1")) {
-
-        return singleField(elementName, visitor.visitMultiValued(elementName, primitiveConverter));
-      } else {
-
-        return singleField(elementName, primitiveConverter);
-      }
-
-    } else if (element.getPath().endsWith("[x]") && !element.getPath().startsWith("Extension")) {
-      // TODO fix for "Extension": https://github.com/google/fhir-data-pipes/issues/559
-
-      // Use a linked hash map to preserve the order of the fields
-      // for iteration.
-      Map<String, T> choiceTypes = new LinkedHashMap<>();
-
-      for (TypeRefComponent typeRef: element.getType()) {
-
-        if (PRIMITIVE_TYPES.contains(typeRef.getCode())) {
-
-          T child = visitor.visitPrimitive(elementName, typeRef.getCode());
-          choiceTypes.put(typeRef.getCode(), child);
-
-        } else {
-
-          StructureDefinition structureDefinition =
-              (StructureDefinition) validationSupport
-                  .fetchStructureDefinition(typeRef.getCode());
-
-          // TODO document why we are resetting the stack here; it is not clear
-          //  why this cannot lead to infinite recursion for choice types. If
-          //  we don't reset the stack, then we should handle null returns.
-          T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
-          Verify.verify(child != null,
-              "Unexpected null choice type {} for element {}", typeRef, element);
-          choiceTypes.put(typeRef.getCode(), child);
-        }
-      }
-
-      StructureField<T> field = new StructureField<>(elementName,
-          elementName,
-          null,
-          false,
-          true,
-          visitor.visitChoice(elementName, choiceTypes));
-
-      return Collections.singletonList(field);
-
-    } else if (!element.getMax().equals("1")) {
-
-      if (getDefinition(element) != null) {
-
-        // Handle defined data types.
-        StructureDefinition definition = getDefinition(element);
-
-        T type = transform(visitor, element, definition, stack);
-
-        return singleField(elementName,
-            visitor.visitMultiValued(elementName, type));
-
-      } else {
-
-        List<StructureField<T>> childElements = transformChildren(visitor,
-            rootDefinition, definitions, stack, element);
-        if (childElements.isEmpty()) {
-          // All children were dropped because of recursion depth limit.
-          return  Collections.emptyList();
-        }
-
-        T result = visitor.visitComposite(elementName,
-            DefinitionVisitorsUtil.pathFromStack(elementName, stack),
-            elementName,
-            rootDefinition.getUrl(),
-            childElements);
-
-        List<StructureField<T>> composite = singleField(elementName, result);
-
-        // Array types should produce only a single element.
-        if (composite.size() != 1) {
-          throw new IllegalStateException("Array type in "
-              + element.getPath()
-              + " must map to a single structure.");
-        }
-
-        // Wrap the item in the corresponding multi-valued type.
-        return singleField(elementName,
-            visitor.visitMultiValued(elementName, composite.get(0).result()));
-      }
-
-    } else if (getDefinition(element) != null) {
-
-      // TODO refactor this and the similar block above for handling defined data types.
-      // Handle defined data types.
-      StructureDefinition definition = getDefinition(element);
-
-      T type = transform(visitor, element, definition, stack);
-
-      return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
-
-    } else {
-
-      // Handle composite type
-      List<StructureField<T>> childElements = transformChildren(visitor, rootDefinition,
-          definitions, stack, element);
-      if (childElements.isEmpty()) {
-        // All children were dropped because of recursion depth limit.
-        return  Collections.emptyList();
-      }
-
-      T result = visitor.visitComposite(elementName,
-          DefinitionVisitorsUtil.pathFromStack(elementName, stack),
-          elementName,
-          rootDefinition.getUrl(),
-          childElements);
-
-      return singleField(elementName, result);
-    }
-  }
-
-  /**
-   * Goes through the list of children of the given `element` and convert each
-   * of those `ElementDefinision`s to `StructureField`s.
-   * NOTE: This is the only place where the traversal stack can grow. It is also
-   * best if this is the only place where `shouldTerminateRecursive` is called.
-   */
-  private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack,
-      ElementDefinition element) {
-
-    QualifiedPath qualifiedPath = new QualifiedPath(rootDefinition.getUrl(),  element.getPath());
-
-    if (shouldTerminateRecursive(visitor, qualifiedPath, stack)) {
-
-      return Collections.emptyList();
-
-    } else {
-      stack.push(qualifiedPath);
-
-      // Handle composite type
-      List<StructureField<T>> childElements = new ArrayList<>();
-
-      for (ElementDefinition child: getChildren(element, definitions)) {
-
-        List<StructureField<T>> childFields = elementToFields(visitor, rootDefinition,
-            child, definitions, stack);
-
-        childElements.addAll(childFields);
-      }
-
-      stack.pop();
-
-      return childElements;
-    }
-  }
-
-  private <T> StructureField<T> transformContained(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      List<StructureDefinition> containedDefinitions,
-      Deque<QualifiedPath> stack,
-      ElementDefinition element) {
-
-    Map<String, StructureField<T>> containedElements = new LinkedHashMap<>();
-
-    for (StructureDefinition containedDefinition: containedDefinitions) {
-
-      ElementDefinition containedRootElement = containedDefinition.getSnapshot()
-          .getElementFirstRep();
-
-      List<ElementDefinition> childDefinitions = containedDefinition.getSnapshot().getElement();
-
-      List<StructureField<T>> childElements = transformChildren(visitor,
-          containedDefinition,
-          childDefinitions,
-          stack,
-          containedRootElement);
-      // At this level no child should be dropped because of recursion limit.
-      Verify.verify(!childElements.isEmpty());
-
-      String rootName = DefinitionVisitorsUtil.elementName(containedRootElement.getPath());
-
-      T result = visitor.visitComposite(rootName,
-          containedRootElement.getPath(),
-          rootName,
-          containedDefinition.getUrl(),
-          childElements);
-
-      containedElements.put(rootName, StructureField.property(rootName, result));
-    }
-
-    T result = visitor.visitContained(element.getPath() + ".contained",
-        rootDefinition.getUrl(),
-        containedElements);
-
-    return StructureField.property("contained", result);
-  }
-
   @Override
   public FhirConversionSupport conversionSupport() {
 
@@ -494,73 +39,106 @@ public class R4StructureDefinitions extends StructureDefinitions {
   }
 
   @Override
-  public <T> T transform(DefinitionVisitor<T> visitor, String resourceTypeUrl) {
-    return transform(visitor, resourceTypeUrl, Collections.emptyList());
+  protected IStructureDefinition getStructureDefinition(String resourceUrl) {
+    return new StructureDefinitionWrapper(
+        (StructureDefinition) context.getValidationSupport().fetchStructureDefinition(resourceUrl));
   }
 
-  @Override
-  public <T> T transform(DefinitionVisitor<T> visitor,
-      String resourceTypeUrl,
-      List<String> containedResourceTypeUrls) {
+  // FHIR version specific interface implementations
 
-    StructureDefinition definition = (StructureDefinition) context.getValidationSupport()
-        .fetchStructureDefinition(resourceTypeUrl);
+  private static class StructureDefinitionWrapper implements IStructureDefinition {
+    private final StructureDefinition structureDefinition;
 
-    if (definition == null) {
-
-      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
+    StructureDefinitionWrapper(StructureDefinition structureDefinition) {
+      this.structureDefinition = structureDefinition;
     }
 
-    List<StructureDefinition> containedDefinitions = containedResourceTypeUrls.stream()
-        .map(containedResourceTypeUrl -> {
-          StructureDefinition containedDefinition = (StructureDefinition) context
-              .getValidationSupport()
-              .fetchStructureDefinition(containedResourceTypeUrl);
+    @Override
+    public String getUrl() {
+      return structureDefinition.getUrl();
+    }
 
-          if (containedDefinition == null) {
+    @Override
+    public String getType() {
+      return structureDefinition.getType();
+    }
 
-            throw new IllegalArgumentException("Unable to find definition for "
-                + containedResourceTypeUrl);
-          }
+    @Override
+    public IElementDefinition getRootDefinition() {
+      return new ElementDefinitionWrapper(structureDefinition.getSnapshot().getElementFirstRep());
+    }
 
-          return containedDefinition;
-        })
-        .collect(Collectors.toList());
-
-    return transformRoot(visitor, definition, containedDefinitions);
+    @Override
+    public List<IElementDefinition> getSnapshotDefinitions() {
+      return structureDefinition.getSnapshot().getElement().stream().map(
+          d -> new ElementDefinitionWrapper(d)).collect(Collectors.toList());
+    }
   }
 
-  // TODO make the separation between this and `elementToFields` more clear.
-  /**
-   * Transforms the given FHIR structure definition.
-   *
-   * @param visitor the visitor performing the transformation
-   * @param parentElement the element containing this definition for additional type information,
-   *     or null if it is not contained in a parent element.
-   * @param definition the FHIR structure definition to be converted
-   * @param stack a stack of FHIR type URLs to detect recursive definitions.
-   *
-   * @return the transformed structure, or null if it should not be included in the parent.
-   */
-  @Nullable
-  private <T> T transform(DefinitionVisitor<T> visitor,
-      ElementDefinition parentElement,
-      StructureDefinition definition,
-      Deque<QualifiedPath> stack) {
+  private static class ElementDefinitionWrapper implements IElementDefinition {
+    private final ElementDefinition elementDefinition;
 
-    List<ElementDefinition> definitions = definition.getSnapshot().getElement();
+    ElementDefinitionWrapper(ElementDefinition elementDefinition) {
+      this.elementDefinition = elementDefinition;
+    }
 
-    ElementDefinition root = definitions.get(0);
+    @Override
+    public String getId() {
+      return elementDefinition.getId();
+    }
 
-    List<StructureField<T>> childElements = transformChildren(visitor, definition,
-        definitions, stack, root);
+    @Override
+    public String getPath() {
+      return elementDefinition.getPath();
+    }
 
-    if ("Reference".equals(definition.getType())) {
+    @Override
+    public String getContentReference() {
+      return elementDefinition.getContentReference();
+    }
 
-      // TODO: if this is in an option there may be other non-reference types here?
-      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+    @Override
+    public String getMax() {
+      return elementDefinition.getMax();
+    }
 
-      List<String> referenceTypes = parentElement.getType()
+    @Override
+    public String getFirstTypeCode() {
+      return elementDefinition.getTypeFirstRep().getCode();
+    }
+
+    @Override
+    public boolean hasSingleType() {
+      return (elementDefinition.getType().size() == 1);
+    }
+
+    @Override
+    public List<String> getAllTypeCodes() {
+      return elementDefinition.getType().stream().map(
+          t -> t.getCode()).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getSliceName() {
+      return elementDefinition.getSliceName();
+    }
+
+    @Override
+    public boolean getIsModifier() {
+      return elementDefinition.getIsModifier();
+    }
+
+    @Override
+    public String getFixedPrimitiveValue() {
+      if (elementDefinition.getFixed() == null) {
+        return null;
+      }
+      return elementDefinition.getFixed().primitiveValue();
+    }
+
+    @Override
+    public List<String> getReferenceTargetProfiles() {
+      return elementDefinition.getType()
           .stream()
           .filter(type -> "Reference".equals(type.getCode()))
           .filter(type -> type.getTargetProfile() != null)
@@ -569,79 +147,24 @@ public class R4StructureDefinitions extends StructureDefinitions {
           // in R4 all "target profiles" (i.e., reference's target type) are under the same `type`
           // while in STU3 we have multiple `type` each with a single target-profile.
           .flatMap(Collection::stream)
-          .map(profile -> {
-
-            IValidationSupport validation = context.getValidationSupport();
-
-            StructureDefinition targetDefinition = (StructureDefinition)
-                validation.fetchStructureDefinition(profile.getValue());
-
-            return targetDefinition.getType();
-          })
-          .sorted()
+          .map(profile -> profile.getValue())
           .collect(Collectors.toList());
+    }
 
-      return visitor.visitReference(parentElement.toString(), referenceTypes, childElements);
-
-    } else {
-
-      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
-
-      // We don't want 'id' to be present in nested fields to make it consistent with SQL-on-FHIR.
-      // https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#id-fields-omitted
-      childElements.removeIf(field -> field.fieldName().equals("id"));
-
-      if (childElements.isEmpty()) {
-        // All children were dropped because of recursion depth limit.
-        return null;
+    @Override
+    public String getFirstTypeProfile() {
+      List<CanonicalType> profiles = elementDefinition.getTypeFirstRep().getProfile();
+      if (profiles == null || profiles.isEmpty()) {
+        return  null;
       }
-      return visitor.visitComposite(rootName,
-          DefinitionVisitorsUtil.pathFromStack(root.getPath(), stack),
-          rootName,
-          definition.getUrl(),
-          childElements);
-    }
-  }
-
-  private <T> T transformRoot(DefinitionVisitor<T> visitor,
-      StructureDefinition definition,
-      List<StructureDefinition> containedDefinitions) {
-
-    ElementDefinition definitionRootElement = definition.getSnapshot().getElementFirstRep();
-
-    List<ElementDefinition> definitions = definition.getSnapshot().getElement();
-
-    Deque<QualifiedPath> stack = new ArrayDeque<>();
-
-    List<StructureField<T>> childElements = transformChildren(visitor,
-        definition,
-        definitions,
-        stack,
-        definitionRootElement);
-    // At this level no child should be dropped because of recursion limit.
-    Verify.verify(!childElements.isEmpty());
-    Verify.verify(stack.isEmpty());
-
-    // If there are contained definitions, create a Resource Container StructureField
-    if (containedDefinitions.size() > 0) {
-
-      StructureField<T> containedElement = transformContained(visitor,
-          definition,
-          containedDefinitions,
-          stack,
-          definitionRootElement);
-
-      // Replace default StructureField with constructed Resource Container StructureField
-      // TODO make this future proof instead of using a hard-coded index for `contained`.
-      childElements.set(5, containedElement);
+      return profiles.get(0).getValue();
     }
 
-    String rootName = DefinitionVisitorsUtil.elementName(definitionRootElement.getPath());
+    @Override
+    public String toString() {
+      return elementDefinition.toString();
+    }
 
-    return visitor.visitComposite(rootName,
-        rootName,
-        rootName,
-        definition.getUrl(),
-        childElements);
   }
+
 }

--- a/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -1,26 +1,14 @@
 package com.cerner.bunsen.definitions.stu3;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.support.IValidationSupport;
-import com.cerner.bunsen.definitions.DefinitionVisitor;
-import com.cerner.bunsen.definitions.DefinitionVisitorsUtil;
 import com.cerner.bunsen.definitions.FhirConversionSupport;
-import com.cerner.bunsen.definitions.QualifiedPath;
+import com.cerner.bunsen.definitions.IElementDefinition;
+import com.cerner.bunsen.definitions.IStructureDefinition;
 import com.cerner.bunsen.definitions.StructureDefinitions;
-import com.cerner.bunsen.definitions.StructureField;
-import com.google.common.base.Verify;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.LinkedHashMap;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.hl7.fhir.dstu3.model.ElementDefinition;
-import org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,415 +27,6 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
     super(context);
   }
 
-  private List<ElementDefinition> getChildren(ElementDefinition parent,
-      List<ElementDefinition> definitions) {
-
-    if (parent.getContentReference() != null) {
-
-      if (!parent.getContentReference().startsWith("#")) {
-
-        throw new IllegalStateException("Non-local references are not yet supported");
-      }
-
-      // Remove the leading hash (#) to get the referenced type.
-      String referencedType = parent.getContentReference().substring(1);
-
-      // Find the actual type to use.
-      parent = definitions.stream()
-          .filter(definition -> definition.getPath().equals(referencedType))
-          .findFirst()
-          .orElseThrow(() -> new IllegalArgumentException("Expected a reference type"));
-    }
-
-    String startsWith = parent.getId() + ".";
-
-    return definitions.stream()
-        .filter(definition -> definition.getId().startsWith(startsWith)
-            && definition.getId().indexOf('.', startsWith.length()) < 0)
-        .collect(Collectors.toList());
-  }
-
-  private StructureDefinition getDefinition(ElementDefinition element) {
-
-    return element.getTypeFirstRep() == null
-        || element.getTypeFirstRep().getCode() == null
-        || element.getTypeFirstRep().getCode().equals("BackboneElement")
-        || element.getTypeFirstRep().getCode().equals("Element")
-        ? null
-        : (StructureDefinition) validationSupport.fetchStructureDefinition(
-            element.getTypeFirstRep().getCode());
-  }
-
-  private <T> List<StructureField<T>> singleField(String elementName, T result) {
-    if (result == null) {
-      return Collections.emptyList();
-    }
-    return Collections.singletonList(StructureField.property(elementName, result));
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      QualifiedPath newPath,
-      Deque<QualifiedPath> stack) {
-
-    int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
-
-    return stack.stream().filter(path -> path.equals(newPath)).count() > maxDepth;
-  }
-
-  private <T> List<StructureField<T>> extensionElementToFields(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition element,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack) {
-
-    // FIXME: extension is a type rather than an external structure....
-    StructureDefinition definition = element.getTypeFirstRep().getProfile() != null
-        ? (StructureDefinition) validationSupport
-        .fetchStructureDefinition(element.getTypeFirstRep().getProfile())
-        : null;
-
-    List<StructureField<T>> extensions;
-
-    if (definition != null) {
-
-      List<ElementDefinition> extensionDefinitions = definition.getSnapshot().getElement();
-
-      ElementDefinition extensionRoot = extensionDefinitions.get(0);
-
-      extensions = visitExtensionDefinition(visitor,
-          rootDefinition,
-          element.getSliceName(),
-          stack,
-          definition.getUrl(),
-          extensionDefinitions,
-          extensionRoot);
-
-    } else {
-
-      if (element.getSliceName() == null) {
-        return Collections.emptyList();
-      }
-
-      extensions = visitExtensionDefinition(visitor,
-          rootDefinition,
-          element.getSliceName(),
-          stack,
-          element.getTypeFirstRep().getProfile(),
-          definitions,
-          element);
-    }
-
-    if (!element.getMax().equals("1") && extensions.size() > 0) {
-      // the nested extension element has max: *
-      return Collections.singletonList(StructureField.extension(
-          extensions.get(0).fieldName(),
-          extensions.get(0).extensionUrl(),
-          extensions.get(0).isModifier(),
-          visitor.visitMultiValued(extensions.get(0).fieldName(), extensions.get(0).result())));
-
-    } else {
-
-      return extensions;
-    }
-  }
-
-  private <T> List<StructureField<T>> visitExtensionDefinition(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      String sliceName,
-      Deque<QualifiedPath> stack,
-      String url,
-      List<ElementDefinition> extensionDefinitions,
-      ElementDefinition extensionRoot) {
-
-    List<ElementDefinition> children = getChildren(extensionRoot, extensionDefinitions);
-
-    // Extensions may contain either additional extensions or a value field, but not both.
-
-    List<ElementDefinition> childExtensions = children.stream()
-        .filter(element -> element.getSliceName() != null)
-        .collect(Collectors.toList());
-
-    if (!childExtensions.isEmpty()) {
-
-      List<StructureField<T>> childFields = new ArrayList<>();
-
-      for (ElementDefinition childExtension: childExtensions) {
-
-        List<StructureField<T>> childField = extensionElementToFields(visitor,
-            rootDefinition, childExtension, extensionDefinitions, stack);
-
-        childFields.addAll(childField);
-      }
-
-      T result = visitor.visitParentExtension(sliceName,
-          url,
-          childFields);
-
-      if (result == null) {
-        return Collections.emptyList();
-      } else {
-        return Collections.singletonList(
-            StructureField.extension(sliceName,
-                url,
-                extensionRoot.getIsModifier(),
-                result));
-      }
-
-    } else {
-
-      // The extension has no children, so produce its value.
-
-      Optional<ElementDefinition> valueElement = children.stream()
-          .filter(e -> e.getPath().contains("value"))
-          .findFirst();
-
-      // FIXME: get the extension URL.
-      Optional<ElementDefinition> urlElement = children.stream()
-          .filter(e -> e.getPath().endsWith("url"))
-          .findFirst();
-
-      String extensionUrl = urlElement.get().getFixed().primitiveValue();
-
-      List<StructureField<T>> childField = elementToFields(visitor, rootDefinition,
-          valueElement.get(), extensionDefinitions, stack);
-
-      T result = visitor.visitLeafExtension(sliceName,
-          extensionUrl,
-          childField.iterator().next().result());
-
-      return Collections.singletonList(
-          StructureField.extension(sliceName,
-              extensionUrl,
-              extensionRoot.getIsModifier(),
-              result));
-
-    }
-  }
-
-  /**
-   * Returns the fields for the given element. The returned stream can be empty
-   * (e.g., for elements with max of zero), or have multiple values (for elements
-   * that generate fields with additional data in siblings.)
-   */
-  private <T> List<StructureField<T>> elementToFields(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      ElementDefinition element,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack) {
-
-    String elementName = DefinitionVisitorsUtil.elementName(element.getPath());
-
-    if (element.getMax().equals("0")) {
-
-      // Fields with max of zero are omitted.
-      return Collections.emptyList();
-
-    } else if ("Extension".equals(element.getTypeFirstRep().getCode())) {
-
-      return extensionElementToFields(visitor, rootDefinition, element, definitions, stack);
-
-    } else if (element.getType().size() == 1
-        && PRIMITIVE_TYPES.contains(element.getTypeFirstRep().getCode())) {
-
-      T primitiveConverter = visitor
-          .visitPrimitive(elementName, element.getTypeFirstRep().getCode());
-
-      if (!element.getMax().equals("1")) {
-
-        return singleField(elementName, visitor.visitMultiValued(elementName, primitiveConverter));
-      } else {
-
-        return singleField(elementName, primitiveConverter);
-      }
-
-    } else if (element.getPath().endsWith("[x]")) {
-
-      // Use a linked hash map to preserve the order of the fields
-      // for iteration.
-      Map<String, T> choiceTypes = new LinkedHashMap<>();
-
-      for (TypeRefComponent typeRef: element.getType()) {
-
-        if (PRIMITIVE_TYPES.contains(typeRef.getCode())) {
-
-          T child = visitor.visitPrimitive(elementName, typeRef.getCode());
-          choiceTypes.put(typeRef.getCode(), child);
-
-        } else {
-
-          StructureDefinition structureDefinition =
-              (StructureDefinition) validationSupport
-                  .fetchStructureDefinition(typeRef.getCode());
-
-          // TODO document why we are resetting the stack here; it is not clear
-          //  why this cannot lead to infinite recursion for choice types. If
-          //  we don't reset the stack, then we should handle null returns.
-          T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
-          Verify.verify(child != null,
-              "Unexpected null choice type {} for element {}", typeRef, element);
-          choiceTypes.put(typeRef.getCode(), child);
-        }
-      }
-
-      StructureField<T> field = new StructureField<>(elementName,
-          elementName,
-          null,
-          false,
-          true,
-          visitor.visitChoice(elementName, choiceTypes));
-
-      return Collections.singletonList(field);
-
-    } else if (!element.getMax().equals("1")) {
-
-      if (getDefinition(element) != null) {
-
-        // Handle defined data types.
-        StructureDefinition definition = getDefinition(element);
-
-        T type = transform(visitor, element, definition, stack);
-
-        return singleField(elementName,
-            visitor.visitMultiValued(elementName, type));
-
-      } else {
-
-        List<StructureField<T>> childElements = transformChildren(visitor,
-            rootDefinition, definitions, stack, element);
-        if (childElements.isEmpty()) {
-          // All children were dropped because of recursion depth limit.
-          return  Collections.emptyList();
-        }
-
-        T result = visitor.visitComposite(elementName,
-            DefinitionVisitorsUtil.pathFromStack(elementName, stack),
-            elementName,
-            rootDefinition.getUrl(),
-            childElements);
-
-        List<StructureField<T>> composite = singleField(elementName, result);
-
-        // Array types should produce only a single element.
-        if (composite.size() != 1) {
-          throw new IllegalStateException("Array type in "
-              + element.getPath()
-              + " must map to a single structure.");
-        }
-
-        // Wrap the item in the corresponding multi-valued type.
-        return singleField(elementName,
-            visitor.visitMultiValued(elementName, composite.get(0).result()));
-      }
-
-    } else if (getDefinition(element) != null) {
-
-      // TODO refactor this and the similar block above for handling defined data types.
-      // Handle defined data types.
-      StructureDefinition definition = getDefinition(element);
-
-      T type = transform(visitor, element, definition, stack);
-
-      return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
-
-    } else {
-
-      // Handle composite type
-      List<StructureField<T>> childElements = transformChildren(visitor, rootDefinition,
-          definitions, stack, element);
-      if (childElements.isEmpty()) {
-        // All children were dropped because of recursion depth limit.
-        return  Collections.emptyList();
-      }
-
-      T result = visitor.visitComposite(elementName,
-          DefinitionVisitorsUtil.pathFromStack(elementName, stack),
-          elementName,
-          rootDefinition.getUrl(),
-          childElements);
-
-      return singleField(elementName, result);
-    }
-  }
-
-  /**
-   * Goes through the list of children of the given `element` and convert each
-   * of those `ElementDefinision`s to `StructureField`s.
-   * NOTE: This is the only place where the traversal stack can grow. It is also
-   * best if this is the only place where `shouldTerminateRecursive` is called.
-   */
-  private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      List<ElementDefinition> definitions,
-      Deque<QualifiedPath> stack,
-      ElementDefinition element) {
-
-    QualifiedPath qualifiedPath = new QualifiedPath(rootDefinition.getUrl(),  element.getPath());
-
-    if (shouldTerminateRecursive(visitor, qualifiedPath, stack)) {
-
-      return Collections.emptyList();
-
-    } else {
-      stack.push(qualifiedPath);
-
-      // Handle composite type
-      List<StructureField<T>> childElements = new ArrayList<>();
-
-      for (ElementDefinition child: getChildren(element, definitions)) {
-
-        List<StructureField<T>> childFields = elementToFields(visitor, rootDefinition,
-            child, definitions, stack);
-
-        childElements.addAll(childFields);
-      }
-
-      stack.pop();
-
-      return childElements;
-    }
-  }
-
-  private <T> StructureField<T> transformContained(DefinitionVisitor<T> visitor,
-      StructureDefinition rootDefinition,
-      List<StructureDefinition> containedDefinitions,
-      Deque<QualifiedPath> stack,
-      ElementDefinition element) {
-
-    Map<String, StructureField<T>> containedElements = new LinkedHashMap<>();
-
-    for (StructureDefinition containedDefinition: containedDefinitions) {
-
-      ElementDefinition containedRootElement = containedDefinition.getSnapshot()
-          .getElementFirstRep();
-
-      List<ElementDefinition> childDefinitions = containedDefinition.getSnapshot().getElement();
-
-      List<StructureField<T>> childElements = transformChildren(visitor,
-          containedDefinition,
-          childDefinitions,
-          stack,
-          containedRootElement);
-      // At this level no child should be dropped because of recursion limit.
-      Verify.verify(!childElements.isEmpty());
-
-      String rootName = DefinitionVisitorsUtil.elementName(containedRootElement.getPath());
-
-      T result = visitor.visitComposite(rootName,
-          containedRootElement.getPath(),
-          rootName,
-          containedDefinition.getUrl(),
-          childElements);
-
-      containedElements.put(rootName, StructureField.property(rootName, result));
-    }
-
-    T result = visitor.visitContained(element.getPath() + ".contained",
-        rootDefinition.getUrl(),
-        containedElements);
-
-    return StructureField.property("contained", result);
-  }
-
   @Override
   public FhirConversionSupport conversionSupport() {
 
@@ -455,147 +34,123 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
   }
 
   @Override
-  public <T> T transform(DefinitionVisitor<T> visitor, String resourceTypeUrl) {
-    return transform(visitor, resourceTypeUrl, Collections.emptyList());
+  protected IStructureDefinition getStructureDefinition(String resourceUrl) {
+    return new StructureDefinitionWrapper(
+        (StructureDefinition) context.getValidationSupport().fetchStructureDefinition(resourceUrl));
   }
 
-  @Override
-  public <T> T transform(DefinitionVisitor<T> visitor,
-      String resourceTypeUrl,
-      List<String> containedResourceTypeUrls) {
+  // FHIR version specific interface implementations
 
-    StructureDefinition definition = (StructureDefinition) context.getValidationSupport()
-        .fetchStructureDefinition(resourceTypeUrl);
+  private static class StructureDefinitionWrapper implements IStructureDefinition {
+    private final StructureDefinition structureDefinition;
 
-    if (definition == null) {
-
-      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
+    StructureDefinitionWrapper(StructureDefinition structureDefinition) {
+      this.structureDefinition = structureDefinition;
     }
 
-    List<StructureDefinition> containedDefinitions = containedResourceTypeUrls.stream()
-        .map(containedResourceTypeUrl -> {
-          StructureDefinition containedDefinition = (StructureDefinition) context
-              .getValidationSupport()
-              .fetchStructureDefinition(containedResourceTypeUrl);
+    @Override
+    public String getUrl() {
+      return structureDefinition.getUrl();
+    }
 
-          if (containedDefinition == null) {
+    @Override
+    public String getType() {
+      return structureDefinition.getType();
+    }
 
-            throw new IllegalArgumentException("Unable to find definition for "
-                + containedResourceTypeUrl);
-          }
+    @Override
+    public IElementDefinition getRootDefinition() {
+      return new ElementDefinitionWrapper(structureDefinition.getSnapshot().getElementFirstRep());
+    }
 
-          return containedDefinition;
-        })
-        .collect(Collectors.toList());
-
-    return transformRoot(visitor, definition, containedDefinitions);
+    @Override
+    public List<IElementDefinition> getSnapshotDefinitions() {
+      return structureDefinition.getSnapshot().getElement().stream().map(
+          d -> new ElementDefinitionWrapper(d)).collect(Collectors.toList());
+    }
   }
 
-  /**
-   * Transforms the given FHIR structure definition.
-   *
-   * @param visitor the visitor performing the transformation
-   * @param parentElement the element containing this definition for additional type information,
-   *     or null if it is not contained in a parent element.
-   * @param definition the FHIR structure definition to be converted
-   * @param stack a stack of FHIR type URLs to detect recursive definitions.
-   *
-   * @return the transformed structure, or null if it should not be included in the parent.
-   */
-  @Nullable
-  private <T> T transform(DefinitionVisitor<T> visitor,
-      ElementDefinition parentElement,
-      StructureDefinition definition,
-      Deque<QualifiedPath> stack) {
+  private static class ElementDefinitionWrapper implements IElementDefinition {
+    private final ElementDefinition elementDefinition;
 
-    List<ElementDefinition> definitions = definition.getSnapshot().getElement();
+    ElementDefinitionWrapper(ElementDefinition elementDefinition) {
+      this.elementDefinition = elementDefinition;
+    }
 
-    ElementDefinition root = definitions.get(0);
+    @Override
+    public String getId() {
+      return elementDefinition.getId();
+    }
 
-    List<StructureField<T>> childElements = transformChildren(visitor, definition,
-        definitions, stack, root);
+    @Override
+    public String getPath() {
+      return elementDefinition.getPath();
+    }
 
-    if ("Reference".equals(definition.getType())) {
+    @Override
+    public String getContentReference() {
+      return elementDefinition.getContentReference();
+    }
 
-      // TODO: if this is in an option there may be other non-reference types here?
-      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+    @Override
+    public String getMax() {
+      return elementDefinition.getMax();
+    }
 
-      List<String> referenceTypes = parentElement.getType()
+    @Override
+    public String getFirstTypeCode() {
+      return elementDefinition.getTypeFirstRep().getCode();
+    }
+
+    @Override
+    public boolean hasSingleType() {
+      return (elementDefinition.getType().size() == 1);
+    }
+
+    @Override
+    public List<String> getAllTypeCodes() {
+      return elementDefinition.getType().stream().map(
+          t -> t.getCode()).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getSliceName() {
+      return elementDefinition.getSliceName();
+    }
+
+    @Override
+    public boolean getIsModifier() {
+      return elementDefinition.getIsModifier();
+    }
+
+    @Override
+    public String getFixedPrimitiveValue() {
+      if (elementDefinition.getFixed() == null) {
+        return null;
+      }
+      return elementDefinition.getFixed().primitiveValue();
+    }
+
+    @Override
+    public List<String> getReferenceTargetProfiles() {
+      return elementDefinition.getType()
           .stream()
           .filter(type -> "Reference".equals(type.getCode()))
           .filter(type -> type.getTargetProfile() != null)
-          .map(type -> {
-
-            IValidationSupport validation = context.getValidationSupport();
-
-            StructureDefinition targetDefinition = (StructureDefinition)
-                validation.fetchStructureDefinition(type.getTargetProfile());
-
-            return targetDefinition.getType();
-          })
-          .sorted()
+          .map(type -> type.getTargetProfile())
           .collect(Collectors.toList());
-
-      return visitor.visitReference(parentElement.toString(), referenceTypes, childElements);
-
-    } else {
-
-      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
-
-      // We don't want 'id' to be present in nested fields to make it consistent with SQL-on-FHIR.
-      // https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#id-fields-omitted
-      childElements.removeIf(field -> field.fieldName().equals("id"));
-
-      if (childElements.isEmpty()) {
-        // All children were dropped because of recursion depth limit.
-        return null;
-      }
-      return visitor.visitComposite(rootName,
-          DefinitionVisitorsUtil.pathFromStack(root.getPath(), stack),
-          rootName,
-          definition.getUrl(),
-          childElements);
-    }
-  }
-
-  private <T> T transformRoot(DefinitionVisitor<T> visitor,
-      StructureDefinition definition,
-      List<StructureDefinition> containedDefinitions) {
-
-    ElementDefinition definitionRootElement = definition.getSnapshot().getElementFirstRep();
-
-    List<ElementDefinition> definitions = definition.getSnapshot().getElement();
-
-    Deque<QualifiedPath> stack = new ArrayDeque<>();
-
-    List<StructureField<T>> childElements = transformChildren(visitor,
-        definition,
-        definitions,
-        stack,
-        definitionRootElement);
-    // At this level no child should be dropped because of recursion limit.
-    Verify.verify(!childElements.isEmpty());
-    Verify.verify(stack.isEmpty());
-
-    // If there are contained definitions, create a Resource Container StructureField
-    if (containedDefinitions.size() > 0) {
-
-      StructureField<T> containedElement = transformContained(visitor,
-          definition,
-          containedDefinitions,
-          stack,
-          definitionRootElement);
-
-      // Replace default StructureField with constructed Resource Container StructureField
-      childElements.set(5, containedElement);
     }
 
-    String rootName = DefinitionVisitorsUtil.elementName(definitionRootElement.getPath());
+    @Override
+    public String getFirstTypeProfile() {
+      return elementDefinition.getTypeFirstRep().getProfile();
+    }
 
-    return visitor.visitComposite(rootName,
-        rootName,
-        rootName,
-        definition.getUrl(),
-        childElements);
+    @Override
+    public String toString() {
+      return elementDefinition.toString();
+    }
+
   }
+
 }

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IElementDefinition.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IElementDefinition.java
@@ -1,0 +1,54 @@
+package com.cerner.bunsen.definitions;
+
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public interface IElementDefinition {
+
+  String getId();
+
+  String getPath();
+
+  String getContentReference();
+
+  String getMax();
+
+  // Note the type codes are FHIR version dependent and are also extensible, see:
+  // https://hl7.org/fhir/valueset-elementdefinition-types.html
+  String getFirstTypeCode();
+
+  /**
+   * See return below.
+   * @return true iff this element has exactly one type (e.g., type does  not end in `[x]`).
+   */
+  boolean hasSingleType();
+
+  List<String> getAllTypeCodes();
+
+  String getSliceName();
+
+  boolean getIsModifier();
+
+  // TODO remove this once we properly handle extension URL extraction.
+  @Nullable
+  String getFixedPrimitiveValue();
+
+  /**
+   * See return below.
+   * @return list of `targetProfile`s for each `type` that is a reference.
+   */
+  List<String> getReferenceTargetProfiles();
+
+  /**
+   * This is a helper to address differences of `ElementDefinition.TypeRefComponent.getProfile()` in
+   * R4 vs. STU3 versions which returns a {@code List<CanonicalType>} in the former but a String
+   * in the latter. This is due to the difference between how `Reference` types are represented
+   * in R4 vs STU3; in R4 all "target profiles" (i.e., reference's target type) are under the same
+   * `type` while in STU3 we have multiple `type` each with a single target-profile.
+   *
+   * @return first profile or null if this element has no profiles
+   */
+  @Nullable
+  String getFirstTypeProfile();
+}

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IStructureDefinition.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IStructureDefinition.java
@@ -1,0 +1,15 @@
+package com.cerner.bunsen.definitions;
+
+import java.util.List;
+
+public interface IStructureDefinition {
+
+  String getUrl();
+
+  String getType();
+
+  IElementDefinition getRootDefinition();
+
+  List<IElementDefinition> getSnapshotDefinitions();
+
+}

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
@@ -3,16 +3,29 @@ package com.cerner.bunsen.definitions;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Constructor;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.hl7.fhir.r4.model.StructureDefinition;
 
 /**
  * Abstract base class to visit FHIR structure definitions.
  */
 public abstract class StructureDefinitions {
 
+  // TODO make this FHIR version specific and hide it under an abstract method.
   protected static final Set<String> PRIMITIVE_TYPES =  ImmutableSet.<String>builder()
       .add("id")
       .add("boolean")
@@ -53,17 +66,366 @@ public abstract class StructureDefinitions {
 
   protected final FhirContext context;
 
-  protected final IValidationSupport validationSupport;
-
   /**
    * Creates a new instance with the given context.
    *
    * @param context the FHIR context.
    */
   public StructureDefinitions(FhirContext context) {
-
     this.context = context;
-    this.validationSupport = context.getValidationSupport();
+  }
+
+  // TODO the current order of methods reflects previous refactored files to make code review
+  //  process simpler; we should probably change this in future and move public methods to the top.
+  private List<IElementDefinition> getChildren(IElementDefinition parent,
+      List<IElementDefinition> definitions) {
+
+    if (parent.getContentReference() != null) {
+      if (!parent.getContentReference().startsWith("#")) {
+        throw new IllegalStateException("Non-local references are not yet supported");
+      }
+
+      // Remove the leading hash (#) to get the referenced type.
+      String referencedType = parent.getContentReference().substring(1);
+
+      // Find the actual type to use.
+      parent = definitions.stream()
+          .filter(definition -> definition.getPath().equals(referencedType))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Expected a reference type"));
+    }
+
+    String startsWith = parent.getId() + ".";
+
+    return definitions.stream()
+        .filter(definition -> definition.getId().startsWith(startsWith)
+            && definition.getId().indexOf('.', startsWith.length()) < 0)
+        .collect(Collectors.toList());
+  }
+
+  private <T> List<StructureField<T>> singleField(String elementName, T result) {
+    if (result == null) {
+      return Collections.emptyList();
+    }
+    return Collections.singletonList(StructureField.property(elementName, result));
+  }
+
+  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
+      QualifiedPath newPath,
+      Deque<QualifiedPath> stack) {
+
+    // TODO we should add configuration parameters for exceptional paths
+    //  that require deeper recursion; this is where to apply that logic:
+    // String elementPath = DefinitionVisitorsUtil.pathFromStack(
+    //    DefinitionVisitorsUtil.elementName(newPath.getElementPath()), stack);
+    // if ("QuestionnaireResponse.item.item.item.item.item.item".startsWith(elementPath)) {
+    //   return false;
+    // }
+
+    int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
+
+    return stack.stream().filter(path -> path.equals(newPath)).count() > maxDepth;
+  }
+
+  private <T> List<StructureField<T>> extensionElementToFields(DefinitionVisitor<T> visitor,
+      IStructureDefinition rootDefinition,
+      IElementDefinition element,
+      List<IElementDefinition> snapshotDefinitions,
+      Deque<QualifiedPath> stack) {
+
+    // FIXME: extension is a type rather than an external structure....
+    IStructureDefinition definition = null;
+    String profileUrl = element.getFirstTypeProfile();
+    if (profileUrl != null) {
+      definition = getStructureDefinition(profileUrl);
+    }
+
+    List<StructureField<T>> extensions;
+
+    if (definition != null) {
+      List<IElementDefinition> extensionDefinitions = definition.getSnapshotDefinitions();
+      IElementDefinition extensionRoot = extensionDefinitions.get(0);
+      extensions = visitExtensionDefinition(visitor,
+          rootDefinition,
+          element.getSliceName(),
+          stack,
+          definition.getUrl(),
+          extensionDefinitions,
+          extensionRoot);
+    } else {
+      if (element.getSliceName() == null) {
+        return Collections.emptyList();
+      }
+      extensions = visitExtensionDefinition(visitor,
+          rootDefinition,
+          element.getSliceName(),
+          stack,
+          element.getFirstTypeProfile(),
+          snapshotDefinitions,
+          element);
+    }
+
+    if (!element.getMax().equals("1") && extensions.size() > 0) {
+      // the nested extension element has max: *
+      return Collections.singletonList(StructureField.extension(
+          extensions.get(0).fieldName(),
+          extensions.get(0).extensionUrl(),
+          extensions.get(0).isModifier(),
+          visitor.visitMultiValued(extensions.get(0).fieldName(), extensions.get(0).result())));
+
+    } else {
+      return extensions;
+    }
+  }
+
+  private <T> List<StructureField<T>> visitExtensionDefinition(DefinitionVisitor<T> visitor,
+      IStructureDefinition rootDefinition,
+      String sliceName,
+      Deque<QualifiedPath> stack,
+      String url,
+      List<IElementDefinition> extensionDefinitions,
+      IElementDefinition extensionRoot) {
+
+    // For extensions, we need to process slices to separate them into individual fields.
+    List<IElementDefinition> children = getChildren(extensionRoot, extensionDefinitions);
+
+    // Extensions may contain either additional extensions or a value field, but not both.
+    // So if it has a child element with a slice name, it has additional extensions.
+    List<IElementDefinition> childExtensions = children.stream()
+        .filter(element -> element.getSliceName() != null)
+        .collect(Collectors.toList());
+
+    if (!childExtensions.isEmpty()) {
+      List<StructureField<T>> childFields = new ArrayList<>();
+
+      for (IElementDefinition childExtension: childExtensions) {
+        List<StructureField<T>> childField = extensionElementToFields(visitor,
+            rootDefinition, childExtension, extensionDefinitions, stack);
+        childFields.addAll(childField);
+      }
+
+      T result = visitor.visitParentExtension(sliceName,
+          url,
+          childFields);
+
+      if (result == null) {
+        return Collections.emptyList();
+      } else {
+        return Collections.singletonList(
+            StructureField.extension(sliceName,
+                url,
+                extensionRoot.getIsModifier(),
+                result));
+      }
+    } else {
+      // The extension has no children, so produce its value.
+      Optional<IElementDefinition> valueElement = children.stream()
+          .filter(e -> e.getPath().contains("value"))
+          .findFirst();
+      // FIXME: get the extension URL.
+      Optional<IElementDefinition> urlElement = children.stream()
+          .filter(e -> e.getPath().endsWith("url"))
+          .findFirst();
+      String extensionUrl = urlElement.get().getFixedPrimitiveValue();
+      List<StructureField<T>> childField = elementToFields(visitor, rootDefinition,
+          valueElement.get(), extensionDefinitions, stack);
+      T result = visitor.visitLeafExtension(sliceName,
+          extensionUrl,
+          childField.iterator().next().result());
+      return Collections.singletonList(
+          StructureField.extension(sliceName,
+              extensionUrl,
+              extensionRoot.getIsModifier(),
+              result));
+    }
+  }
+
+  /**
+   * Returns the fields for the given element. The returned stream can be empty
+   * (e.g., for elements with max of zero), or have multiple values (for elements
+   * that generate fields with additional data in siblings.)
+   */
+  private <T> List<StructureField<T>> elementToFields(DefinitionVisitor<T> visitor,
+      IStructureDefinition rootDefinition,
+      IElementDefinition element,
+      List<IElementDefinition> snapshotDefinitions,
+      Deque<QualifiedPath> stack) {
+
+    String elementName = DefinitionVisitorsUtil.elementName(element.getPath());
+
+    if (element.getMax().equals("0")) {
+      // Fields with max of zero are omitted.
+      return Collections.emptyList();
+    } else if ("Extension".equals(element.getFirstTypeCode())) {
+      return extensionElementToFields(visitor, rootDefinition, element, snapshotDefinitions, stack);
+    } else if (element.getSliceName() != null) {
+      // Drop slices for non-extension fields; otherwise we will end up with duplicated fields.
+      return Collections.emptyList();
+    } else if (element.hasSingleType() && PRIMITIVE_TYPES.contains(element.getFirstTypeCode())) {
+      T primitiveConverter = visitor
+          .visitPrimitive(elementName, element.getFirstTypeCode());
+      if (!element.getMax().equals("1")) {
+        return singleField(elementName, visitor.visitMultiValued(elementName, primitiveConverter));
+      } else {
+        return singleField(elementName, primitiveConverter);
+      }
+
+    } else if (element.getPath().endsWith("[x]") && !element.getPath().startsWith("Extension")) {
+      // TODO fix for "Extension": https://github.com/google/fhir-data-pipes/issues/559
+
+      // Use a linked hash map to preserve the order of the fields
+      // for iteration.
+      Map<String, T> choiceTypes = new LinkedHashMap<>();
+
+      for (String typeCode : element.getAllTypeCodes()) {
+        if (PRIMITIVE_TYPES.contains(typeCode)) {
+          T child = visitor.visitPrimitive(elementName, typeCode);
+          choiceTypes.put(typeCode, child);
+        } else {
+          IStructureDefinition structureDefinition = getStructureDefinition(typeCode);
+
+          // TODO document why we are resetting the stack here; it is not clear
+          //  why this cannot lead to infinite recursion for choice types. If
+          //  we don't reset the stack, then we should handle null returns.
+          T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
+          Verify.verify(child != null,
+              "Unexpected null choice type {} for element {}", typeCode, element);
+          choiceTypes.put(typeCode, child);
+        }
+      }
+
+      StructureField<T> field = new StructureField<>(elementName,
+          elementName,
+          null,
+          false,
+          true,
+          visitor.visitChoice(elementName, choiceTypes));
+      return Collections.singletonList(field);
+    } else if (!element.getMax().equals("1")) {
+      if (getDefinition(element) != null) {
+        // Handle defined data types.
+        IStructureDefinition definition = getDefinition(element);
+        T type = transform(visitor, element, definition, stack);
+        return singleField(elementName,
+            visitor.visitMultiValued(elementName, type));
+      } else {
+        List<StructureField<T>> childElements = transformChildren(visitor,
+            rootDefinition, snapshotDefinitions, stack, element);
+        if (childElements.isEmpty()) {
+          // All children were dropped because of recursion depth limit.
+          return  Collections.emptyList();
+        }
+        T result = visitor.visitComposite(elementName,
+            DefinitionVisitorsUtil.pathFromStack(elementName, stack),
+            elementName,
+            rootDefinition.getUrl(),
+            childElements);
+        List<StructureField<T>> composite = singleField(elementName, result);
+        // Array types should produce only a single element.
+        if (composite.size() != 1) {
+          throw new IllegalStateException("Array type in "
+              + element.getPath()
+              + " must map to a single structure.");
+        }
+
+        // Wrap the item in the corresponding multi-valued type.
+        return singleField(elementName,
+            visitor.visitMultiValued(elementName, composite.get(0).result()));
+      }
+
+    } else if (getDefinition(element) != null) {
+
+      // TODO refactor this and the similar block above for handling defined data types.
+      // Handle defined data types.
+      IStructureDefinition definition = getDefinition(element);
+      T type = transform(visitor, element, definition, stack);
+      return singleField(DefinitionVisitorsUtil.elementName(element.getPath()), type);
+    } else {
+
+      // Handle composite type
+      List<StructureField<T>> childElements = transformChildren(visitor, rootDefinition,
+          snapshotDefinitions, stack, element);
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return  Collections.emptyList();
+      }
+
+      T result = visitor.visitComposite(elementName,
+          DefinitionVisitorsUtil.pathFromStack(elementName, stack),
+          elementName,
+          rootDefinition.getUrl(),
+          childElements);
+
+      return singleField(elementName, result);
+    }
+  }
+
+  /**
+   * Goes through the list of children of the given `element` and convert each
+   * of those `ElementDefinision`s to `StructureField`s.
+   * NOTE: This is the only place where the traversal stack can grow. It is also
+   * best if this is the only place where `shouldTerminateRecursive` is called.
+   */
+  private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
+      IStructureDefinition rootDefinition,
+      List<IElementDefinition> snapshotDefinitions,
+      Deque<QualifiedPath> stack,
+      IElementDefinition element) {
+
+    QualifiedPath qualifiedPath = new QualifiedPath(rootDefinition.getUrl(),  element.getPath());
+
+    if (shouldTerminateRecursive(visitor, qualifiedPath, stack)) {
+      return Collections.emptyList();
+    } else {
+      stack.push(qualifiedPath);
+
+      // Handle composite type
+      List<StructureField<T>> childElements = new ArrayList<>();
+
+      for (IElementDefinition child: getChildren(element, snapshotDefinitions)) {
+        List<StructureField<T>> childFields = elementToFields(visitor, rootDefinition,
+            child, snapshotDefinitions, stack);
+        childElements.addAll(childFields);
+      }
+
+      stack.pop();
+
+      return childElements;
+    }
+  }
+
+  private <T> StructureField<T> transformContained(DefinitionVisitor<T> visitor,
+      IStructureDefinition rootDefinition,
+      List<IStructureDefinition> containedDefinitions,
+      Deque<QualifiedPath> stack,
+      IElementDefinition element) {
+
+    Map<String, StructureField<T>> containedElements = new LinkedHashMap<>();
+
+    for (IStructureDefinition containedDefinition: containedDefinitions) {
+      IElementDefinition containedRootElement = containedDefinition.getRootDefinition();
+      List<IElementDefinition> snapshotDefinitions = containedDefinition.getSnapshotDefinitions();
+      List<StructureField<T>> childElements = transformChildren(visitor,
+          containedDefinition,
+          snapshotDefinitions,
+          stack,
+          containedRootElement);
+      // At this level no child should be dropped because of recursion limit.
+      Verify.verify(!childElements.isEmpty());
+      String rootName = DefinitionVisitorsUtil.elementName(containedRootElement.getPath());
+      T result = visitor.visitComposite(rootName,
+          containedRootElement.getPath(),
+          rootName,
+          containedDefinition.getUrl(),
+          childElements);
+      containedElements.put(rootName, StructureField.property(rootName, result));
+    }
+
+    T result = visitor.visitContained(element.getPath() + ".contained",
+        rootDefinition.getUrl(),
+        containedElements);
+
+    return StructureField.property("contained", result);
   }
 
   /**
@@ -74,8 +436,9 @@ public abstract class StructureDefinitions {
    * @param <T> the return type of the visitor.
    * @return the transformed result.
    */
-  public abstract <T> T transform(DefinitionVisitor<T> visitor,
-      String resourceTypeUrl);
+  public <T> T transform(DefinitionVisitor<T> visitor, String resourceTypeUrl) {
+    return transform(visitor, resourceTypeUrl, Collections.emptyList());
+  }
 
   /**
    * Transforms a FHIR resource to a type defined by the visitor.
@@ -86,9 +449,148 @@ public abstract class StructureDefinitions {
    * @param <T> the return type of the visitor.
    * @return the transformed result.
    */
-  public abstract <T> T transform(DefinitionVisitor<T> visitor,
+  public <T> T transform(DefinitionVisitor<T> visitor,
       String resourceTypeUrl,
-      List<String> containedResourceTypeUrls);
+      List<String> containedResourceTypeUrls) {
+
+    IStructureDefinition definition = getStructureDefinition(resourceTypeUrl);
+
+    if (definition == null) {
+      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
+    }
+
+    List<IStructureDefinition> containedDefinitions = containedResourceTypeUrls.stream()
+        .map(containedResourceTypeUrl -> {
+          IStructureDefinition containedDefinition =
+              getStructureDefinition(containedResourceTypeUrl);
+
+          if (containedDefinition == null) {
+            throw new IllegalArgumentException("Unable to find definition for "
+                + containedResourceTypeUrl);
+          }
+
+          return containedDefinition;
+        })
+        .collect(Collectors.toList());
+
+    return transformRoot(visitor, definition, containedDefinitions);
+  }
+
+  // TODO make the separation between this and `elementToFields` more clear.
+  /**
+   * Transforms the given FHIR structure definition.
+   *
+   * @param visitor the visitor performing the transformation
+   * @param parentElement the element containing this definition for additional type information,
+   *     or null if it is not contained in a parent element.
+   * @param definition the FHIR structure definition to be converted
+   * @param stack a stack of FHIR type URLs to detect recursive definitions.
+   *
+   * @return the transformed structure, or null if it should not be included in the parent.
+   */
+  @Nullable
+  private <T> T transform(DefinitionVisitor<T> visitor,
+      IElementDefinition parentElement,
+      IStructureDefinition definition,
+      Deque<QualifiedPath> stack) {
+
+    List<IElementDefinition> snapshotDefinitions = definition.getSnapshotDefinitions();
+    IElementDefinition root = definition.getRootDefinition();
+
+    List<StructureField<T>> childElements = transformChildren(visitor, definition,
+        snapshotDefinitions, stack, root);
+
+    if ("Reference".equals(definition.getType())) {
+
+      // TODO: if this is in an option there may be other non-reference types here?
+      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+
+      List<String> referenceProfiles = parentElement.getReferenceTargetProfiles();
+      List<String> referenceTypes = referenceProfiles.stream()
+          .map(profile -> getStructureDefinition(profile).getType())
+          .sorted()
+          .collect(Collectors.toList());
+      return visitor.visitReference(parentElement.toString(), referenceTypes, childElements);
+    } else {
+      String rootName = DefinitionVisitorsUtil.elementName(root.getPath());
+
+      // We don't want 'id' to be present in nested fields to make it consistent with SQL-on-FHIR.
+      // https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#id-fields-omitted
+      childElements.removeIf(field -> field.fieldName().equals("id"));
+
+      if (childElements.isEmpty()) {
+        // All children were dropped because of recursion depth limit.
+        return null;
+      }
+      return visitor.visitComposite(rootName,
+          DefinitionVisitorsUtil.pathFromStack(root.getPath(), stack),
+          rootName,
+          definition.getUrl(),
+          childElements);
+    }
+  }
+
+  private <T> T transformRoot(DefinitionVisitor<T> visitor,
+      IStructureDefinition definition,
+      List<IStructureDefinition> containedDefinitions) {
+
+    IElementDefinition rootElement = definition.getRootDefinition();
+    List<IElementDefinition> snapshotDefinitions = definition.getSnapshotDefinitions();
+    Deque<QualifiedPath> stack = new ArrayDeque<>();
+    List<StructureField<T>> childElements = transformChildren(visitor,
+        definition,
+        snapshotDefinitions,
+        stack,
+        rootElement);
+    // At this level no child should be dropped because of recursion limit.
+    Verify.verify(!childElements.isEmpty());
+    Verify.verify(stack.isEmpty());
+
+    // If there are contained definitions, create a Resource Container StructureField
+    if (containedDefinitions.size() > 0) {
+      StructureField<T> containedElement = transformContained(visitor,
+          definition,
+          containedDefinitions,
+          stack,
+          rootElement);
+
+      // Replace default StructureField with constructed Resource Container StructureField
+      // TODO make this future proof instead of using a hard-coded index for `contained`.
+      childElements.set(5, containedElement);
+    }
+
+    String rootName = DefinitionVisitorsUtil.elementName(rootElement.getPath());
+
+    return visitor.visitComposite(rootName,
+        rootName,
+        rootName,
+        definition.getUrl(),
+        childElements);
+  }
+
+  /**
+   * Returns the structure definition interface corresponding to the given URL.
+   *
+   * @param resourceUrl it can be a resource type like `Patient` or a profile URL.
+   * @return the {@link IStructureDefinition} corresponding to the `resourceUrl`.
+   */
+  protected abstract IStructureDefinition getStructureDefinition(String resourceUrl);
+
+  /**
+   * Returns the structure definition interface corresponding to the given element.
+   * @param element the target element
+   * @return the structure definition or null if the given element has no type code.
+   */
+  @Nullable
+  private IStructureDefinition getDefinition(IElementDefinition element) {
+    String typeCode = element.getFirstTypeCode();
+    return typeCode == null
+        || typeCode.equals("BackboneElement")
+        || typeCode.equals("Element")
+        ? null
+        : getStructureDefinition(typeCode);
+  }
+
 
   /**
    * Returns supporting functions to make FHIR conversion work independent of version.


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #496 
Adds two interfaces to hide FHIR version differences of StructureDefinition and ElementDefinition resources. This enabled us to refactor the vast amount of duplicated code for transforming these resource definitions.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Relied on unit/e2e tests; these changes are expected to have no functional impact.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
