### PR TITLE
Reducing the memory configuration values to support low resource env

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,4 +45,4 @@ enable_jemalloc
 # The -Xmx value is to make sure there is a minimum amount of memory; it can be
 # increased if more memory is available and is desired to be used by pipelines.
 # Note this is related to the memory config in flink-conf.yaml too.
-java -Xms6g -Xmx6g -jar /app/controller.jar
+java -Xms2g -Xmx2g -jar /app/controller.jar

--- a/docker/config/flink-conf.yaml
+++ b/docker/config/flink-conf.yaml
@@ -16,12 +16,12 @@
 
 # This is needed to prevent an "Insufficient number of network buffers"
 # exceptions when running the merger on large input with many workers.
-taskmanager.memory.network.max: 1gb
+taskmanager.memory.network.max: 256mb
 
 # This is needed to be able to process large resources, otherwise in JDBC
 # mode we may get the following exception:
 # "The record exceeds the maximum size of a sort buffer ..."
-taskmanager.memory.managed.size: 2gb
+taskmanager.memory.managed.size: 256mb
 
 # This is to make pipeline.run() non-blocking with FlinkRunner; unfortunately
 # this is overwritten in `local` mode: https://stackoverflow.com/a/74416240


### PR DESCRIPTION
## Description of what I changed

Reduced the JVM heap and Flink memory configurations to support low resource environments.

## E2E test

Tested the Qwiklabs codelab setup prepared for the OHS analytics demo.


## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
