### PR TITLE
Updates the HAPI JPA version in e2e to latest

### DIFF
--- a/docker/hapi-compose.yml
+++ b/docker/hapi-compose.yml
@@ -31,9 +31,7 @@ services:
       - default
     
   hapi-server:
-    # Using an older version as the latest image broke our build.
-    # image: "hapiproject/hapi:latest"
-    image: "hapiproject/hapi:v6.1.0"
+    image: "hapiproject/hapi:latest"
     container_name: hapi-server
     environment:
       - hapi.fhir.mdm_enabled=false

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class JdbcFetchHapi {
       // TODO check for null values before accessing columns; this caused NPEs with `latest` HAPI.
       switch (resultSet.getString("res_encoding")) {
         case "JSON":
-          jsonResource = new String(resultSet.getBytes("res_text"), Charsets.UTF_8);
+          jsonResource = new String(resultSet.getBytes("res_text_vc"), Charsets.UTF_8);
           break;
         case "JSONC":
           Blob blob = resultSet.getBlob("res_text");
@@ -157,7 +157,8 @@ public class JdbcFetchHapi {
       StringBuilder builder =
           new StringBuilder(
               "SELECT res.res_id, hfi.forced_id, res.res_type, res.res_updated, res.res_ver,"
-                  + " res.res_version, ver.res_encoding, ver.res_text  FROM hfj_resource res JOIN"
+                  + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc "
+                  + " FROM hfj_resource res JOIN"
                   + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver  "
                   + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid WHERE"
                   + " res.res_type = ? AND res.res_id % ? = ? AND"


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This is a follow-up to #926, please see [this comment](https://github.com/google/fhir-data-pipes/pull/926#issuecomment-1936912782) for details.

Note the changes in the SQL query are cosmetic, to be more readable.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Relying on e2e tests (tested this with different versions of HAPI JPA).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
