### PR TITLE
Temporarily reducing the Flink memory params for low resource machines

### DIFF
--- a/docker/config/flink-conf.yaml
+++ b/docker/config/flink-conf.yaml
@@ -16,12 +16,12 @@
 
 # This is needed to prevent an "Insufficient number of network buffers"
 # exceptions when running the merger on large input with many workers.
-taskmanager.memory.network.max: 5gb
+taskmanager.memory.network.max: 2gb
 
 # This is needed to be able to process large resources, otherwise in JDBC
 # mode we may get the following exception:
 # "The record exceeds the maximum size of a sort buffer ..."
-taskmanager.memory.managed.size: 2gb
+taskmanager.memory.managed.size: 1gb
 
 # This is to make pipeline.run() non-blocking with FlinkRunner; unfortunately
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240


### PR DESCRIPTION
## Description of what I changed

Temporarily reducing the Flink memory params to work fine in low resource settings.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Tested the full run on the application deployed via docker 

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
