### PR TITLE
added views to the controller and a fast recreate option

### DIFF
--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -20,6 +20,7 @@ import com.cerner.bunsen.definitions.StringConverter;
 import com.cerner.bunsen.definitions.StructureField;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -88,8 +89,27 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
   // Avro `decimal` type  has a fixed scale and a maximum precision but with a fixed scale we have
   // no guarantees on the precision of the FHIR `decimal` type. See this for more details:
   // https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/issues/156#issuecomment-880964207
+  // On the other hand, when we convert Avro records back to HAPI objects, we need to convert
+  // `Double` values to `BigDecimal `because that's the Java type HAPI uses for `decimal` type of
+  // FHIR (Double and BigDecimal are not assignable to each other hence explicit conversions).
+  // Note with this approach we are loosing some precision!
   private static final HapiConverter<Schema> DOUBLE_CONVERTER =
       new PrimitiveConverter<Schema>("Double") {
+        @Override
+        public void toHapi(Object input, IPrimitiveType primitive) {
+          Preconditions.checkArgument((input instanceof BigDecimal) || (input instanceof Double));
+          if (input instanceof Double) {
+            primitive.setValue(BigDecimal.valueOf((Double) input));
+          } else {
+            primitive.setValue(input);
+          }
+        }
+
+        protected Object fromHapi(IPrimitiveType primitive) {
+          Object value = primitive.getValue();
+          Preconditions.checkState(value instanceof BigDecimal);
+          return ((BigDecimal) value).doubleValue();
+        }
 
         @Override
         public Schema getDataType() {

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -95,6 +95,10 @@ public class R4AvroConverterTest {
   @BeforeClass
   public static void convertTestData() throws IOException {
 
+    // TODO update these conversions to actually use the wire/binary format, i.e., create
+    //  the wire format from the Avro object then re-read/convert that format back to an
+    //  Avro object before converting back to a HAPI object. That way we make sure that
+    //  if the Avro object is serialized to disk, it is still convertible back to HAPI objects.
     AvroConverter observationConverter =
         AvroConverter.forResource(FhirContexts.forR4(), "Observation");
 
@@ -160,8 +164,9 @@ public class R4AvroConverterTest {
 
     // Decode the Avro decimal to ensure the expected value is there.
     BigDecimal avroDecimal =
-        (BigDecimal)
-            ((Record) ((Record) avroObservation.get("value")).get("quantity")).get("value");
+        BigDecimal.valueOf(
+            (Double)
+                ((Record) ((Record) avroObservation.get("value")).get("quantity")).get("value"));
 
     Assert.assertEquals(originalDecimal.compareTo(avroDecimal), 0);
 

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterTest.java
@@ -96,7 +96,7 @@ public class R4AvroConverterTest {
   public static void convertTestData() throws IOException {
 
     // TODO update these conversions to actually use the wire/binary format, i.e., create
-    //  the wire format from the Avro object then re-read/convert that format back to an
+    //  the serialized format from the Avro object then re-read/convert that format back to an
     //  Avro object before converting back to a HAPI object. That way we make sure that
     //  if the Avro object is serialized to disk, it is still convertible back to HAPI objects.
     AvroConverter observationConverter =

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterTest.java
@@ -156,8 +156,9 @@ public class Stu3AvroConverterTest {
 
     // Decode the Avro decimal to ensure the expected value is there.
     BigDecimal avroDecimal =
-        (BigDecimal)
-            ((Record) ((Record) avroObservation.get("value")).get("quantity")).get("value");
+        BigDecimal.valueOf(
+            (Double)
+                ((Record) ((Record) avroObservation.get("value")).get("quantity")).get("value"));
 
     Assert.assertEquals(originalDecimal.compareTo(avroDecimal), 0);
 

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/EnumConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/EnumConverter.java
@@ -17,7 +17,10 @@ public class EnumConverter<T> extends StringConverter<T> {
       input = null;
     }
 
-    primitive.setValueAsString((String) input);
+    // We can't assume the type is necessarily `String` for Avro `string`
+    // types; it can be Utf8 too, see:
+    // https://github.com/apache/parquet-mr/commit/918609f2cc4e4de95445ce4fdd7dc952b9625017
+    primitive.setValueAsString(input.toString());
   }
 
   @Override

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StringConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StringConverter.java
@@ -13,7 +13,13 @@ public class StringConverter<T> extends PrimitiveConverter<T> {
 
   @Override
   public void toHapi(Object input, IPrimitiveType primitive) {
-    primitive.setValueAsString((String) input);
+    // Note we cannot simply cast `input` to `String` because the type used
+    // is not necessarily String when reading the Avro record with a `string`
+    // field; it can be Utf8, and it is controlled by `avro.java.string` field
+    // type property in the schema, see:
+    // https://github.com/apache/parquet-mr/commit/918609f2cc4e4de95445ce4fdd7dc952b9625017
+    // https://github.com/apache/parquet-mr/blob/8264d8b2329f6e7a9ad900e2f9d32abee80f29ff/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java#L410
+    primitive.setValueAsString(input.toString());
   }
 
   @Override

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -120,6 +120,15 @@ steps:
     - PARQUET_SUBDIR=JDBC_HAPI
     - DOCKER_NETWORK=--use_docker_network
 
+# The `views` database is used for creating flat views from ViewDefinitions.
+- name: 'postgres'
+  id: 'Create views database'
+  entrypoint: psql
+  env:
+  - PGPASSWORD=admin
+  args: [ '-U', 'admin', '-d', 'postgres', '-h', 'hapi-fhir-db', '-p', '5432',
+          '-c', 'CREATE DATABASE views;']
+
 - name: 'docker/compose'
   id: 'Bring up controller and Spark containers'
   env:
@@ -130,6 +139,16 @@ steps:
 
 - name: '${_REPOSITORY}/e2e-tests/controller-spark:${_TAG}'
   id: 'Run E2E Test for Dockerized Controller and Spark Thriftserver'
+
+# The controller logs don't appear in Cloud Build output because we run it in
+# the detached mode. For debugging controller failures we can use something like
+#  the following (and forcing the previous step to have 0 exit code).
+# - name: 'gcr.io/cloud-builders/docker'
+#   id: 'PRINT CONTROLLER LOGS'
+#   entrypoint: /bin/bash
+#   args:
+#   - -c
+#   - docker logs pipeline-controller
 
 - name: 'docker/compose'
   id: 'Bring down controller and Spark containers'

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -38,6 +38,9 @@ fhirdata:
   createHiveResourceTables: true
   thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   hiveResourceViewsDir: "config/views"
+  viewDefinitionsDir: "config/views"
+  sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
+
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/docker/config/hapi-postgres-config_local_views.json
+++ b/docker/config/hapi-postgres-config_local_views.json
@@ -1,0 +1,9 @@
+{
+  "jdbcDriverClass": "org.postgresql.Driver",
+  "databaseService" : "postgresql",
+  "databaseHostName" : "hapi-fhir-db",
+  "databasePort" : "5432",
+  "databaseUser" : "admin",
+  "databasePassword" : "admin",
+  "databaseName" : "views"
+}

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -242,6 +242,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
         if (bundle.getEntry() == null) {
           return;
         }
+        // TODO consider processing the whole Bundle in one batched DB update.
         for (BundleEntryComponent entry : bundle.getEntry()) {
           Resource resource = entry.getResource();
           if (resourceTypes == null || resourceTypes.contains(resource.getResourceType().name())) {

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -287,7 +287,7 @@ public class FhirEtl {
       if (options.getFhirServerUrl().isEmpty() && !options.isJdbcModeHapi()) {
         throw new IllegalArgumentException(
             "One of --fhirServerUrl --jdbcModeHapi --parquetInputDwhRoot --sourceJsonFilePattern"
-                + " --parquetInputDwhRoot should be set!");
+                + " should be set!");
       }
     }
   }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,19 @@ public interface FhirEtlOptions extends PipelineOptions {
 
   void setViewDefinitionsDir(String value);
 
+  @Description(
+      "The path to the data-warehouse directory of Parquet files to be read. The content of this "
+          + "directory is expected to have the same structure used in output data-warehouse, i.e., "
+          + "one dir per each resource type. If this is enabled, --fhirServerUrl and "
+          + "--fhirDatabaseConfigPath should be disabled because input resources are read from "
+          + "Parquet files. This is for example useful when we want to regenerate the views. "
+          + "[EXPERIMENTAL]")
+  @Required
+  @Default.String("")
+  String getParquetInputDwhRoot();
+
+  void setParquetInputDwhRoot(String value);
+
   // TODO add the option for CSV output of views.
   // @Description(
   //     "The output directory for CSV files generated for ViewDefinitions in viewDefinitionsDir.\n"
@@ -236,7 +249,8 @@ public interface FhirEtlOptions extends PipelineOptions {
   // void setSinkCsvDir();
 
   @Description(
-      "The pattern for input JSON files, e.g., 'PATH/*'. Each file should be one Bundle resource.")
+      "The pattern for input JSON files, e.g., 'PATH/*'. Each file should be one Bundle resource. "
+          + "[EXPERIMENTAL]")
   @Default.String("")
   String getSourceJsonFilePattern();
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
@@ -208,7 +208,7 @@ public interface FhirEtlOptions extends PipelineOptions {
   void setSince(String value);
 
   @Description(
-      "Path to the sink database config; if not set, no sink DB is used [experimental].\n"
+      "Path to the sink database config; if not set, no sink DB is used.\n"
           + "If viewDefinitionsDir is set, the output tables will be the generated views\n"
           + "(the `name` field value will be used as the table name); if not, one table\n"
           + "per resource type is created with the JSON content of a resource and its\n"
@@ -217,6 +217,14 @@ public interface FhirEtlOptions extends PipelineOptions {
   String getSinkDbConfigPath();
 
   void setSinkDbConfigPath(String value);
+
+  @Description(
+      "If true, drops the old view tables first and recreate them; otherwise create tables \n"
+          + "only if they do not exit.")
+  @Default.Boolean(false)
+  Boolean getRecreateSinkTables();
+
+  void setRecreateSinkTables(Boolean value);
 
   @Description(
       "The directory from which SQL-on-FHIR-v2 ViewDefinition json files are read.\n"

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/MetricsConstants.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/MetricsConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,6 @@ public class MetricsConstants {
   public static final String TOTAL_PUSH_TIME_MILLIS = "totalPushTimeMillis_";
   public static final String TOTAL_PARSE_TIME_MILLIS = "totalParseTimeMillis_";
   public static final String TOTAL_NO_OF_RESOURCES = "totalNoOfResources_";
+  public static final String TOTAL_AVRO_CONVERSION_TIME_MILLIS = "totalAvroConversionTimeMillis_";
+  public static final String TOTAL_AVRO_CONVERSIONS = "totalNumOfAvroConversions_";
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ProcessGenericRecords.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ProcessGenericRecords.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import com.google.fhir.analytics.view.ViewApplicationException;
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.values.KV;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessGenericRecords extends FetchSearchPageFn<GenericRecord> {
+
+  private static final Logger log = LoggerFactory.getLogger(ProcessGenericRecords.class);
+
+  // This is the number of resources that are put in each bundle to be processed. The main impact
+  // of this is when we are uploading to another FHIR server.
+  // This should probably be exposed as a config param, but for now this is a good enough constant.
+  private static final int BUNDLE_SIZE = 10;
+
+  private String resourceType;
+  private List<Resource> cachedResources;
+  private Counter totalAvroConversionTime;
+  private Counter totalAvroConversions;
+
+  ProcessGenericRecords(FhirEtlOptions options, String resourceType) {
+    super(options, "ProcessGenericRecords_" + resourceType);
+    this.resourceType = resourceType;
+  }
+
+  @Override
+  public void setup() throws SQLException, PropertyVetoException {
+    super.setup();
+    cachedResources = new ArrayList<>();
+    totalAvroConversionTime =
+        Metrics.counter(
+            MetricsConstants.METRICS_NAMESPACE,
+            MetricsConstants.TOTAL_AVRO_CONVERSION_TIME_MILLIS + resourceType);
+    totalAvroConversions =
+        Metrics.counter(
+            MetricsConstants.METRICS_NAMESPACE,
+            MetricsConstants.TOTAL_AVRO_CONVERSIONS + resourceType);
+  }
+
+  @Override
+  public void teardown() throws IOException {
+    if (!cachedResources.isEmpty()) {
+      try {
+        processBundle(flushCacheToBundle());
+      } catch (SQLException | ViewApplicationException e) {
+        // This is not perfect but the parent teardown only has IOException.
+        throw new IOException(e);
+      }
+    }
+    super.teardown();
+  }
+
+  private Bundle flushCacheToBundle() {
+    Bundle bundle = new Bundle();
+    for (Resource resource : cachedResources) {
+      bundle.addEntry(new BundleEntryComponent().setResource(resource));
+    }
+    cachedResources.clear();
+    return bundle;
+  }
+
+  @ProcessElement
+  public void processElement(@Element GenericRecord record, OutputReceiver<KV<String, Integer>> out)
+      throws IOException, SQLException, ViewApplicationException {
+    try {
+      long startTime = System.currentTimeMillis();
+      Resource resource =
+          AvroConversionUtil.getInstance().convertToHapi(record, resourceType, fhirContext);
+      totalAvroConversionTime.inc(System.currentTimeMillis() - startTime);
+      totalAvroConversions.inc();
+      cachedResources.add(resource);
+      if (cachedResources.size() >= BUNDLE_SIZE) {
+        processBundle(flushCacheToBundle());
+      }
+    } catch (IllegalArgumentException e) {
+      log.error("Dropping bad record because: " + e.getMessage());
+    }
+  }
+}

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ConvertResourceFnTest {
           }
         };
     convertResourceFn.setup();
-    ParquetUtil.initializeAvroConverters();
+    AvroConversionUtil.initializeAvroConverters();
   }
 
   @Test

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/FetchResourcesTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/FetchResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class FetchResourcesTest {
     FhirEtlOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(FhirEtlOptions.class);
     fetchResources = new MockedFetchResources(options, bundle);
-    ParquetUtil.initializeAvroConverters();
+    AvroConversionUtil.initializeAvroConverters();
   }
 
   @Test

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/FetchSearchPageFnTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/FetchSearchPageFnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class FetchSearchPageFnTest {
         };
     this.fhirContext = FhirContext.forR4();
     fetchSearchPageFn.setup();
-    ParquetUtil.initializeAvroConverters();
+    AvroConversionUtil.initializeAvroConverters();
   }
 
   @Test

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
@@ -79,15 +79,11 @@ public class JdbcResourceWriterTest {
   public void testWriteResource() throws SQLException, ViewApplicationException {
     JdbcResourceWriter testWriter = new JdbcResourceWriter(dataSourceMock, "", fhirContext);
     testWriter.writeResource((Resource) parser.parseResource(patientResourceStr));
-    verify(statementMock, times(5)).setString(any(Integer.class), any(String.class));
-    verify(statementMock, times(5)).setString(indexCaptor.capture(), idCaptor.capture());
-    // These are for the first DELETE.
+    verify(statementMock, times(4)).setString(any(Integer.class), any(String.class));
+    verify(statementMock, times(4)).setString(indexCaptor.capture(), idCaptor.capture());
     assertThat(indexCaptor.getAllValues().get(0), equalTo(1));
     assertThat(idCaptor.getAllValues().get(0), equalTo("my-patient-id"));
-    // These are for the INSERT.
-    assertThat(indexCaptor.getAllValues().get(1), equalTo(1));
-    assertThat(idCaptor.getAllValues().get(1), equalTo("my-patient-id"));
-    assertThat(indexCaptor.getAllValues().get(3), equalTo(3));
-    assertThat(idCaptor.getAllValues().get(3), equalTo("my-patient-id"));
+    assertThat(indexCaptor.getAllValues().get(2), equalTo(3));
+    assertThat(idCaptor.getAllValues().get(2), equalTo("my-patient-id"));
   }
 }

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,11 +79,15 @@ public class JdbcResourceWriterTest {
   public void testWriteResource() throws SQLException, ViewApplicationException {
     JdbcResourceWriter testWriter = new JdbcResourceWriter(dataSourceMock, "", fhirContext);
     testWriter.writeResource((Resource) parser.parseResource(patientResourceStr));
-    verify(statementMock, times(4)).setString(any(Integer.class), any(String.class));
-    verify(statementMock, times(4)).setString(indexCaptor.capture(), idCaptor.capture());
+    verify(statementMock, times(5)).setString(any(Integer.class), any(String.class));
+    verify(statementMock, times(5)).setString(indexCaptor.capture(), idCaptor.capture());
+    // These are for the first DELETE.
     assertThat(indexCaptor.getAllValues().get(0), equalTo(1));
     assertThat(idCaptor.getAllValues().get(0), equalTo("my-patient-id"));
-    assertThat(indexCaptor.getAllValues().get(2), equalTo(3));
-    assertThat(idCaptor.getAllValues().get(2), equalTo("my-patient-id"));
+    // These are for the INSERT.
+    assertThat(indexCaptor.getAllValues().get(1), equalTo(1));
+    assertThat(idCaptor.getAllValues().get(1), equalTo("my-patient-id"));
+    assertThat(indexCaptor.getAllValues().get(3), equalTo(3));
+    assertThat(idCaptor.getAllValues().get(3), equalTo("my-patient-id"));
   }
 }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/AvroConversionUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/AvroConversionUtil.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import com.cerner.bunsen.FhirContexts;
+import com.cerner.bunsen.avro.AvroConverter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.avro.Conversions.DecimalConversion;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificData;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is supposed to hold all AvroConverter objects, i.e., for all resource types. It is
+ * also intended to be a singleton because creation of these objects can be expensive. So any user
+ * that needs an AvroConverter gets the single instance of this class (per JVM) using `getInstance`.
+ */
+public class AvroConversionUtil {
+
+  private static final Logger log = LoggerFactory.getLogger(AvroConversionUtil.class);
+
+  // This is the singleton instance.
+  private static AvroConversionUtil instance;
+
+  // TODO make this map FHIR version dependent: https://github.com/google/fhir-data-pipes/issues/400
+  private final Map<String, AvroConverter> converterMap;
+
+  /**
+   * This is to fix the logical type conversions for BigDecimal. This should be called once before
+   * any FHIR resource conversion to Avro.
+   */
+  public static void initializeAvroConverters() {
+    // For more context on the next two conversions, see this thread: https://bit.ly/3iE4rwS
+    // Add BigDecimal conversion to the singleton instance to fix "Unknown datum type" Avro
+    // exception.
+    GenericData.get().addLogicalTypeConversion(new DecimalConversion());
+    // This is for a similar error in the ParquetWriter.write which uses SpecificData.get() as its
+    // model.
+    SpecificData.get().addLogicalTypeConversion(new DecimalConversion());
+  }
+
+  private AvroConversionUtil() {
+    converterMap = Maps.newHashMap();
+  }
+
+  static synchronized AvroConversionUtil getInstance() {
+    if (instance == null) {
+      instance = new AvroConversionUtil();
+    }
+    return instance;
+  }
+
+  synchronized AvroConverter getConverter(String resourceType, FhirContext fhirContext) {
+    if (!converterMap.containsKey(resourceType)) {
+      // TODO: Check how to automate discovery of relevant profiles to be applied. Right now we need
+      // to supply the corresponding resource profile identifier for the extensions to work, e.g.,
+      // "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" instead of "Patient".
+      // https://github.com/google/fhir-data-pipes/issues/560
+      AvroConverter converter = AvroConverter.forResource(fhirContext, resourceType);
+      converterMap.put(resourceType, converter);
+    }
+    return converterMap.get(resourceType);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  GenericRecord convertToAvro(Resource resource, FhirContext fhirContext) {
+    AvroConverter converter = getConverter(resource.getResourceType().name(), fhirContext);
+    // TODO: Check why Bunsen returns IndexedRecord instead of GenericRecord.
+    return (GenericRecord) converter.resourceToAvro(resource);
+  }
+
+  @VisibleForTesting
+  Resource convertToHapi(GenericRecord record, String resourceType, FhirContext fhirContext) {
+    // Note resourceType can also be inferred from the record (through fhirType).
+    AvroConverter converter = getConverter(resourceType, fhirContext);
+    IBaseResource resource = converter.avroToResource(record);
+    // TODO: fix this for other FHIR versions: https://github.com/google/fhir-data-pipes/issues/400
+    if (!(resource instanceof Resource)) {
+      throw new IllegalArgumentException("Cannot convert input record to resource!");
+    }
+    return (Resource) resource;
+  }
+
+  public Schema getResourceSchema(String resourceType, FhirVersionEnum fhirVersion) {
+    return getResourceSchema(resourceType, FhirContexts.contextFor(fhirVersion));
+  }
+
+  public Schema getResourceSchema(String resourceType, FhirContext fhirContext) {
+    AvroConverter converter = getConverter(resourceType, fhirContext);
+    Schema schema = converter.getSchema();
+    log.debug(String.format("Schema for resource type %s is %s", resourceType, schema));
+    return schema;
+  }
+
+  public List<GenericRecord> generateRecords(Bundle bundle, FhirContext fhirContext) {
+    List<GenericRecord> records = new ArrayList<>();
+    if (bundle.getTotal() == 0) {
+      return records;
+    }
+    for (BundleEntryComponent entry : bundle.getEntry()) {
+      Resource resource = entry.getResource();
+      GenericRecord record = convertToAvro(resource, fhirContext);
+      if (record != null) {
+        records.add(record);
+      }
+    }
+    return records;
+  }
+}

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -332,7 +332,7 @@ public class DwhFiles {
     return Instant.parse(result.get(0));
   }
 
-  public void writeToFile(String fileName, byte[] content) throws IOException {
+  public void overwriteFile(String fileName, byte[] content) throws IOException {
     ResourceId resourceId =
         FileSystems.matchNewResource(getRoot(), true)
             .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
@@ -341,13 +341,13 @@ public class DwhFiles {
     MatchResult matchResult = Iterables.getOnlyElement(matches);
 
     if (matchResult.status() == Status.OK) {
-      String errorMessage =
-          String.format(
-              "Attempting to write to the file %s which already exists",
-              getRoot() + "/" + fileName);
-      log.error(errorMessage);
-      throw new FileAlreadyExistsException(errorMessage);
-    } else if (matchResult.status() == Status.NOT_FOUND) {
+      String warnMessage =
+          String.format("Overwriting the existing file %s", getRoot() + "/" + fileName);
+      log.warn(warnMessage);
+      FileSystems.delete(List.of(resourceId));
+    }
+
+    if (matchResult.status() == Status.NOT_FOUND || matchResult.status() == Status.OK) {
       WritableByteChannel writableByteChannel = FileSystems.create(resourceId, MimeTypes.BINARY);
       writableByteChannel.write(ByteBuffer.wrap(content));
       writableByteChannel.close();

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import ca.uhn.fhir.parser.DataFormatException;
 import com.cerner.bunsen.FhirContexts;
 import com.google.api.client.util.Sets;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -107,7 +108,7 @@ public class DwhFiles {
    * @param fhirContext
    */
   DwhFiles(String dwhRoot, FhirContext fhirContext) {
-    Preconditions.checkNotNull(dwhRoot);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(dwhRoot));
     this.dwhRoot = dwhRoot;
     this.fhirContext = fhirContext;
   }
@@ -129,6 +130,15 @@ public class DwhFiles {
   public ResourceId getResourcePath(String resourceType) {
     return FileSystems.matchNewResource(getRoot(), true)
         .resolve(resourceType, StandardResolveOptions.RESOLVE_DIRECTORY);
+  }
+
+  /**
+   * @param resourceType the type of the FHIR resources
+   * @return The file pattern for Parquet files of `resourceType` in this DWH.
+   */
+  public String getFilePattern(String resourceType) {
+    return String.format(
+        "%s*%s", getResourcePath(resourceType).toString(), ParquetUtil.PARQUET_EXTENSION);
   }
 
   /**

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/model/DatabaseConfiguration.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/model/DatabaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewManager.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +50,8 @@ public class ViewManager {
     Preconditions.checkArgument(!viewDefinitionsDir.isEmpty());
     ViewManager viewManager = new ViewManager();
     List<Path> viewPaths = new ArrayList<>();
-    try (Stream<Path> paths = Files.walk(Paths.get(viewDefinitionsDir))) {
+    try (Stream<Path> paths =
+        Files.walk(Paths.get(viewDefinitionsDir), FileVisitOption.FOLLOW_LINKS)) {
       paths
           .filter(f -> f.toString().endsWith(JSON_EXT))
           .forEach(

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+// TODO add testes for DSTU3 resources too.
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericRecord;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Observation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AvroConversionUtilTest {
+  private AvroConversionUtil instance = AvroConversionUtil.getInstance();
+
+  private FhirContext fhirContext;
+  private String patientBundle;
+  private String observationBundle;
+
+  @Before
+  public void setup() throws IOException {
+    AvroConversionUtil.initializeAvroConverters();
+    patientBundle =
+        Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);
+    observationBundle =
+        Resources.toString(
+            Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
+    this.fhirContext = FhirContext.forR4Cached();
+  }
+
+  @Test
+  public void getResourceSchema_Patient() {
+    Schema schema = instance.getResourceSchema("Patient", fhirContext);
+    assertThat(schema.getField("id").toString(), notNullValue());
+    assertThat(schema.getField("identifier").toString(), notNullValue());
+    assertThat(schema.getField("name").toString(), notNullValue());
+  }
+
+  @Test
+  public void getResourceSchema_Observation() {
+    Schema schema = instance.getResourceSchema("Observation", fhirContext);
+    assertThat(schema.getField("id").toString(), notNullValue());
+    assertThat(schema.getField("identifier").toString(), notNullValue());
+    assertThat(schema.getField("basedOn").toString(), notNullValue());
+    assertThat(schema.getField("subject").toString(), notNullValue());
+    assertThat(schema.getField("code").toString(), notNullValue());
+  }
+
+  @Test
+  public void getResourceSchema_Encounter() {
+    Schema schema = instance.getResourceSchema("Encounter", fhirContext);
+    assertThat(schema.getField("id").toString(), notNullValue());
+    assertThat(schema.getField("identifier").toString(), notNullValue());
+    assertThat(schema.getField("status").toString(), notNullValue());
+    assertThat(schema.getField("class").toString(), notNullValue());
+  }
+
+  @Test
+  public void generateRecords_BundleOfPatients() {
+    IParser parser = fhirContext.newJsonParser();
+    Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
+    List<GenericRecord> recordList = instance.generateRecords(bundle, fhirContext);
+    assertThat(recordList.size(), equalTo(1));
+    assertThat(recordList.get(0).get("address"), notNullValue());
+    Collection<Object> addressList = (Collection<Object>) recordList.get(0).get("address");
+    assertThat(addressList.size(), equalTo(1));
+    Record address = (Record) addressList.iterator().next();
+    assertThat((String) address.get("city"), equalTo("Waterloo"));
+  }
+
+  @Test
+  public void generateRecords_BundleOfObservations() {
+    IParser parser = fhirContext.newJsonParser();
+    Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
+    List<GenericRecord> recordList = instance.generateRecords(bundle, fhirContext);
+    assertThat(recordList.size(), equalTo(6));
+  }
+
+  @Test
+  public void generateRecordForPatient() {
+    IParser parser = fhirContext.newJsonParser();
+    Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
+    GenericRecord record =
+        AvroConversionUtil.getInstance()
+            .convertToAvro(bundle.getEntry().get(0).getResource(), fhirContext);
+    Collection<Object> addressList = (Collection<Object>) record.get("address");
+    // TODO We need to fix this again; the root cause is the change in `id` type to System.String.
+    // https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/issues/55
+    // assertThat(record.get("id"), equalTo("471be3bc-08c7-4d78-a4ab-1b3d044dae67"));
+    assertThat(addressList.size(), equalTo(1));
+    Record address = (Record) addressList.iterator().next();
+    assertThat((String) address.get("city"), equalTo("Waterloo"));
+  }
+
+  @Test
+  public void convertObservationWithBigDecimalValue() throws IOException {
+    String observationStr =
+        Resources.toString(
+            Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
+    IParser parser = fhirContext.newJsonParser();
+    Observation observation = parser.parseResource(Observation.class, observationStr);
+    GenericRecord record = AvroConversionUtil.getInstance().convertToAvro(observation, fhirContext);
+    GenericData.Record valueRecord = (GenericData.Record) record.get("value");
+    Double value = (Double) ((GenericData.Record) valueRecord.get("quantity")).get("value");
+    assertThat(value, closeTo(25, 0.001));
+  }
+}

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package com.google.fhir.analytics;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.number.IsCloseTo.closeTo;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -27,18 +25,11 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericData.Record;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Observation;
@@ -48,15 +39,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // TODO add testes for DSTU3 resources too.
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParquetUtilTest {
-
-  private static final Logger log = LoggerFactory.getLogger(ParquetUtil.class);
 
   private static final String PARQUET_ROOT = "parquet_root";
 
@@ -77,7 +64,7 @@ public class ParquetUtilTest {
     File rootFolder = testFolder.newFolder(PARQUET_ROOT);
     rootPath = Paths.get(rootFolder.getPath());
     Files.createDirectories(rootPath);
-    ParquetUtil.initializeAvroConverters();
+    AvroConversionUtil.initializeAvroConverters();
     patientBundle =
         Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);
     observationBundle =
@@ -85,68 +72,6 @@ public class ParquetUtilTest {
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
     this.fhirContext = FhirContext.forR4Cached();
     parquetUtil = new ParquetUtil(FhirVersionEnum.R4, rootPath.toString(), 0, 0, "TEST_");
-  }
-
-  @Test
-  public void getResourceSchema_Patient() {
-    Schema schema = parquetUtil.getResourceSchema("Patient", fhirContext);
-    assertThat(schema.getField("id").toString(), notNullValue());
-    assertThat(schema.getField("identifier").toString(), notNullValue());
-    assertThat(schema.getField("name").toString(), notNullValue());
-  }
-
-  @Test
-  public void getResourceSchema_Observation() {
-    Schema schema = parquetUtil.getResourceSchema("Observation", fhirContext);
-    assertThat(schema.getField("id").toString(), notNullValue());
-    assertThat(schema.getField("identifier").toString(), notNullValue());
-    assertThat(schema.getField("basedOn").toString(), notNullValue());
-    assertThat(schema.getField("subject").toString(), notNullValue());
-    assertThat(schema.getField("code").toString(), notNullValue());
-  }
-
-  @Test
-  public void getResourceSchema_Encounter() {
-    Schema schema = parquetUtil.getResourceSchema("Encounter", fhirContext);
-    assertThat(schema.getField("id").toString(), notNullValue());
-    assertThat(schema.getField("identifier").toString(), notNullValue());
-    assertThat(schema.getField("status").toString(), notNullValue());
-    assertThat(schema.getField("class").toString(), notNullValue());
-  }
-
-  @Test
-  public void generateRecords_BundleOfPatients() {
-    IParser parser = fhirContext.newJsonParser();
-    Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
-    List<GenericRecord> recordList = parquetUtil.generateRecords(bundle);
-    assertThat(recordList.size(), equalTo(1));
-    assertThat(recordList.get(0).get("address"), notNullValue());
-    Collection<Object> addressList = (Collection<Object>) recordList.get(0).get("address");
-    assertThat(addressList.size(), equalTo(1));
-    Record address = (Record) addressList.iterator().next();
-    assertThat((String) address.get("city"), equalTo("Waterloo"));
-  }
-
-  @Test
-  public void generateRecords_BundleOfObservations() {
-    IParser parser = fhirContext.newJsonParser();
-    Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
-    List<GenericRecord> recordList = parquetUtil.generateRecords(bundle);
-    assertThat(recordList.size(), equalTo(6));
-  }
-
-  @Test
-  public void generateRecordForPatient() {
-    IParser parser = fhirContext.newJsonParser();
-    Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
-    GenericRecord record = parquetUtil.convertToAvro(bundle.getEntry().get(0).getResource());
-    Collection<Object> addressList = (Collection<Object>) record.get("address");
-    // TODO We need to fix this again; the root cause is the change in `id` type to System.String.
-    // https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/issues/55
-    // assertThat(record.get("id"), equalTo("471be3bc-08c7-4d78-a4ab-1b3d044dae67"));
-    assertThat(addressList.size(), equalTo(1));
-    Record address = (Record) addressList.iterator().next();
-    assertThat((String) address.get("city"), equalTo("Waterloo"));
   }
 
   @Test
@@ -255,19 +180,6 @@ public class ParquetUtilTest {
                                 + fileSeparator
                                 + "Observation_output-"));
     assertThat(files.count(), equalTo(1L));
-  }
-
-  @Test
-  public void convertObservationWithBigDecimalValue() throws IOException {
-    String observationStr =
-        Resources.toString(
-            Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
-    IParser parser = fhirContext.newJsonParser();
-    Observation observation = parser.parseResource(Observation.class, observationStr);
-    GenericRecord record = parquetUtil.convertToAvro(observation);
-    GenericData.Record valueRecord = (GenericData.Record) record.get("value");
-    BigDecimal value = (BigDecimal) ((GenericData.Record) valueRecord.get("quantity")).get("value");
-    assertThat(value.doubleValue(), closeTo(25, 0.001));
   }
 
   /**

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -135,6 +135,19 @@ fhirdata:
   # you can use those predefined views in your dev. env. too.
   hiveResourceViewsDir: "config/views"
 
+  # The location from which ViewDefinition resources are read and applied to the
+  # corresponding input FHIR resources. Any file in this directory that ends
+  # `.json` is assumed to be a single ViewDefinition. To output these views to a
+  # relational database, the next sinkDbConfigPath should also be set.
+  viewDefinitionsDir: "config/views"
+
+  # The configuration file for the sink database. If `viewDefinitionsDir` is set
+  # then the generated views are materialized and written to this DB. If not,
+  # then the raw FHIR JSON resources are written to this DB. Note enabling this
+  # feature can have a noticeable impact on pipelines performance. The default
+  # empty string disables this feature.
+  sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
+
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/pipelines/controller/config/hapi-postgres-config_local_views.json
+++ b/pipelines/controller/config/hapi-postgres-config_local_views.json
@@ -1,0 +1,9 @@
+{
+  "jdbcDriverClass": "org.postgresql.Driver",
+  "databaseService" : "postgresql",
+  "databaseHostName" : "172.17.0.1",
+  "databasePort" : "5432",
+  "databaseUser" : "admin",
+  "databasePassword" : "admin",
+  "databaseName" : "views"
+}

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2023 Google LLC
+    Copyright 2020-2024 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -217,7 +217,10 @@
                   <!-- These options enable access to all methods in the mentioned packages at
                   compile and runtime. These are added as MANIFEST entries in the bundled jar. These
                   had to be enabled specifically for accessing the
-                  `jdk.internal.misc.VM.maxDirectMemory()` API -->
+                  `jdk.internal.misc.VM.maxDirectMemory()` API
+                  TODO find an easy way to add these for IDE debugging too;
+                   currently we need to comment out the corresponding part.
+                  -->
                   <Add-Exports>java.base/jdk.internal.misc</Add-Exports>
                   <Add-Opens>java.base/jdk.internal.misc=ALL-UNNAMED</Add-Opens>
                 </manifestEntries>

--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -184,12 +184,8 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <!-- The version specification should not be needed but on Cloud-Build
-          for some reason it picks 3.0.0 and then fails as it needs Java 17. -->
-        <!-- This is for being able to debug from IDE. -->
-        <configuration>
-          <fork>false</fork>
-        </configuration>
+        <!-- The "fork" configuration parameter was removed in Spring Boot 3;
+           we need another way to be able to debug from IDE. -->
         <executions>
           <execution>
             <!-- This creates the standalone fat-jar with "-exec" suffix.  -->

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,10 @@ public class DataProperties {
 
   private String hiveResourceViewsDir;
 
+  private String viewDefinitionsDir;
+
+  private String sinkDbConfigPath;
+
   private String fhirServerPassword;
 
   private String fhirServerUserName;
@@ -122,6 +126,35 @@ public class DataProperties {
     Preconditions.checkState(!createHiveResourceTables || !thriftserverHiveConfig.isEmpty());
   }
 
+  private PipelineConfig.PipelineConfigBuilder addFlinkOptions(FhirEtlOptions options) {
+    PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = PipelineConfig.builder();
+    options.setRunner(FlinkRunner.class);
+    FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);
+    flinkOptions.setMaxParallelism(getMaxWorkers());
+    if (numThreads > 0) {
+      flinkOptions.setParallelism(numThreads);
+    }
+
+    pipelineConfigBuilder.fhirEtlOptions(options);
+    return pipelineConfigBuilder;
+  }
+
+  PipelineConfig createRecreateViewsOptions(String dwhRoot) {
+    Preconditions.checkState(!Strings.isNullOrEmpty(viewDefinitionsDir));
+    Preconditions.checkState(!Strings.isNullOrEmpty(sinkDbConfigPath));
+    Preconditions.checkState(!Strings.isNullOrEmpty(dwhRoot));
+    FhirEtlOptions options = PipelineOptionsFactory.as(FhirEtlOptions.class);
+    logger.info(
+        "Creating options for recreating views in {} into DB config {} from DWH {} ",
+        viewDefinitionsDir,
+        sinkDbConfigPath,
+        dwhRoot);
+    options.setParquetInputDwhRoot(dwhRoot);
+    options.setViewDefinitionsDir(viewDefinitionsDir);
+    options.setSinkDbConfigPath(sinkDbConfigPath);
+    return addFlinkOptions(options).build();
+  }
+
   PipelineConfig createBatchOptions() {
     FhirEtlOptions options = PipelineOptionsFactory.as(FhirEtlOptions.class);
     logger.info("Converting options for fhirServerUrl {} and dbConfig {}", fhirServerUrl, dbConfig);
@@ -131,21 +164,25 @@ public class DataProperties {
       options.setJdbcModeHapi(true);
       options.setFhirDatabaseConfigPath(dbConfig);
     } else {
-      options.setFhirServerUrl(fhirServerUrl);
-      options.setFhirServerPassword(fhirServerPassword);
-      options.setFhirServerUserName(fhirServerUserName);
-      options.setFhirServerOAuthTokenEndpoint(fhirServerOAuthTokenEndpoint);
-      options.setFhirServerOAuthClientId(fhirServerOAuthClientId);
-      options.setFhirServerOAuthClientSecret(fhirServerOAuthClientSecret);
+      options.setFhirServerUrl(Strings.nullToEmpty(fhirServerUrl));
+      options.setFhirServerPassword(Strings.nullToEmpty(fhirServerPassword));
+      options.setFhirServerUserName(Strings.nullToEmpty(fhirServerUserName));
+      options.setFhirServerOAuthTokenEndpoint(Strings.nullToEmpty(fhirServerOAuthTokenEndpoint));
+      options.setFhirServerOAuthClientId(Strings.nullToEmpty(fhirServerOAuthClientId));
+      options.setFhirServerOAuthClientSecret(Strings.nullToEmpty(fhirServerOAuthClientSecret));
     }
-    options.setResourceList(resourceList);
-
-    PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = PipelineConfig.builder();
+    if (resourceList != null) {
+      options.setResourceList(resourceList);
+    }
+    options.setViewDefinitionsDir(Strings.nullToEmpty(viewDefinitionsDir));
+    options.setSinkDbConfigPath(Strings.nullToEmpty(sinkDbConfigPath));
 
     // Using underscore for suffix as hyphens are discouraged in hive table names.
     String timestampSuffix =
         Instant.now().toString().replace(":", "-").replace("-", "_").replace(".", "_");
     options.setOutputParquetPath(dwhRootPrefix + TIMESTAMP_PREFIX + timestampSuffix);
+
+    PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = addFlinkOptions(options);
 
     // Get hold of thrift server parquet directory from dwhRootPrefix config.
     String thriftServerParquetPathPrefix =
@@ -154,14 +191,6 @@ public class DataProperties {
         thriftServerParquetPathPrefix + TIMESTAMP_PREFIX + timestampSuffix);
     pipelineConfigBuilder.timestampSuffix(timestampSuffix);
 
-    options.setRunner(FlinkRunner.class);
-    FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);
-    flinkOptions.setMaxParallelism(getMaxWorkers());
-    if (numThreads > 0) {
-      flinkOptions.setParallelism(numThreads);
-    }
-
-    pipelineConfigBuilder.fhirEtlOptions(options);
     return pipelineConfigBuilder.build();
   }
 
@@ -179,7 +208,10 @@ public class DataProperties {
             ""),
         new ConfigFields("fhirdata.resourceList", resourceList, "", ""),
         new ConfigFields("fhirdata.maxWorkers", String.valueOf(maxWorkers), "", ""),
-        new ConfigFields("fhirdata.dbConfig", dbConfig, "", ""));
+        new ConfigFields("fhirdata.numThreads", String.valueOf(numThreads), "", ""),
+        new ConfigFields("fhirdata.dbConfig", dbConfig, "", ""),
+        new ConfigFields("fhirdata.viewDefinitionsDir", viewDefinitionsDir, "", ""),
+        new ConfigFields("fhirdata.sinkDbConfigPath", sinkDbConfigPath, "", ""));
   }
 
   ConfigFields getConfigFields(FhirEtlOptions options, Method getMethod) {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -152,6 +152,7 @@ public class DataProperties {
     options.setParquetInputDwhRoot(dwhRoot);
     options.setViewDefinitionsDir(viewDefinitionsDir);
     options.setSinkDbConfigPath(sinkDbConfigPath);
+    options.setRecreateSinkTables(true);
     return addFlinkOptions(options).build();
   }
 

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/MainController.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/MainController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.google.fhir.analytics;
 
+import com.google.common.base.Strings;
 import java.beans.PropertyVetoException;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -61,6 +62,10 @@ public class MainController {
       model.addAttribute("next_run", next.toString());
       model.addAttribute("hasDwh", true);
     }
+    model.addAttribute(
+        "enableView",
+        !Strings.isNullOrEmpty(dataProperties.getViewDefinitionsDir())
+            && !Strings.isNullOrEmpty(dataProperties.getSinkDbConfigPath()));
     FhirEtlOptions options = dataProperties.createBatchOptions().getFhirEtlOptions();
     List<DataProperties.ConfigFields> configParams = dataProperties.getConfigParams();
     model.addAttribute("configParams", configParams);

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -702,7 +702,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
       if (!Strings.isNullOrEmpty(dwhRoot)) {
         String stackTrace = ExceptionUtils.getStackTrace(e);
         DwhFiles.forRoot(dwhRoot)
-            .writeToFile(ERROR_FILE_NAME, stackTrace.getBytes(StandardCharsets.UTF_8));
+            .overwriteFile(ERROR_FILE_NAME, stackTrace.getBytes(StandardCharsets.UTF_8));
       }
     } catch (IOException ex) {
       logger.error("Error while capturing error to a file", ex);

--- a/pipelines/controller/src/main/resources/templates/index.html
+++ b/pipelines/controller/src/main/resources/templates/index.html
@@ -30,8 +30,9 @@
       }
     }
 
-    function runPipeline(isFullRun) {
-      console.log('Trying to start pipeline; isFullRun: ' + isFullRun);
+    // valid `runMode`s: 'INCREMENTAL', 'FULL', 'VIEWS'
+    function runPipeline(runMode) {
+      console.log('Trying to start pipeline; runMode: ' + runMode);
       var xhr = new XMLHttpRequest();
       xhr.open("POST", '/run', true);
       xhr.onreadystatechange = function() {
@@ -52,7 +53,7 @@
         }
       }
       formData = new FormData();
-      formData.append('isFullRun', isFullRun);
+      formData.append('runMode', runMode);
       changeVisibility('pipelineWait', true);
       xhr.send(formData);
     }
@@ -245,34 +246,60 @@
           </div>
           <!-- TODO add last run time -->
           <!-- End to-do -->
-          <div class="row row-cols-1 row-cols-md-2 mb-2 text-center">
+          <div class="row row-cols-1 row-cols-sm-1 row-cols-md-3 mb-2 text-center">
+
+            <!-- "Run Incremental" button -->
             <div class="col">
               <div class="card md-5 rounded-3 shadow-sm">
                 <div class="card-header py-3">
                   <h5>Run Incremental Pipeline</h5>
                 </div>
                 <div class="card-body">
-                  <p>This fetches the resources since last run and merges them into the data-warehouse.</p>
+                  <p>This fetches the resources since last run and merges them into the
+                    data-warehouse.</p>
                   <button type="submit" name="mode" class="button btn btn-primary"
-                          th:classappend="${hasDwh ? '' : 'disabled'}" onclick="runPipeline(false)">
-                  Run Incremental
+                          th:classappend="${hasDwh ? '' : 'disabled'}"
+                          onclick="runPipeline('INCREMENTAL')">
+                    Run Incremental
                   </button>
                 </div>
               </div>
             </div>
+
+            <!-- "Run Full" button -->
             <div class="col">
               <div class="card md-4 rounded-3 shadow-sm">
                 <div class="card-header py-3">
                   <h5>Run Full Pipeline</h5>
                 </div>
                 <div class="card-body">
-                  <p>Fetch all of the resources and create a new data-warehouse snapshot</p>
-                  <button type="submit" name="mode" class="button btn btn-primary" onclick="runPipeline(true)">
+                  <p>This fetches all the resources and create a new data-warehouse snapshot.</p>
+                  <button type="submit" name="mode" class="button btn btn-primary"
+                          onclick="runPipeline('FULL')">
                     Run Full
                   </button>
                 </div>
               </div>
             </div>
+
+            <!-- "Recreate Views" button -->
+            <div class="col">
+              <div class="card md-4 rounded-3 shadow-sm">
+                <div class="card-header py-3">
+                  <h5>Recreate Views</h5>
+                </div>
+                <div class="card-body">
+                  <p>This reads the current data-warehouse snapshot and recreates the flat views in
+                    the sink database.</p>
+                  <button type="submit" name="mode" class="button btn btn-primary"
+                          th:classappend="${hasDwh AND enableView ? '' : 'disabled'}"
+                          onclick="runPipeline('VIEWS')">
+                    Recreate Views
+                  </button>
+                </div>
+              </div>
+            </div>
+
           </div>
         </div>
         <div style="margin-top: 50px">

--- a/pipelines/streaming/src/main/java/com/google/fhir/analytics/Runner.java
+++ b/pipelines/streaming/src/main/java/com/google/fhir/analytics/Runner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class Runner {
 
   // Main method that starts the streaming pipeline.
   public static void main(String[] args) throws Exception {
-    ParquetUtil.initializeAvroConverters();
+    AvroConversionUtil.initializeAvroConverters();
 
     MAIN.addRoutesBuilder(new DebeziumListener(args));
     // and enable graceful hangup support when container/process is shutdown


### PR DESCRIPTION
## Description of what I changed

This is the last piece that fixes #916. Beside adding the incremental view update option to the `controller`, this also implements a fast view recreation option. This is done by reading the whole DWH snapshot (the Parquet files), convert them back to HAPI objects, and apply the new view logic on them. This can be an order of magnitude (or more) faster than refetching resources from the FHIR server. For a fairly large DWH (which originally took ~200 minutes to create by reading from the FHIR server), recreating views only took ~13 to 18 minutes (depending on old views size/presence). From this time, less than 2 minutes was actually converting Avro to HAPI.

Note we never used the Avro to HAPI feature of Bunsen in our production code; this first usage uncovered some new bugs which are fixed in this PR as well.

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the controller and tested the FULL and VIEWS modes. See above for performance testing.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
