### PR TITLE
Fixes issues for upgrading to newer hapi.fhir libs

### DIFF
--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -27,7 +27,7 @@
 
     <compile.source>11</compile.source>
 
-    <hapi.fhir.version>6.4.4</hapi.fhir.version>
+    <hapi.fhir.version>6.6.2</hapi.fhir.version>
     <avro.version>1.11.2</avro.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>2.2</hamcrest.version>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -46,13 +46,13 @@
     <junit.version>4.13.2</junit.version>
     <slf4j.version>2.0.7</slf4j.version>
     <logback.version>1.4.7</logback.version>
-    <hapifhirVersion>6.4.4</hapifhirVersion>
+    <hapifhirVersion>6.6.2</hapifhirVersion>
     <hamcrest.version>2.2</hamcrest.version>
     <openmrsPlatformVersion>2.6.0-SNAPSHOT</openmrsPlatformVersion>
     <mockito.version>5.2.0</mockito.version>
     <jcommander.version>1.82</jcommander.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
-    <beam.version>2.45.0</beam.version>
+    <beam.version>2.49.0</beam.version>
     <auto-value.version>1.10.2</auto-value.version>
   </properties>
 
@@ -159,6 +159,15 @@
       <artifactId>auto-value</artifactId>
       <version>${auto-value.version}</version>
       <optional>true</optional>
+    </dependency>
+
+    <!-- This is to override the old Jackson dependency that Beam has; without
+      this the libraries that depend on newer Jackson throw NoClassDefFound.
+      TODO remove this dependency once Beam is upgraded. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.15.0</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #725 
The root cause of the dependency issues seems to be diamond dependencies on Jackson through different libraries. The problem is that the latest release of Beam depends on `2.14.1` of `jackson-core` and that causes `NoClassDefFound` exceptions due to other libraries (e.g., Hapi 6.6.2) depending on newer Jackson.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Relying on unit/e2e tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
