### PR TITLE
Fix for the high memory usage

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,7 +44,7 @@ enable_jemalloc
 
 if [[ -z "$JAVA_OPTS" ]]; then
   echo "JAVA_OPTS is empty, initialising with default values"
-  JAVA_OPTS="-Xms2g -Xmx2g"
+  JAVA_OPTS="-Xms6g -Xmx6g"
 fi
 
 # The -Xmx value is to make sure there is a minimum amount of memory; it can be

--- a/docker/.env
+++ b/docker/.env
@@ -22,5 +22,7 @@ DWH_ROOT=./dwh
 # data dump set `small`, which is the default mode.
 DATABASE_DUMP_MODE=small
 
-# JVM parameters to be used by the application
+# JVM parameters to be used by the application. If the application is being run to use FlinkRunner
+# with local cluster mode (default currently), then the Xmx value should be set to a minimum value
+# defined by the private function in com.google.fhir.analytics.FlinkConfiguration.minJVMMemory()
 JAVA_OPTS=-Xms2g -Xmx2g

--- a/docker/.env
+++ b/docker/.env
@@ -22,7 +22,16 @@ DWH_ROOT=./dwh
 # data dump set `small`, which is the default mode.
 DATABASE_DUMP_MODE=small
 
-# JVM parameters to be used by the application. If the application is being run to use FlinkRunner
-# with local cluster mode (default currently), then the Xmx value should be set to a minimum value
-# defined by the private function in com.google.fhir.analytics.FlinkConfiguration.minJVMMemory()
-JAVA_OPTS=-Xms2g -Xmx2g
+# JVM parameters to be used by the application. If the application is set to use FlinkRunner for the
+# Beam pipelines in local cluster mode (which is the default currently), then the JVM total memory
+# should be roughly set with a minimum value derived by the below equation.
+
+# Minimum JVM Memory
+#   = Memory for JVM stack, perm files etc
+#     + (#Parallel Pipeline Threads * #Parallel Pipelines * (1.6 * Parquet Row Group Size))
+# Refer com.google.fhir.analytics.FlinkConfiguration.minJVMMemory() for the accurate value
+
+# So, for a 32 core machine, with Parquet Row Group size of 32mb and with the capability of
+# running 2 pipelines in parallel, the minimum JVM memory needed would be 6g (512mb allocation for
+# JVM stack and others)
+JAVA_OPTS=-Xms6g -Xmx6g

--- a/docker/.env
+++ b/docker/.env
@@ -28,10 +28,11 @@ DATABASE_DUMP_MODE=small
 
 # Minimum JVM Memory
 #   = Memory for JVM stack, perm files etc
-#     + (#Parallel Pipeline Threads * #Parallel Pipelines * (1.6 * Parquet Row Group Size))
+#     + (#Parallel Pipeline Threads * #Parallel Pipelines * Parquet Row Group Size
+#         * Parquet Row Group Inflation factor when data is decoded)
 # Refer com.google.fhir.analytics.FlinkConfiguration.minJVMMemory() for the accurate value
 
 # So, for a 32 core machine, with Parquet Row Group size of 32mb and with the capability of
 # running 2 pipelines in parallel, the minimum JVM memory needed would be 6g (512mb allocation for
-# JVM stack and others)
+# JVM stack and others). The Parquet Row Group Inflation factor is estimated to be 2.
 JAVA_OPTS=-Xms6g -Xmx6g

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -38,6 +38,7 @@ fhirdata:
   createHiveResourceTables: true
   thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   hiveResourceViewsDir: "config/views"
+  rowGroupSizeForParquetFiles: 33554432   # 32mb
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -26,11 +26,11 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public interface BasePipelineOptions extends PipelineOptions {
   @Description(
       "The approximate size (bytes) of the row-groups in Parquet files. When this size is reached,"
-          + " the content is flushed to disk. A large value means more data for one column can be"
-          + " fit into one big column chunk which will speed up the reading of column data. On the"
+          + " the content is flushed to disk. A large value means more data for one column can fit"
+          + " into one big column chunk which will speed up the reading of column data. On the"
           + " downside, larger value means more in-memory size will be needed to hold the data "
-          + " before writing to files. The default 0 uses the default row-group size of Parquet"
-          + " writers.")
+          + " before writing to files. The default value of 0 means use the default row-group size"
+          + " of Parquet writers.")
   @Default.Integer(0)
   int getRowGroupSizeForParquetFiles();
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * Base common class for the batch and incremental pipeline runs, containing the common
+ * configurations
+ */
+public interface BasePipelineOptions extends PipelineOptions {
+  @Description(
+      "The approximate size (bytes) of the row-groups in Parquet files. When this size is reached,"
+          + " the content is flushed to disk. A large value means more data for one column can be"
+          + " fit into one big column chunk which will speed up the reading of column data. On the"
+          + " downside, larger value means more in-memory size will be needed to hold the data "
+          + " before writing to files. The default 0 uses the default row-group size of Parquet"
+          + " writers.")
+  @Default.Integer(0)
+  int getRowGroupSizeForParquetFiles();
+
+  void setRowGroupSizeForParquetFiles(int value);
+}

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -27,7 +27,7 @@ public interface BasePipelineOptions extends PipelineOptions {
   @Description(
       "The approximate size (bytes) of the row-groups in Parquet files. When this size is reached,"
           + " the content is flushed to disk. A large value means more data for one column can fit"
-          + " into one big column chunk which will speed up the reading of column data. On the"
+          + " into one big column chunk which means better compression and faster IO/query. On the"
           + " downside, larger value means more in-memory size will be needed to hold the data "
           + " before writing to files. The default value of 0 means use the default row-group size"
           + " of Parquet writers.")

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@ package com.google.fhir.analytics;
 
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
-import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.Validation.Required;
 
 /** Options supported by {@link FhirEtl}. */
-public interface FhirEtlOptions extends PipelineOptions {
+public interface FhirEtlOptions extends BasePipelineOptions {
 
   @Description("Fhir source server URL, e.g., http://localhost:8091/fhir, etc.")
   @Required
@@ -165,16 +164,6 @@ public interface FhirEtlOptions extends PipelineOptions {
   int getSecondsToFlushParquetFiles();
 
   void setSecondsToFlushParquetFiles(int value);
-
-  @Description(
-      "The approximate size (bytes) of the row-groups in Parquet files. When this size is reached,"
-          + " the content is flushed to disk. This won't be triggered if there are less than 100"
-          + " records.\n"
-          + "The default 0 uses the default row-group size of Parquet writers.")
-  @Default.Integer(0)
-  int getRowGroupSizeForParquetFiles();
-
-  void setRowGroupSizeForParquetFiles(int value);
 
   // TODO: Either remove this feature or properly implement patient history fetching based on
   //   Patient Compartment definition.

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,10 +157,10 @@ public class JdbcFetchHapi {
       StringBuilder builder =
           new StringBuilder(
               "SELECT res.res_id, hfi.forced_id, res.res_type, res.res_updated, res.res_ver,"
-                  + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc  FROM hfj_resource res JOIN"
-                  + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver  "
-                  + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid WHERE"
-                  + " res.res_type = ? AND res.res_id % ? = ? AND"
+                  + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc  FROM"
+                  + " hfj_resource res JOIN hfj_res_ver ver ON res.res_id = ver.res_id AND"
+                  + " res.res_ver = ver.res_ver   LEFT JOIN hfj_forced_id hfi ON res.res_id ="
+                  + " hfi.resource_pid WHERE res.res_type = ? AND res.res_id % ? = ? AND"
                   + " ver.res_encoding != 'DEL'");
       // TODO do date sanity-checking on `since` (note this is partly done by HAPI client call).
       if (since != null && !since.isEmpty()) {

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMergerOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMergerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@ package com.google.fhir.analytics;
 
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
-import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.Validation.Required;
 
 /** Options supported by {@link ParquetMerger}. */
-public interface ParquetMergerOptions extends PipelineOptions {
+public interface ParquetMergerOptions extends BasePipelineOptions {
 
   @Description(
       "The path to the first set of Parquet files to be merged; the data-warehouse file  structure"

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -135,6 +135,12 @@ fhirdata:
   # you can use those predefined views in your dev. env. too.
   hiveResourceViewsDir: "config/views"
 
+  # This is the size of the Parquet Row Group (a logical horizontal partitioning into rows) that
+  # will be used for creating row groups in parquet file by pipelines. A large value means more data
+  # for one column can be fit into one big column chunk which will speed up the reading of column
+  # data. On the downside, more in-memory will be needed to hold the data before writing to files.
+  rowGroupSizeForParquetFiles: 33554432   # 32mb
+
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,8 @@ public class DataProperties {
   private String fhirServerOAuthClientId;
 
   private String fhirServerOAuthClientSecret;
+
+  private int rowGroupSizeForParquetFiles;
 
   @PostConstruct
   void validateProperties() {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -209,8 +209,8 @@ public class FlinkConfiguration {
    * the number of parquet row groups that can be read or written in parallel by the pipeline
    * threads. This is roughly derived by the below formula.
    *
-   * <p>memoryNeeded = Misc memory for JVM stack + (#Parallel Pipeline Threads * #Parallel Pipelines
-   * * Parquet Row Group Size)
+   * <p>Minimum JVM Memory = Memory for JVM stack, perm files etc + (#Parallel Pipeline Threads *
+   * #Parallel Pipelines * (Parquet Row Group Size + buffer for parsing the parquet file))
    */
   private long minJVMMemory(DataProperties dataProperties) {
     int rowGroupSize =
@@ -219,7 +219,7 @@ public class FlinkConfiguration {
             : ParquetWriter.DEFAULT_BLOCK_SIZE;
     int parallelism =
         dataProperties.getNumThreads() > 0 ? dataProperties.getNumThreads() : DEFAULT_PARALLELISM;
-    // Temporary memory needed for decoding the read data from files.
+    // Temporary memory needed for decoding the read data from parquet files.
     long tempBufferSize = (long) Math.max(40 * 1024 * 1024, 0.6 * rowGroupSize);
     // This is the minimum memory required for reading/writing parquet row groups in parallel by
     // pipelines.

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ public class FlinkConfigurationTest {
   public void testNonAutoGenerationWithDefaultConfiguration() throws IOException {
     DataProperties dataProperties = new DataProperties();
     dataProperties.setAutoGenerateFlinkConfiguration(false);
+    dataProperties.setNumThreads(1);
     try (MockedStatic<GlobalConfiguration> mockedStatic =
         Mockito.mockStatic(GlobalConfiguration.class)) {
       Configuration defaultConfiguration = new Configuration();


### PR DESCRIPTION
## Description of what I changed

Fixes #900

The incremental run used to fail when there were high number of FHIR resources to be processed already present in the system. This was because during the incremental run, the delta records had to be merged with the existing records in the parquet files and this needed reading of all the parquet records.

It turned out to be that the minimum amount of memory needed to read from all the parquet shards in parallel is determined by the below formula

```memoryNeeded = Misc memory for JVM stack + (#Parallel Pipeline Threads * #Parallel Pipelines * Parquet Row Group Size)```

This was causing failures for the default parquet row size of 128mb which needed a high memory to load these records into in-memory by all the pipeline threads.

Changes are made to reduce the Parquet Row Group Size to 32mb to run the pipelines even on a low resource environment and it is made configurable as well. Also, the application fails fast if the configured params is not sufficient.

## E2E test

Ran the pipelines incremental runs and verified the following
- Tested with an initial load of 80K patients already being set and then processed a delta records of 100 patients. The pipeline did not fail and successfully processed the records.

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
