### PR TITLE
Changes to support the Windows OS platform

### DIFF
--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
@@ -475,30 +474,56 @@ public class R4AvroConverterTest {
             .map(Object::toString)
             .collect(Collectors.toSet());
 
+    String fileSeparator = File.separator;
     List<String> filesToBeVerified =
         Arrays.asList(
             // Ensure common types were generated
-            "com/cerner/bunsen/r4/avro/Period.java",
-            "com/cerner/bunsen/r4/avro/PatientCoding.java",
-            "com/cerner/bunsen/r4/avro/ValueSet.java",
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "r4", "avro", "Period.java"}),
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "r4", "avro", "PatientCoding.java"}),
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "r4", "avro", "ValueSet.java"}),
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "r4", "avro", "Period.java"}),
             // The specific profile should be created in the expected sub-package.
-            "com/cerner/bunsen/r4/avro/us/core/Patient.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "r4", "avro", "us", "core", "Patient.java"
+                }),
             // Check extension types.
-            "com/cerner/bunsen/r4/avro/us/core/UsCoreRace.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "r4", "avro", "us", "core", "UsCoreRace.java"
+                }),
             // Choice types include each choice that could be used.
-            "com/cerner/bunsen/r4/avro/ChoiceBooleanInteger.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "r4", "avro", "ChoiceBooleanInteger.java"
+                }),
             // Contained types created.
-            "com/cerner/bunsen/r4/avro/us/core/MedicationRequestContained.java");
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com",
+                  "cerner",
+                  "bunsen",
+                  "r4",
+                  "avro",
+                  "us",
+                  "core",
+                  "MedicationRequestContained.java"
+                }));
 
     // Ensure common types were generated
     for (String fileToBeVerified : filesToBeVerified) {
-      String fileSeparator = File.separator;
-      // In case of Windows the path should contain `\\` as the file separator (double slash since
-      // java escapes backslash). Replace `\\` with `\\\\` as the regex will eat one backslash.
-      fileSeparator =
-          fileSeparator.replaceAll(
-              Matcher.quoteReplacement("\\"), Matcher.quoteReplacement("\\\\"));
-      fileToBeVerified = fileToBeVerified.replaceAll("/", fileSeparator);
       Assert.assertTrue(javaFiles.contains(fileToBeVerified));
     }
   }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -4,6 +4,7 @@ import com.cerner.bunsen.FhirContexts;
 import com.cerner.bunsen.r4.TestData;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Files;
@@ -17,7 +18,6 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.compiler.specific.SpecificCompiler;
 import org.apache.avro.generic.GenericData.Record;
-import org.apache.commons.lang3.SystemUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -491,9 +491,7 @@ public class R4AvroConverterTest {
 
     // Ensure common types were generated
     for (String fileToBeVerified : filesToBeVerified) {
-      if (SystemUtils.IS_OS_WINDOWS) {
-        fileToBeVerified = fileToBeVerified.replaceAll("/", "\\\\");
-      }
+      fileToBeVerified = fileToBeVerified.replaceAll("/", File.separator);
       Assert.assertTrue(javaFiles.contains(fileToBeVerified));
     }
   }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
@@ -491,7 +492,13 @@ public class R4AvroConverterTest {
 
     // Ensure common types were generated
     for (String fileToBeVerified : filesToBeVerified) {
-      fileToBeVerified = fileToBeVerified.replaceAll("/", File.separator);
+      String fileSeparator = File.separator;
+      // In case of Windows the path should contain `\\` as the file separator (double slash since
+      // java escapes backslash). Replace `\\` with `\\\\` as the regex will eat one backslash.
+      fileSeparator =
+          fileSeparator.replaceAll(
+              Matcher.quoteReplacement("\\"), Matcher.quoteReplacement("\\\\"));
+      fileToBeVerified = fileToBeVerified.replaceAll("/", fileSeparator);
       Assert.assertTrue(javaFiles.contains(fileToBeVerified));
     }
   }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -17,6 +17,7 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.compiler.specific.SpecificCompiler;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.commons.lang3.SystemUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -473,23 +474,28 @@ public class R4AvroConverterTest {
             .map(Object::toString)
             .collect(Collectors.toSet());
 
+    List<String> filesToBeVerified =
+        Arrays.asList(
+            // Ensure common types were generated
+            "com/cerner/bunsen/r4/avro/Period.java",
+            "com/cerner/bunsen/r4/avro/PatientCoding.java",
+            "com/cerner/bunsen/r4/avro/ValueSet.java",
+            // The specific profile should be created in the expected sub-package.
+            "com/cerner/bunsen/r4/avro/us/core/Patient.java",
+            // Check extension types.
+            "com/cerner/bunsen/r4/avro/us/core/UsCoreRace.java",
+            // Choice types include each choice that could be used.
+            "com/cerner/bunsen/r4/avro/ChoiceBooleanInteger.java",
+            // Contained types created.
+            "com/cerner/bunsen/r4/avro/us/core/MedicationRequestContained.java");
+
     // Ensure common types were generated
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/Period.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/PatientCoding.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/ValueSet.java"));
-
-    // The specific profile should be created in the expecter4b-package.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/us/core/Patient.java"));
-
-    // Check extension types.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/us/core/UsCoreRace.java"));
-
-    // Choice types include each choice that could be used.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/r4/avro/ChoiceBooleanInteger.java"));
-
-    // Contained types created.
-    Assert.assertTrue(
-        javaFiles.contains("com/cerner/bunsen/r4/avro/us/core/MedicationRequestContained.java"));
+    for (String fileToBeVerified : filesToBeVerified) {
+      if (SystemUtils.IS_OS_WINDOWS) {
+        fileToBeVerified = fileToBeVerified.replaceAll("/", "\\\\");
+      }
+      Assert.assertTrue(javaFiles.contains(fileToBeVerified));
+    }
   }
 
   // TODO add test profile for R4: https://github.com/google/fhir-data-pipes/issues/558

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
@@ -4,6 +4,7 @@ import com.cerner.bunsen.FhirContexts;
 import com.cerner.bunsen.stu3.TestData;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Files;
@@ -12,12 +13,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.compiler.specific.SpecificCompiler;
 import org.apache.avro.generic.GenericData.Record;
-import org.apache.commons.lang3.SystemUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
@@ -493,9 +494,13 @@ public class Stu3AvroConverterTest {
 
     // Ensure common types were generated
     for (String fileToBeVerified : filesToBeVerified) {
-      if (SystemUtils.IS_OS_WINDOWS) {
-        fileToBeVerified = fileToBeVerified.replaceAll("/", "\\\\");
-      }
+      String fileSeparator = File.separator;
+      // In case of Windows the path should contain `\\` as the file separator (double slash since
+      // java escapes backslash). Replace `\\` with `\\\\` as the regex will eat one backslash.
+      fileSeparator =
+          fileSeparator.replaceAll(
+              Matcher.quoteReplacement("\\"), Matcher.quoteReplacement("\\\\"));
+      fileToBeVerified = fileToBeVerified.replaceAll("/", fileSeparator);
       Assert.assertTrue(javaFiles.contains(fileToBeVerified));
     }
   }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
@@ -17,6 +17,7 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.compiler.specific.SpecificCompiler;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.commons.lang3.SystemUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
@@ -475,23 +476,28 @@ public class Stu3AvroConverterTest {
             .map(Object::toString)
             .collect(Collectors.toSet());
 
+    List<String> filesToBeVerified =
+        Arrays.asList(
+            // Ensure common types were generated
+            "com/cerner/bunsen/stu3/avro/Period.java",
+            "com/cerner/bunsen/stu3/avro/PatientCoding.java",
+            "com/cerner/bunsen/stu3/avro/ValueSet.java",
+            // The specific profile should be created in the expected sub-package.
+            "com/cerner/bunsen/stu3/avro/us/core/Patient.java",
+            // Check extension types.
+            "com/cerner/bunsen/stu3/avro/us/core/UsCoreRace.java",
+            // Choice types include each choice that could be used.
+            "com/cerner/bunsen/stu3/avro/ChoiceBooleanInteger.java",
+            // Contained types created.
+            "com/cerner/bunsen/stu3/avro/us/core/MedicationRequestContained.java");
+
     // Ensure common types were generated
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/Period.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/PatientCoding.java"));
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/ValueSet.java"));
-
-    // The specific profile should be created in the expected sub-package.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/us/core/Patient.java"));
-
-    // Check extension types.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/us/core/UsCoreRace.java"));
-
-    // Choice types include each choice that could be used.
-    Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/ChoiceBooleanInteger.java"));
-
-    // Contained types created.
-    Assert.assertTrue(
-        javaFiles.contains("com/cerner/bunsen/stu3/avro/us/core/MedicationRequestContained.java"));
+    for (String fileToBeVerified : filesToBeVerified) {
+      if (SystemUtils.IS_OS_WINDOWS) {
+        fileToBeVerified = fileToBeVerified.replaceAll("/", "\\\\");
+      }
+      Assert.assertTrue(javaFiles.contains(fileToBeVerified));
+    }
   }
 
   @Test

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
@@ -477,30 +476,53 @@ public class Stu3AvroConverterTest {
             .map(Object::toString)
             .collect(Collectors.toSet());
 
+    String fileSeparator = File.separator;
     List<String> filesToBeVerified =
         Arrays.asList(
             // Ensure common types were generated
-            "com/cerner/bunsen/stu3/avro/Period.java",
-            "com/cerner/bunsen/stu3/avro/PatientCoding.java",
-            "com/cerner/bunsen/stu3/avro/ValueSet.java",
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "stu3", "avro", "Period.java"}),
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "stu3", "avro", "PatientCoding.java"}),
+            String.join(
+                fileSeparator,
+                new String[] {"com", "cerner", "bunsen", "stu3", "avro", "ValueSet.java"}),
             // The specific profile should be created in the expected sub-package.
-            "com/cerner/bunsen/stu3/avro/us/core/Patient.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "stu3", "avro", "us", "core", "Patient.java"
+                }),
             // Check extension types.
-            "com/cerner/bunsen/stu3/avro/us/core/UsCoreRace.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "stu3", "avro", "us", "core", "UsCoreRace.java"
+                }),
             // Choice types include each choice that could be used.
-            "com/cerner/bunsen/stu3/avro/ChoiceBooleanInteger.java",
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com", "cerner", "bunsen", "stu3", "avro", "ChoiceBooleanInteger.java"
+                }),
             // Contained types created.
-            "com/cerner/bunsen/stu3/avro/us/core/MedicationRequestContained.java");
+            String.join(
+                fileSeparator,
+                new String[] {
+                  "com",
+                  "cerner",
+                  "bunsen",
+                  "stu3",
+                  "avro",
+                  "us",
+                  "core",
+                  "MedicationRequestContained.java"
+                }));
 
     // Ensure common types were generated
     for (String fileToBeVerified : filesToBeVerified) {
-      String fileSeparator = File.separator;
-      // In case of Windows the path should contain `\\` as the file separator (double slash since
-      // java escapes backslash). Replace `\\` with `\\\\` as the regex will eat one backslash.
-      fileSeparator =
-          fileSeparator.replaceAll(
-              Matcher.quoteReplacement("\\"), Matcher.quoteReplacement("\\\\"));
-      fileToBeVerified = fileToBeVerified.replaceAll("/", fileSeparator);
       Assert.assertTrue(javaFiles.contains(fileToBeVerified));
     }
   }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -93,8 +93,8 @@ public class DwhFiles {
    * <p>Windows OS:
    *
    * <ul>
-   *   <li>TestRoot\\SamplePrefix
-   *   <li>C:\\Users\\beam\\TestRoot\\SamplePrefix
+   *   <li>TestRoot\SamplePrefix
+   *   <li>C:\Users\beam\TestRoot\SamplePrefix
    * </ul>
    *
    * <p>GCS filesystem

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -15,15 +15,14 @@
  */
 package com.google.fhir.analytics;
 
+import static org.apache.beam.sdk.io.FileSystems.DEFAULT_SCHEME;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.DataFormatException;
 import com.cerner.bunsen.FhirContexts;
 import com.google.api.client.util.Sets;
 import com.google.common.base.Preconditions;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -31,12 +30,11 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
@@ -62,6 +60,9 @@ public class DwhFiles {
 
   private static final String INCREMENTAL_DIR = "incremental_run";
 
+  private static final Pattern FILE_SCHEME_PATTERN =
+      Pattern.compile("(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*):/.*");
+
   private final String dwhRoot;
 
   private final FhirContext fhirContext;
@@ -70,6 +71,33 @@ public class DwhFiles {
     this(dwhRoot, FhirContexts.forR4());
   }
 
+  /**
+   * In order to interpret the file paths correctly the {@code dwhRoot} has to represented in one of
+   * the below formats according to the filesystem platform:
+   *
+   * <p>Linux/Mac:
+   *
+   * <ul>
+   *   <li>TestRoot/SamplePrefix
+   *   <li>/Users/beam/TestRoot/SamplePrefix
+   * </ul>
+   *
+   * <p>Windows OS:
+   *
+   * <ul>
+   *   <li>TestRoot\\SamplePrefix
+   *   <li>C:\\Users\\beam\\TestRoot\\SamplePrefix
+   * </ul>
+   *
+   * <p>GCS filesystem
+   *
+   * <ul>
+   *   <li>gs://TestBucket/TestRoot/SamplePrefix
+   * </ul>
+   *
+   * @param dwhRoot
+   * @param fhirContext
+   */
   DwhFiles(String dwhRoot, FhirContext fhirContext) {
     Preconditions.checkNotNull(dwhRoot);
     this.dwhRoot = dwhRoot;
@@ -156,14 +184,10 @@ public class DwhFiles {
     //  response. This issue https://github.com/google/fhir-data-pipes/issues/288 helps in
     //  maintaining the number of file to an optimum value.
 
-    ResourceId childResourceId =
-        FileSystems.matchNewResource(dwhRoot, true)
-            .resolve("*/*", StandardResolveOptions.RESOLVE_FILE);
-
-    Set<String> fileSet = new HashSet<>();
+    String fileSeparator = getFileSeparatorForDwhFiles(dwhRoot);
     List<MatchResult> matchedChildResultList =
-        FileSystems.matchResources(Collections.singletonList(childResourceId));
-
+        FileSystems.match(Arrays.asList(dwhRoot + fileSeparator + "*" + fileSeparator + "*"));
+    Set<String> fileSet = new HashSet<>();
     for (MatchResult matchResult : matchedChildResultList) {
       if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
         for (Metadata metadata : matchResult.metadata()) {
@@ -197,12 +221,10 @@ public class DwhFiles {
    * @throws IOException
    */
   public void copyResourcesToDwh(String resourceType, DwhFiles destDwh) throws IOException {
-    ResourceId sourceFiles =
-        FileSystems.matchNewResource(getRoot(), true)
-            .resolve(resourceType, StandardResolveOptions.RESOLVE_DIRECTORY)
-            .resolve("*", StandardResolveOptions.RESOLVE_FILE);
-
-    List<MatchResult> sourceMatchResultList = FileSystems.matchResources(List.of(sourceFiles));
+    String fileSeparator = getFileSeparatorForDwhFiles(getRoot());
+    List<MatchResult> sourceMatchResultList =
+        FileSystems.match(
+            Arrays.asList(getRoot() + fileSeparator + resourceType + fileSeparator + "*"));
     List<ResourceId> sourceResourceIdList = new ArrayList<>();
 
     // The sourceMatchResultList should only contain 1 element as the matching list
@@ -313,6 +335,48 @@ public class DwhFiles {
               getRoot() + "/" + fileName, matchResult.status());
       log.error(errorMessage);
       throw new IOException(errorMessage);
+    }
+  }
+
+  /**
+   * This method returns the file separator for the filesystem where the data-warehouse is hosted.
+   *
+   * @param dwhRootPrefix the root directory prefix of the filesystem.
+   * @return the file separator
+   */
+  public static String getFileSeparatorForDwhFiles(String dwhRootPrefix) {
+    String scheme = parseScheme(dwhRootPrefix);
+    switch (scheme) {
+      case DEFAULT_SCHEME:
+        return File.separator;
+      case GcsPath.SCHEME:
+        return "/";
+      default:
+        String errorMessage = String.format("File system scheme=%s is not yet supported", scheme);
+        log.error(errorMessage);
+        throw new IllegalArgumentException(errorMessage);
+    }
+  }
+
+  /**
+   * This method returns the schema of the passed in spec. This is inspired from the parsing logic
+   * in the repo <a href="https://github.com/apache/beam">Beam File System</a>
+   *
+   * @param spec - the spec from which the schema needs to be parsed
+   * @return the schema
+   */
+  public static String parseScheme(String spec) {
+    // The spec is almost, but not quite, a URI. In particular,
+    // the reserved characters '[', ']', and '?' have meanings that differ
+    // from their use in the URI spec. ('*' is not reserved).
+    // Here, we just need the scheme, which is so circumscribed as to be
+    // very easy to extract with a regex.
+    Matcher matcher = FILE_SCHEME_PATTERN.matcher(spec);
+
+    if (!matcher.matches()) {
+      return DEFAULT_SCHEME;
+    } else {
+      return matcher.group("scheme").toLowerCase();
     }
   }
 }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,43 +103,26 @@ public class ParquetUtil {
    * @param parquetFilePath The directory under which the Parquet files are written.
    */
   public ParquetUtil(FhirVersionEnum fhirVersionEnum, String parquetFilePath) {
-    this(fhirVersionEnum, parquetFilePath, 0, 0, "", FileSystems.getDefault());
+    this(fhirVersionEnum, parquetFilePath, 0, 0, "");
   }
 
+  // TODO remove this constructor and only expose a similar one in `DwhFiles` (for testing).
   /**
-   * The preferred constructor for the streaming mode.
-   *
    * @param fhirVersionEnum This should match the resources intended to be converted.
    * @param parquetFilePath The directory under which the Parquet files are written.
    * @param secondsToFlush The interval after which the content of Parquet writers is flushed to
    *     disk.
    * @param rowGroupSize The approximate size of row-groups in the Parquet files (0 means use
    *     default).
+   * @param namePrefix The prefix directory at which the Parquet files are written
    */
-  public ParquetUtil(
-      FhirVersionEnum fhirVersionEnum,
-      String parquetFilePath,
-      int secondsToFlush,
-      int rowGroupSize,
-      String namePrefix) {
-    this(
-        fhirVersionEnum,
-        parquetFilePath,
-        secondsToFlush,
-        rowGroupSize,
-        namePrefix,
-        FileSystems.getDefault());
-  }
-
-  // TODO remove this constructor and only expose a similar one in `DwhFiles` (for testing).
   @VisibleForTesting
   ParquetUtil(
       FhirVersionEnum fhirVersionEnum,
       String parquetFilePath,
       int secondsToFlush,
       int rowGroupSize,
-      String namePrefix,
-      FileSystem fileSystem) {
+      String namePrefix) {
     if (fhirVersionEnum == FhirVersionEnum.DSTU3 || fhirVersionEnum == FhirVersionEnum.R4) {
       this.fhirContext = FhirContexts.contextFor(fhirVersionEnum);
     } else {
@@ -203,7 +184,6 @@ public class ParquetUtil {
   }
 
   private synchronized void createWriter(String resourceType) throws IOException {
-    // TODO: Find a way to convince Hadoop file operations to use `fileSystem` (needed for testing).
 
     ResourceId resourceId = getUniqueOutputFilePath(resourceType);
     WritableByteChannel writableByteChannel =

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/GcsDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/GcsDwhFilesTest.java
@@ -216,6 +216,12 @@ public class GcsDwhFilesTest {
     Mockito.verify(mockGcsUtil, Mockito.times(1)).open(GcsPath.fromUri(gcsFileName));
   }
 
+  @Test
+  public void dwhRootPrefixForGCSPath_returnsFileSeparator() {
+    String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles("gs://testbucket/testdirectory");
+    Assert.assertEquals("/", fileSeparator);
+  }
+
   private void mockFileRead(String gcsFileName, Instant instant) throws IOException {
     // Any request to open gets a new bogus channel
     Path tempPath = Files.createTempFile("timestamp", ".txt");

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
@@ -30,21 +30,40 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class LocalDwhFilesTest {
   @Test
-  public void getResourcePathTest() {
+  public void getResourcePathTestNonWindows() {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
     DwhFiles dwhFiles = new DwhFiles("/tmp", FhirContext.forR4Cached());
     assertThat(dwhFiles.getResourcePath("Patient").toString(), equalTo("/tmp/Patient/"));
   }
 
   @Test
-  public void newIncrementalRunPathTest() throws IOException {
+  public void getResourcePathTestWindows() {
+    Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+    DwhFiles dwhFiles = new DwhFiles("C:\\tmp", FhirContext.forR4Cached());
+    assertThat(dwhFiles.getResourcePath("Patient").toString(), equalTo("C:\\tmp\\Patient\\"));
+  }
+
+  @Test
+  public void newIncrementalRunPathTestNonWindows() throws IOException {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
     DwhFiles instance = new DwhFiles("/tmp", FhirContext.forR4Cached());
     ResourceId incrementalRunPath = instance.newIncrementalRunPath();
     assertThat(incrementalRunPath.toString(), equalTo("/tmp/incremental_run/"));
+  }
+
+  @Test
+  public void newIncrementalRunPathTesWindows() throws IOException {
+    Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+    DwhFiles instance = new DwhFiles("C:\\tmp", FhirContext.forR4Cached());
+    ResourceId incrementalRunPath = instance.newIncrementalRunPath();
+    assertThat(incrementalRunPath.toString(), equalTo("C:\\tmp\\incremental_run\\"));
   }
 
   @Test

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import ca.uhn.fhir.context.FhirContext;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
@@ -170,6 +171,30 @@ public class LocalDwhFilesTest {
 
     Files.delete(timestampPath);
     Files.delete(root);
+  }
+
+  @Test
+  public void passNonWindowsLocalPathDwhRootPrefix_returnsFileSeparator() {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    // Absolute Path
+    String fs1 = DwhFiles.getFileSeparatorForDwhFiles("/rootDir/prefix");
+    Assert.assertEquals(File.separator, fs1);
+    // Relative Path
+    String fs2 = DwhFiles.getFileSeparatorForDwhFiles("baseDir/prefix");
+    Assert.assertEquals(File.separator, fs2);
+  }
+
+  @Test
+  public void passWindowsLocalPathDwhRootPrefix_returnsFileSeparator() {
+    Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+    // Absolute Path
+    String fs1 = DwhFiles.getFileSeparatorForDwhFiles("C:\\prefix");
+    Assert.assertEquals(File.separator, fs1);
+    String fs2 = DwhFiles.getFileSeparatorForDwhFiles("C:\\rootDir\\prefix");
+    Assert.assertEquals(File.separator, fs2);
+    // Relative Path
+    String fs3 = DwhFiles.getFileSeparatorForDwhFiles("baseDir\\prefix");
+    Assert.assertEquals(File.separator, fs3);
   }
 
   private void createFile(Path path, byte[] bytes) throws IOException {

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -43,11 +43,12 @@ fhirdata:
   # Sample 1 : "/fhir-test-analytics/dwh/controller_DWH_ORIG"
   # Sample 2 : "dwh/controller_DWH_ORIG"
   #
-  # For Windows file systems, dwhRootPrefix must be of the format
-  # "<baseDirPath>\\<prefix>" and can be absolute or relative. <baseDirPath>
-  # is required for Windows, and must contain 1 or more directory names.
-  # Sample 1 : "C:\\fhir-test-analytics\\dwh\\controller_DWH_ORIG"
-  # Sample 2 : "dwh\\controller_DWH_ORIG"
+  # For Windows file systems, dwhRootPrefix must be of the format "<baseDirPath>\\<prefix>" and can
+  # be absolute or relative. In case of absolute the <baseDirPath> is non-mandatory and in case of
+  # relative it should contain mandatory <baseDirPath> with 1 or more directory names.
+  # Sample 1 : `C:\\controller_DWH_ORIG`
+  # Sample 1 : `C:\\fhir-test-analytics\\dwh\\controller_DWH_ORIG`
+  # Sample 2 : `dwh\\controller_DWH_ORIG`
   #
   # Note for developers: You can make a symlink of `[repo_root]/docker/dwh` here
   # such that the Thrift Server of `compose-controller-spark-sql-single.yaml`

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -40,7 +40,14 @@ fhirdata:
   # For *nix file systems, dwhRootPrefix must be of the format
   # "/<baseDirPath>/<prefix>" and can be absolute or relative. <baseDirPath>
   # is required for *nix, and must contain 1 or more directory names.
-  # dwhRootPrefix: "gs://fhir-test-analytics/config/controller_DWH_ORIG"
+  # Sample 1 : "/fhir-test-analytics/dwh/controller_DWH_ORIG"
+  # Sample 2 : "dwh/controller_DWH_ORIG"
+  #
+  # For Windows file systems, dwhRootPrefix must be of the format
+  # "<baseDirPath>\\<prefix>" and can be absolute or relative. <baseDirPath>
+  # is required for Windows, and must contain 1 or more directory names.
+  # Sample 1 : "C:\\fhir-test-analytics\\dwh\\controller_DWH_ORIG"
+  # Sample 2 : "dwh\\controller_DWH_ORIG"
   #
   # Note for developers: You can make a symlink of `[repo_root]/docker/dwh` here
   # such that the Thrift Server of `compose-controller-spark-sql-single.yaml`

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -43,12 +43,14 @@ fhirdata:
   # Sample 1 : "/fhir-test-analytics/dwh/controller_DWH_ORIG"
   # Sample 2 : "dwh/controller_DWH_ORIG"
   #
-  # For Windows file systems, dwhRootPrefix must be of the format "<baseDirPath>\\<prefix>" and can
+  # For Windows file systems, dwhRootPrefix must be of the format '<baseDirPath>\<prefix>' and can
   # be absolute or relative. In case of absolute the <baseDirPath> is non-mandatory and in case of
-  # relative it should contain mandatory <baseDirPath> with 1 or more directory names.
-  # Sample 1 : `C:\\controller_DWH_ORIG`
-  # Sample 1 : `C:\\fhir-test-analytics\\dwh\\controller_DWH_ORIG`
-  # Sample 2 : `dwh\\controller_DWH_ORIG`
+  # relative it should contain mandatory <baseDirPath> with 1 or more directory names. Use
+  # single-quotes or no-quotes for the value so that backslash character is treated as a regular
+  # character and not as an escaped character
+  # Sample 1 : 'C:\controller_DWH_ORIG'
+  # Sample 1 : 'C:\fhir-test-analytics\dwh\controller_DWH_ORIG'
+  # Sample 2 : dwh\controller_DWH_ORIG
   #
   # Note for developers: You can make a symlink of `[repo_root]/docker/dwh` here
   # such that the Thrift Server of `compose-controller-spark-sql-single.yaml`

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DwhFilesManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DwhFilesManager.java
@@ -345,9 +345,10 @@ public class DwhFilesManager {
    */
   Set<ResourceId> getAllChildDirectories(String baseDir) throws IOException {
     String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(baseDir);
-    // Do not use FileSystems.matchResources(..) as it internally uses Paths.get() which fails in
-    // Windows OS platform to resolve the files correctly when the glob expressions are present.
-    // Refer https://bugs.openjdk.org/browse/JDK-8197918 for details.
+    // Avoid using ResourceId.resolve(..) method to resolve the files when the path contains glob
+    // expressions with multiple special characters like **, */* etc as this api only supports
+    // single special characters like `*` or `..`. Rather use the FileSystems.match(..) if the path
+    // contains glob expressions.
     List<MatchResult> matchResultList =
         FileSystems.match(
             List.of(

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DwhFilesManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DwhFilesManager.java
@@ -15,7 +15,7 @@
  */
 package com.google.fhir.analytics;
 
-import static org.apache.beam.sdk.io.FileSystems.DEFAULT_SCHEME;
+import static com.google.fhir.analytics.DwhFiles.DEFAULT_SCHEME;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -30,8 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
@@ -69,9 +67,6 @@ public class DwhFilesManager {
   private String dwhRootPrefix;
 
   private int numOfDwhSnapshotsToRetain;
-
-  private static final Pattern WINDOWS_SCHEME_PATTERN =
-      Pattern.compile("(?<scheme>[a-zA-Z]):\\\\(?<path>.*)");
 
   private static final Logger logger = LoggerFactory.getLogger(DwhFilesManager.class.getName());
 
@@ -174,10 +169,12 @@ public class DwhFilesManager {
    * @throws IOException
    */
   private void deleteDirectoryAndFiles(ResourceId rootDirectory) throws IOException {
-
     String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(rootDirectory.toString());
     List<MatchResult> matchedFilesResultList =
-        FileSystems.match(Collections.singletonList(rootDirectory + fileSeparator + "**"));
+        FileSystems.match(
+            List.of(
+                DwhFiles.getPathEndingWithFileSeparator(rootDirectory.toString(), fileSeparator)
+                    + "**"));
 
     // Collect the matched files which also includes the files under the subdirectories, at the same
     // time collect the directories as well.
@@ -282,7 +279,7 @@ public class DwhFilesManager {
 
   /**
    * This method returns the base directory where the DWH snapshots needs to be created. This is
-   * determined by ignoring the prefix part in the given input format <baseDir></prefix> for the
+   * determined by ignoring the prefix part in the given input format <baseDir>/<prefix> for the
    * dwhRootPrefix
    *
    * @param dwhRootPrefix
@@ -303,7 +300,7 @@ public class DwhFilesManager {
   /**
    * This method returns the prefix name that needs to be applied to the DWH snapshot root folder
    * name. This is determined by considering the prefix part in the given input format
-   * <baseDir></prefix> for the dwhRootPrefix
+   * <baseDir>/<prefix> for the dwhRootPrefix
    *
    * @param dwhRootPrefix
    * @return the prefix name
@@ -352,7 +349,12 @@ public class DwhFilesManager {
     // Windows OS platform to resolve the files correctly when the glob expressions are present.
     // Refer https://bugs.openjdk.org/browse/JDK-8197918 for details.
     List<MatchResult> matchResultList =
-        FileSystems.match(Arrays.asList(baseDir + fileSeparator + "*" + fileSeparator + "*"));
+        FileSystems.match(
+            List.of(
+                DwhFiles.getPathEndingWithFileSeparator(baseDir, fileSeparator)
+                    + "*"
+                    + fileSeparator
+                    + "*"));
     Set<ResourceId> childDirectories = new HashSet<>();
     for (MatchResult matchResult : matchResultList) {
       if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
@@ -374,11 +376,7 @@ public class DwhFilesManager {
     int index = -1;
     switch (scheme) {
       case DEFAULT_SCHEME:
-        if (isSchemeWindows(dwhRootPrefix)) {
-          index = getLastIndexOfSlashInWindowsSpec(dwhRootPrefix);
-        } else {
-          index = dwhRootPrefix.lastIndexOf(File.separator);
-        }
+        index = dwhRootPrefix.lastIndexOf(File.separator);
         break;
       case GcsPath.SCHEME:
         // Fetch the last index position of the character '/' after the bucket name in the gcs path.
@@ -398,24 +396,6 @@ public class DwhFilesManager {
         String errorMessage = String.format("File system scheme=%s is not yet supported", scheme);
         logger.error(errorMessage);
         throw new IllegalArgumentException(errorMessage);
-    }
-    return index;
-  }
-
-  private boolean isSchemeWindows(String spec) {
-    return WINDOWS_SCHEME_PATTERN.matcher(spec).matches();
-  }
-
-  private int getLastIndexOfSlashInWindowsSpec(String spec) {
-    Matcher matcher = WINDOWS_SCHEME_PATTERN.matcher(spec);
-    if (!matcher.matches()) return -1;
-
-    String path = matcher.group("path");
-    if (Strings.isNullOrEmpty(path)) return -1;
-
-    int index = path.lastIndexOf("\\");
-    if (index != -1) {
-      index = spec.lastIndexOf(path) + index;
     }
     return index;
   }

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -476,8 +476,9 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         if (tokens.length > 1) {
           String timestamp = tokens[1];
           logger.info("Creating resource tables for relative path {}", path.getFilename());
+          String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(rootPrefix);
           List<String> existingResources =
-              dwhFilesManager.findExistingResources(baseDir + "/" + path.getFilename());
+              dwhFilesManager.findExistingResources(baseDir + fileSeparator + path.getFilename());
           hiveTableManager.createResourceAndCanonicalTables(
               existingResources, timestamp, path.getFilename());
         }
@@ -638,7 +639,8 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         String endTime = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_END).toString();
         dwhRunDetails.setEndTime(endTime);
       } else {
-        dwhRoot = dwhRoot.endsWith("/") ? dwhRoot : dwhRoot + "/";
+        String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(dwhRoot);
+        dwhRoot = dwhRoot.endsWith(fileSeparator) ? dwhRoot : dwhRoot + fileSeparator;
         dwhRunDetails.setLogFilePath(dwhRoot + ERROR_FILE_NAME);
       }
       dwhRunDetails.setStatus(status);

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/LocalDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/LocalDwhFilesManagerTest.java
@@ -142,29 +142,26 @@ public class LocalDwhFilesManagerTest {
   @Test
   public void testBaseDirForWindows() {
     assumeTrue(SystemUtils.IS_OS_WINDOWS);
-    String baseDir1 = dwhFilesManager.getBaseDir("C:\\root\\prefix");
-    assertThat(baseDir1, equalTo("C:\\root"));
+    String baseDir1 = dwhFilesManager.getBaseDir("C:\\prefix");
+    assertThat(baseDir1, equalTo("C\\"));
 
-    String baseDir2 = dwhFilesManager.getBaseDir("C:\\root\\child\\prefix");
-    assertThat(baseDir2, equalTo("C:\\root\\child"));
+    String baseDir2 = dwhFilesManager.getBaseDir("C:\\root\\prefix");
+    assertThat(baseDir2, equalTo("C:\\root"));
 
-    String baseDir3 = dwhFilesManager.getBaseDir("nonRoot\\prefix");
-    assertThat(baseDir3, equalTo("nonRoot"));
+    String baseDir3 = dwhFilesManager.getBaseDir("C:\\root\\child\\prefix");
+    assertThat(baseDir3, equalTo("C:\\root\\child"));
 
-    String baseDir4 = dwhFilesManager.getBaseDir("nonRoot\\child\\prefix");
-    assertThat(baseDir4, equalTo("nonRoot\\child"));
+    String baseDir4 = dwhFilesManager.getBaseDir("nonRoot\\prefix");
+    assertThat(baseDir4, equalTo("nonRoot"));
+
+    String baseDir5 = dwhFilesManager.getBaseDir("nonRoot\\child\\prefix");
+    assertThat(baseDir5, equalTo("nonRoot\\child"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testBaseDirForInvalidPathNonWindows() {
     assumeFalse(SystemUtils.IS_OS_WINDOWS);
     dwhFilesManager.getBaseDir("/root");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testBaseDirForInvalidPathWindows() {
-    assumeTrue(SystemUtils.IS_OS_WINDOWS);
-    dwhFilesManager.getBaseDir("C:\\root");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -190,30 +187,26 @@ public class LocalDwhFilesManagerTest {
 
   public void testPrefixForWindows() {
     assumeTrue(SystemUtils.IS_OS_WINDOWS);
-
-    String prefix1 = dwhFilesManager.getPrefix("C:\\root\\prefix");
+    String prefix1 = dwhFilesManager.getBaseDir("C:\\prefix");
     assertThat(prefix1, equalTo("prefix"));
 
-    String prefix2 = dwhFilesManager.getPrefix("C:\\root\\child\\prefix");
+    String prefix2 = dwhFilesManager.getPrefix("C:\\root\\prefix");
     assertThat(prefix2, equalTo("prefix"));
 
-    String prefix3 = dwhFilesManager.getPrefix("nonRoot\\prefix");
+    String prefix3 = dwhFilesManager.getPrefix("C:\\root\\child\\prefix");
     assertThat(prefix3, equalTo("prefix"));
 
-    String prefix4 = dwhFilesManager.getPrefix("nonRoot\\child\\prefix");
+    String prefix4 = dwhFilesManager.getPrefix("nonRoot\\prefix");
     assertThat(prefix4, equalTo("prefix"));
+
+    String prefix5 = dwhFilesManager.getPrefix("nonRoot\\child\\prefix");
+    assertThat(prefix5, equalTo("prefix"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrefixForInvalidPathNonWindows() {
     assumeFalse(SystemUtils.IS_OS_WINDOWS);
     dwhFilesManager.getPrefix("/prefix");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testPrefixForInvalidPathWindows() {
-    assumeTrue(SystemUtils.IS_OS_WINDOWS);
-    dwhFilesManager.getPrefix("C:\\prefix");
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/pipelines/controller/src/test/resources/application-test.properties
+++ b/pipelines/controller/src/test/resources/application-test.properties
@@ -17,6 +17,9 @@
 fhirdata.fhirServerUrl=http://localhost:9091/fhir
 fhirdata.incrementalSchedule=0 0 * * * *
 fhirdata.resourceList=Patient,Encounter,Observation
+# For Windows platform the file separator is a backslash(\) and the Properties.load(..) method
+# treats backslash as an escape character. So use two backslashes in the path for Windows.
+# fhirdata.dwhRootPrefix=config\\controller_DWH_TEST
 fhirdata.dwhRootPrefix=config/controller_DWH_TEST
 fhirdata.purgeSchedule=0 30 * * * *
 fhirdata.numOfDwhSnapshotsToRetain=3


### PR DESCRIPTION
## Description of what I changed

Fixes #843 

In Windows platform usage of [ResourceId.resolve(..)](https://github.com/apache/beam/blob/6a2db44c41051e7ceee03225021bfeb4e0c2442f/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceId.java#L85) method to resolve paths with glob expressions (containing multiple special characters like `**`, `*/*` etc) is leading to the error `java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/...`. This is because it internally uses `Paths.get()` which fails in Windows OS platform to resolve the paths correctly. Refer https://bugs.openjdk.org/browse/JDK-8197918 for details. Also, the documentation of this api [ResourceId.resolve(..)](https://github.com/apache/beam/blob/6a2db44c41051e7ceee03225021bfeb4e0c2442f/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceId.java#L85) does not talk about the support for glob expressions in general. Its best to avoid using this api for resolving paths containing multiple special characters.

As a fix, Instead of creating `ResourceId` to match for files, we can create `string path specs` with glob expressions and use this api [FileSystems.match(..)](https://github.com/apache/beam/blob/6a2db44c41051e7ceee03225021bfeb4e0c2442f/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java#L124) to match the files, which documents about the support for glob expressions as well.

Unsolved: There are `2` warnings which are being reported when the pipelines are being executed in Windows platform, the details are documented here #869.

## E2E test

Tested the `Full run` and `Incremental Runs` in Windows platform.
Tested the `Full` and `Incremental` runs for GCS File System on Unix platform.

TESTED:

Regression tests on Unix platform for `Full` and `Incremental` runs.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
