### PR TITLE
Fixed paging to use FHIR standard paging url rather than HAPI-FHIR's …

### DIFF
--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/FhirSearchUtilTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/FhirSearchUtilTest.java
@@ -19,10 +19,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,11 +54,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class FhirSearchUtilTest {
 
-  private static final String PAGE_URL_PARAM = "_getpages=861af9b4-d847-4831-b945-ab1f6f08f03e";
-
   private static final String BASE_URL = "http://localhost:9020/openmrs/ws/fhir2/R4";
 
   private static final String SEARCH_URL = "Patient?given=TEST";
+
+  private static final String OFFSET_PARAM = "_offset=15";
+
+  private static final String COUNT_PARAM = "_count=15";
+
+  private static final String SUMMARY_PARAM = "_summary=data";
+
+  private static final String GIVEN_PARAM = "given=Bashir";
 
   @Mock private OpenmrsUtil openmrsUtil;
 
@@ -86,7 +92,6 @@ public class FhirSearchUtilTest {
     IParser parser = fhirContext.newJsonParser();
     bundle = parser.parseResource(Bundle.class, bundleStr);
     fhirSearchUtil = new FhirSearchUtil(openmrsUtil);
-    when(openmrsUtil.getSourceFhirUrl()).thenReturn(BASE_URL);
     when(openmrsUtil.getSourceClient()).thenReturn(genericClient);
     when(openmrsUtil.getSourceClient(anyBoolean())).thenReturn(genericClient);
     when(genericClient.search()).thenReturn(untypedQuery);
@@ -102,7 +107,18 @@ public class FhirSearchUtilTest {
   @Test
   public void testFindBaseSearchUrl() {
     String baseUrl = fhirSearchUtil.findBaseSearchUrl(bundle);
-    assertThat(baseUrl, equalTo(BASE_URL + "?" + PAGE_URL_PARAM));
+    assertThat(
+        baseUrl,
+        equalTo(
+            BASE_URL
+                + "?"
+                + OFFSET_PARAM
+                + "&"
+                + COUNT_PARAM
+                + "&"
+                + SUMMARY_PARAM
+                + "&"
+                + GIVEN_PARAM));
   }
 
   @Test
@@ -140,7 +156,7 @@ public class FhirSearchUtilTest {
     options.setBatchSize(15);
     Map<String, List<SearchSegmentDescriptor>> segmentMap = fhirSearchUtil.createSegments(options);
     assertThat(segmentMap.size(), equalTo(1));
-    assertThat(segmentMap.get("Patient").size(), equalTo(4));
+    assertThat(segmentMap.get("Patient").size(), equalTo(1));
   }
 
   @Test
@@ -152,7 +168,7 @@ public class FhirSearchUtilTest {
     when(query.lastUpdated(any())).thenReturn(query);
     Map<String, List<SearchSegmentDescriptor>> segmentMap = fhirSearchUtil.createSegments(options);
     assertThat(segmentMap.size(), equalTo(1));
-    assertThat(segmentMap.get("Patient").size(), equalTo(4));
+    assertThat(segmentMap.get("Patient").size(), equalTo(1));
     ArgumentCaptor<DateRangeParam> dateCaptor = ArgumentCaptor.forClass(DateRangeParam.class);
     verify(query).lastUpdated(dateCaptor.capture());
     DateRangeParam value = dateCaptor.getValue();

--- a/pipelines/batch/src/test/resources/bundle.json
+++ b/pipelines/batch/src/test/resources/bundle.json
@@ -16,11 +16,11 @@
   "link": [
     {
       "relation": "self",
-      "url": "http://localhost:9020/openmrs/ws/fhir2/R4/Patient?_count=15&_getpagesoffset=0&_summary=data&given=Bashir"
+      "url": "http://localhost:9020/openmrs/ws/fhir2/R4/Patient?_offset=0&_count=15&_summary=data&given=Bashir"
     },
     {
       "relation": "next",
-      "url": "http://localhost:9020/openmrs/ws/fhir2/R4?_getpages=861af9b4-d847-4831-b945-ab1f6f08f03e&_getpagesoffset=15&_count=15&_bundletype=searchset"
+      "url": "http://localhost:9020/openmrs/ws/fhir2/R4?_offset=15&_count=15&_summary=data&given=Bashir"
     }
   ],
   "entry": [


### PR DESCRIPTION
…custom solution

## Description of what I changed

<!--- Describe your changes in detail -->
Paging for resources from a FHIR server was only implemented to handle HAPI FHIR's custom paging, I switched it to use the more standard "next" link within FHIR's standard.
<!--- It can simply be your commit message, which you must have -->

Appears related to #533

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
