### PR TITLE
Generate `flink-conf.yaml` file automatically to set optimum conf values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ COPY --from=build /app/pipelines/controller/target/controller-bundled.jar .
 
 COPY ./docker/config ./config
 
-# Flink will read the flink-conf.yaml file from this directory.
+# Flink will read the flink-conf.yaml file from this directory if the auto generation of flink
+# configuration is disabled
 ENV FLINK_CONF_DIR=/app/config
 
 COPY docker-entrypoint.sh /

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,7 +42,12 @@ enable_jemalloc() {
 
 enable_jemalloc
 
+if [[ -z "$JAVA_OPTS" ]]; then
+  echo "JAVA_OPTS is empty, initialising with default values"
+  JAVA_OPTS="-Xms2g -Xmx2g"
+fi
+
 # The -Xmx value is to make sure there is a minimum amount of memory; it can be
 # increased if more memory is available and is desired to be used by pipelines.
 # Note this is related to the memory config in flink-conf.yaml too.
-java -Xms2g -Xmx2g -jar /app/controller-bundled.jar
+java $JAVA_OPTS -jar /app/controller-bundled.jar

--- a/docker/.env
+++ b/docker/.env
@@ -21,3 +21,6 @@ DWH_ROOT=./dwh
 # This is for openmrs-compose.yaml; for big data dump set `big`, for small
 # data dump set `small`, which is the default mode.
 DATABASE_DUMP_MODE=small
+
+# JVM parameters to be used by the application
+JAVA_OPTS=-Xms2g -Xmx2g

--- a/docker/compose-controller-spark-sql-released.yaml
+++ b/docker/compose-controller-spark-sql-released.yaml
@@ -59,6 +59,8 @@ services:
     volumes:
       - ${PIPELINE_CONFIG}:/app/config:ro
       - ${DWH_ROOT}:/dwh
+    environment:
+      - JAVA_OPTS=$JAVA_OPTS
     ports:
       - '8090:8080'
     networks:

--- a/docker/compose-controller-spark-sql-single.yaml
+++ b/docker/compose-controller-spark-sql-single.yaml
@@ -60,6 +60,8 @@ services:
     volumes:
       - ${PIPELINE_CONFIG}:/app/config:ro
       - ${DWH_ROOT}:/dwh
+    environment:
+      - JAVA_OPTS=$JAVA_OPTS
     ports:
       - '8090:8080'
     networks:

--- a/docker/compose-controller-spark-sql.yaml
+++ b/docker/compose-controller-spark-sql.yaml
@@ -71,6 +71,8 @@ services:
     volumes:
       - ${PIPELINE_CONFIG}:/app/config:ro
       - ${DWH_ROOT}:/dwh
+    environment:
+      - JAVA_OPTS=$JAVA_OPTS
     ports:
       - '8090:8080'
     networks:

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -34,6 +34,7 @@ fhirdata:
   resourceList: "Patient,Encounter,Observation,Questionnaire,Condition,Practitioner,Location,Organization"
   maxWorkers: 1
   numThreads: -1
+  autoGenerateFlinkConfiguration: true
   createHiveResourceTables: true
   thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   hiveResourceViewsDir: "config/views"

--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -14,8 +14,8 @@
 
 FROM maven:3.8.7-eclipse-temurin-17-focal
 
-RUN apt-get update && apt-get install -y jq  python3.7 python3-pip 
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+RUN apt-get update && apt-get install -y jq  python3.8 python3-pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 RUN pip3 install virtualenv google-auth requests
 
 COPY pipeline_validation.sh pipeline_validation.sh

--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM adoptopenjdk/maven-openjdk11
+FROM maven:3.8.7-eclipse-temurin-17-focal
 
 RUN apt-get update && apt-get install -y jq  python3.7 python3-pip 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -71,7 +71,7 @@ public class ParquetMerger {
   private static PCollection<KV<String, Iterable<GenericRecord>>> readAndGroupById(
       Pipeline pipeline, List<DwhFiles> dwhFilesList, String resourceType) {
 
-    // Reading all parquet files at once instead of one at a time, reduces the number of Flink
+    // Reading all parquet files at once instead of one set at a time, reduces the number of Flink
     // reshuffle operations by one.
     PCollection<ReadableFile> inputFiles =
         pipeline

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -64,9 +64,15 @@ public class ParquetMerger {
   private static String SYSTEM_KEY = "system";
   private static String CODE_KEY = "code";
 
+  /**
+   * This method reads all the Parquet files under the paths {@code dwhFilesList} for the given
+   * {@code resourceType}. It then groups the records by ID key and returns the grouped PCollection.
+   */
   private static PCollection<KV<String, Iterable<GenericRecord>>> readAndGroupById(
       Pipeline pipeline, List<DwhFiles> dwhFilesList, String resourceType) {
 
+    // Reading all parquet files at once instead of one at a time, reduces the number of Flink
+    // reshuffle operations by one.
     PCollection<ReadableFile> inputFiles =
         pipeline
             .apply(Create.of(getParquetFilePaths(resourceType, dwhFilesList)))

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -105,6 +105,13 @@ fhirdata:
   # Otherwise, the number of threads is equal to the number of cores.
   numThreads: -1
 
+  # Generate Flink configuration file `flink-conf.yaml` automatically based on the parallelism set
+  # via the parameter `numThreads` and the `cores` available in the machine. The generated file will
+  # have the parameters set with optimised values necessary to run the pipelines without fail.
+  # Disable this parameter to manually pass the configuration file by pointing the environment
+  # variable FLINK_CONF_DIR to the directory where the flink-conf.yaml is placed.
+  autoGenerateFlinkConfiguration: true
+
   # Whether resource tables should be automatically created on a
   # Hive/Spark server. Primarily meant for single-machine deployment.
   createHiveResourceTables: false

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -105,11 +105,15 @@ fhirdata:
   # Otherwise, the number of threads is equal to the number of cores.
   numThreads: -1
 
-  # Generate Flink configuration file `flink-conf.yaml` automatically based on the parallelism set
-  # via the parameter `numThreads` and the `cores` available in the machine. The generated file will
-  # have the parameters set with optimised values necessary to run the pipelines without fail.
-  # Disable this parameter to manually pass the configuration file by pointing the environment
-  # variable FLINK_CONF_DIR to the directory where the flink-conf.yaml is placed.
+  # In case of Flink local execution mode (which is the default currently), generate Flink
+  # configuration file `flink-conf.yaml` automatically based on the parallelism set via the
+  # parameter `numThreads` and the `cores` available in the machine. The generated file will have
+  # the parameters set with optimised values necessary to run the pipelines without fail. Disable
+  # this parameter to manually pass the configuration file by pointing the environment variable
+  # FLINK_CONF_DIR to the directory where the flink-conf.yaml is placed.
+  #
+  # Note for Flink non-local execution mode, this parameter has to be disabled and the configuration
+  # file has to be passed manually which has more fine-grained control parameters
   autoGenerateFlinkConfiguration: true
 
   # Whether resource tables should be automatically created on a

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -215,8 +215,9 @@
               <archive>
                 <manifestEntries>
                   <!-- These options enable access to all methods in the mentioned packages at
-                  compile and runtime. These options are added as MANIFEST entries in the bundled
-                  jar  -->
+                  compile and runtime. These are added as MANIFEST entries in the bundled jar. These
+                  had to be enabled specifically for accessing the
+                  `jdk.internal.misc.VM.maxDirectMemory()` API -->
                   <Add-Exports>java.base/jdk.internal.misc</Add-Exports>
                   <Add-Opens>java.base/jdk.internal.misc=ALL-UNNAMED</Add-Opens>
                 </manifestEntries>

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -201,6 +201,30 @@
         </executions>
 
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <!-- These options enable access to all methods in the mentioned packages at
+                  compile and runtime. These options are added as MANIFEST entries in the bundled
+                  jar  -->
+                  <Add-Exports>java.base/jdk.internal.misc</Add-Exports>
+                  <Add-Opens>java.base/jdk.internal.misc=ALL-UNNAMED</Add-Opens>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -93,6 +93,8 @@ public class DataProperties {
 
   private String fhirServerUserName;
 
+  private boolean autoGenerateFlinkConfiguration;
+
   private String fhirServerOAuthTokenEndpoint;
 
   private String fhirServerOAuthClientId;

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -41,10 +41,24 @@ public class FlinkConfiguration {
   private static final Logger logger = LoggerFactory.getLogger(FlinkConfiguration.class.getName());
   static final String TEMP_FLINK_CONF_DIR = "tmp-flink-conf";
 
-  // This value is arrived based on the maximum number of reshuffle/partition operations that can
-  // occur in the pipelines. This has to be updated if any modifications are made to the pipelines
-  // that impact the reshuffle/partition operations.
+  /**
+   * This value is arrived based on the maximum number of reshuffle/partition operations that can
+   * occur in the pipelines. This has to be updated if any modifications are made to the pipelines
+   * that impact the reshuffle/partition operations.
+   *
+   * <p>Currently, for incremental run a maximum of 7 reshuffle/partition operations take place.
+   *
+   * <ul>
+   *   <li>2 reshuffle operations for matching and reading from Parquet files
+   *   <li>1 reshuffle operation for GroupByKey
+   *   <li>4 reshuffle operations for writing back to new parquet files (some kind of map-reduce
+   *       logic is used).
+   * </ul>
+   *
+   * <p>An extra number is allocated as a buffer
+   */
   static final int NUMBER_OF_RESHUFFLES = 8;
+
   private static final int DEFAULT_PARALLELISM = Runtime.getRuntime().availableProcessors();
   static final String DEFAULT_MANAGED_MEMORY_SIZE = "256mb";
   private static final String KEY_VALUE_FORMAT = "%s: %s";

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import com.google.common.base.Strings;
+import com.google.fhir.analytics.metrics.FlinkJobListener;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.FileSystemUtils;
+
+/** This class is responsible for the generation and validation of Flink configuration file. */
+public class FlinkConfiguration {
+
+  private static final Logger logger = LoggerFactory.getLogger(FlinkConfiguration.class.getName());
+  static final String TEMP_FLINK_CONF_DIR = "tmp-flink-conf";
+
+  // This value is arrived based on the maximum number of reshuffle/partition operations that can
+  // occur in the pipelines. This has to be updated if any modifications are made to the pipelines
+  // that impact the reshuffle/partition operations.
+  static final int NUMBER_OF_RESHUFFLES = 8;
+  private static final int DEFAULT_PARALLELISM = Runtime.getRuntime().availableProcessors();
+  static final String DEFAULT_MANAGED_MEMORY_SIZE = "256mb";
+  private static final String KEY_VALUE_FORMAT = "%s: %s";
+  private String flinkConfDir;
+
+  public String getFlinkConfDir() {
+    return flinkConfDir;
+  }
+
+  /**
+   * This method auto-generates/validates the flink-conf.yaml file. The auto generated file contains
+   * parameter values which are optimised for the pipelines to run without fail. In case of
+   * auto-generated file, the file is placed in a temporary directory and will be deleted once the
+   * application is stopped.
+   *
+   * <p>In particular the task manager network buffer size for each pipeline is inspired from this
+   * <a
+   * href="https://nightlies.apache.org/flink/flink-docs-release-1.8/ops/config.html#configuring-the-network-buffers">link</a>
+   *
+   * <p>This method also fails fast if the generated/passed flink configuration values might result
+   * in failure based on the JVM Heap memory values.
+   *
+   * @param dataProperties the application properties
+   * @throws IOException
+   */
+  void initialiseFlinkConfiguration(DataProperties dataProperties) throws IOException {
+    if (dataProperties.isAutoGenerateFlinkConfiguration()) {
+      Path confPath = Files.createTempDirectory(TEMP_FLINK_CONF_DIR);
+      logger.info("Creating Flink temporary configuration directory at {}", confPath);
+      Path filePath = Paths.get(confPath.toString(), GlobalConfiguration.FLINK_CONF_FILENAME);
+      validateAndCreateConfFile(filePath, dataProperties);
+      this.flinkConfDir = confPath.toString();
+      deleteFilesRecursivelyOnExit(confPath);
+    } else {
+      String envFlinkConfDir = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
+      Configuration configuration;
+      if (Strings.isNullOrEmpty(envFlinkConfDir)) {
+        logger.warn(
+            "The environment variable {} is not set, hence default flink configuration will"
+                + " be used.",
+            ConfigConstants.ENV_FLINK_CONF_DIR);
+        configuration = GlobalConfiguration.loadConfiguration();
+      } else {
+        logger.info(
+            "Flink configuration will be initialised from the directory at {}", envFlinkConfDir);
+        configuration = GlobalConfiguration.loadConfiguration(envFlinkConfDir);
+      }
+      configuration = TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
+      validateDirectMemoryMax(
+          configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX).getBytes(),
+          configuration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE).getBytes());
+    }
+  }
+
+  private void validateAndCreateConfFile(Path filePath, DataProperties dataProperties)
+      throws IOException {
+    long networkMemoryMax = calculateNetworkMemoryMax(dataProperties);
+    validateDirectMemoryMax(networkMemoryMax, MemorySize.parseBytes(DEFAULT_MANAGED_MEMORY_SIZE));
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toString()))) {
+      logger.info("Network memory : {}", networkMemoryMax);
+      writer.write(
+          String.format(
+              KEY_VALUE_FORMAT, TaskManagerOptions.NETWORK_MEMORY_MAX.key(), networkMemoryMax));
+      writer.newLine();
+      writer.write(
+          String.format(
+              KEY_VALUE_FORMAT,
+              TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+              DEFAULT_MANAGED_MEMORY_SIZE));
+      writer.newLine();
+      writer.write(
+          String.format(KEY_VALUE_FORMAT, DeploymentOptions.ATTACHED.key(), Boolean.FALSE));
+      writer.newLine();
+      writer.write(
+          String.format(
+              KEY_VALUE_FORMAT,
+              DeploymentOptions.JOB_LISTENERS.key(),
+              FlinkJobListener.class.getName()));
+    }
+  }
+
+  private void validateDirectMemoryMax(long networkMemoryInBytes, long managedMemoryInBytes) {
+    long totalDirectMemory = networkMemoryInBytes + managedMemoryInBytes;
+    long totalDirectMemoryOfAllParallelPipelines =
+        totalDirectMemory * EtlUtils.NO_OF_PARALLEL_PIPELINES;
+
+    long jvmMaxDirectMemory = jdk.internal.misc.VM.maxDirectMemory();
+    if (jvmMaxDirectMemory <= totalDirectMemoryOfAllParallelPipelines) {
+      String errorMessage =
+          String.format(
+              "Total Flink Off-Heap Memory param values should be less than the JVM Maximum Direct"
+                  + " Memory. JVM maxDirectMemory=%s bytes, Total Flink Off-Heap Memory=%s bytes",
+              jvmMaxDirectMemory, totalDirectMemoryOfAllParallelPipelines);
+      logger.error(errorMessage);
+      throw new IllegalConfigurationException(errorMessage);
+    }
+  }
+
+  private long calculateNetworkMemoryMax(DataProperties dataProperties) {
+    int parallelism =
+        dataProperties.getNumThreads() > 0 ? dataProperties.getNumThreads() : DEFAULT_PARALLELISM;
+    int numOfNetworkBuffers = (int) Math.pow(parallelism + 1, 2) * NUMBER_OF_RESHUFFLES;
+    return numOfNetworkBuffers * TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes();
+  }
+
+  private void deleteFilesRecursivelyOnExit(Path path) {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    FileSystemUtils.deleteRecursively(path);
+                  } catch (IOException e) {
+                    logger.warn(
+                        "Error occurred while deleting the files recursively for the path {}",
+                        path.toString());
+                  }
+                }));
+  }
+}

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.google.fhir.analytics;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.fhir.analytics.metrics.FlinkJobListener;
 import java.io.BufferedWriter;
@@ -85,6 +86,13 @@ public class FlinkConfiguration {
    * @throws IOException
    */
   void initialiseFlinkConfiguration(DataProperties dataProperties) throws IOException {
+    boolean isFlinkModelLocal = isFlinkModeLocal(dataProperties);
+    Preconditions.checkState(
+        isFlinkModelLocal || !dataProperties.isAutoGenerateFlinkConfiguration(),
+        "Auto-generation of Flink configuration is only applicable for Local execution mode");
+    // Do not generate or validate the Flink configuration in case of non-local mode
+    if (!isFlinkModelLocal) return;
+
     if (dataProperties.isAutoGenerateFlinkConfiguration()) {
       Path confPath = Files.createTempDirectory(TEMP_FLINK_CONF_DIR);
       logger.info("Creating Flink temporary configuration directory at {}", confPath);
@@ -177,5 +185,11 @@ public class FlinkConfiguration {
                         path.toString());
                   }
                 }));
+  }
+
+  private boolean isFlinkModeLocal(DataProperties dataProperties) {
+    // TODO: Enable the pipeline for Flink non-local modes as well
+    // https://github.com/google/fhir-data-pipes/issues/893
+    return true;
   }
 }

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import static com.google.fhir.analytics.FlinkConfiguration.DEFAULT_MANAGED_MEMORY_SIZE;
+import static com.google.fhir.analytics.FlinkConfiguration.NUMBER_OF_RESHUFFLES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FlinkConfigurationTest {
+
+  @ParameterizedTest
+  @MethodSource("provideFlinkParams")
+  public void testConfigurations(int numThreads, long expectedNetworkMemory) throws IOException {
+    DataProperties dataProperties = new DataProperties();
+    dataProperties.setAutoGenerateFlinkConfiguration(true);
+    dataProperties.setNumThreads(numThreads);
+    FlinkConfiguration flinkConfiguration = new FlinkConfiguration();
+    flinkConfiguration.initialiseFlinkConfiguration(dataProperties);
+
+    assertThat(
+        Files.exists(
+            Paths.get(
+                flinkConfiguration.getFlinkConfDir(), GlobalConfiguration.FLINK_CONF_FILENAME)),
+        equalTo(Boolean.TRUE));
+    Configuration configuration =
+        GlobalConfiguration.loadConfiguration(flinkConfiguration.getFlinkConfDir());
+    assertThat(
+        configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX).getBytes(),
+        equalTo(expectedNetworkMemory));
+    assertThat(
+        configuration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE).getBytes(),
+        equalTo(MemorySize.parseBytes(DEFAULT_MANAGED_MEMORY_SIZE)));
+  }
+
+  private static Stream<Arguments> provideFlinkParams() {
+    return Stream.of(
+        // The percentage completion is rounded off to next highest integer
+        Arguments.of(2, getNetworkMemory(2)), Arguments.of(2, getNetworkMemory(2)));
+  }
+
+  private static long getNetworkMemory(int numThreads) {
+    return (int) (Math.pow((numThreads + 1), 2))
+        * NUMBER_OF_RESHUFFLES
+        * TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes();
+  }
+}

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -304,7 +304,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>11</release>
+          <source>17</source>
+          <target>17</target>
+          <compilerArgs>
+            <!-- Enable access to the packages at compile time -->
+            <arg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Enable access to the packages at run time -->
+          <argLine>--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/pipelines/streaming/Dockerfile
+++ b/pipelines/streaming/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM adoptopenjdk/maven-openjdk11
+FROM maven:3.8.7-eclipse-temurin-17-focal
 
 ARG WORK_DIR="/usr/src/Main"
 COPY target/streaming-bundled.jar ${WORK_DIR}/app.jar


### PR DESCRIPTION
## Description of what I changed

Fixes #823 
- Enabled a feature flag to automate the generation of `flink-conf.yaml` based on the `numThreads` in `application.yaml` file and the number of `cores` available in the machine.
- If the flag is disabled, then the `flink-conf.yaml` directed by the env. var `FLINK_CONF_DIR` will be used. If var is empty, then default conf will be used.
- JAVA_OPTS can be set to override the default JVM heap and other parameter values.
-  The application will fail to launch if the JVM Off Heap memory is insufficient for the Flink cluster to launch.
- Fixes the regression introduced by this [change](https://github.com/google/fhir-data-pipes/pull/670) where the maxWorkers was defaulted to 1 and in turn the num of shards for parquet files was also 1.

## E2E test

Tested `Full Run` and `Incremental Run` by enabling and disabling the flags. Also tested for different `numThread` configurations.

TESTED:

Load tested the application on a 48 core machine. Given below are the results

Run # | Run Type | # of Patient Records | Time in secs (Before Change) | Time in secs (After Change) | Remarks
-- | -- | -- | -- | -- | --
1 | Full | 9K | 400 | 358 | Full run timing remains the same before and after the changes
2 | Full (Repeat) | 9K | 360 | 256 |  
3 | Incremental | 9K Upfront + 100 additional | 140 | 30 | The improvement in time after change is because of fixing the regression (increased num of shards from 1 to N)
4 | Incremental | 9K Upfront + 500 additional | 180 | 32 |  

After fixing the regression the time taken for incremental run has significantly reduced

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
