### PR TITLE
Deprecation of `maxWorkers` param

### DIFF
--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -32,7 +32,6 @@ fhirdata:
   # prevent regression of https://github.com/google/fhir-data-pipes/issues/785.
   # TODO: add resource table creation to e2e tests.
   resourceList: "Patient,Encounter,Observation,Questionnaire,Condition,Practitioner,Location,Organization"
-  maxWorkers: 1
   numThreads: -1
   autoGenerateFlinkConfiguration: true
   createHiveResourceTables: true

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -232,7 +232,7 @@ public class ParquetMerger {
           ParquetIO.sink(AvroConversionUtil.getInstance().getResourceSchema(type, fhirContext))
               .withCompressionCodec(CompressionCodecName.SNAPPY);
       if (options.getRowGroupSizeForParquetFiles() > 0) {
-        parquetSink.withRowGroupSize(options.getRowGroupSizeForParquetFiles());
+        parquetSink = parquetSink.withRowGroupSize(options.getRowGroupSizeForParquetFiles());
       }
       merged.apply(
           FileIO.<GenericRecord>write()

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -97,12 +97,11 @@ fhirdata:
   # https://github.com/google/fhir-data-pipes/issues/785.
   resourceList: "Patient,Encounter,Observation,Questionnaire,Condition,Practitioner,Location,Organization"
 
-  # The maximum number of Flink workers to use. Each worker may have 
-  # `numThreads` parallel threads.
-  maxWorkers: 1
-
-  # If a positive number, the number of threads to use per worker.
-  # Otherwise, the number of threads is equal to the number of cores.
+  # The parallelism to be used for a pipeline job. In case of FlinkRunner, if the value is set to
+  # -1, then in the local execution mode the number of threads the job uses will be equal to the
+  # number of cores in the machine, whereas in the remote mode (cluster) only 1 thread is used.
+  # If set to a positive value, then in both the modes the pipeline uses these many threads combined
+  # across all the workers.
   numThreads: -1
 
   # In case of Flink local execution mode (which is the default currently), generate Flink

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -79,8 +79,6 @@ public class DataProperties {
 
   private String resourceList;
 
-  private int maxWorkers;
-
   private int numThreads;
 
   private String thriftserverHiveConfig;
@@ -132,7 +130,6 @@ public class DataProperties {
     PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = PipelineConfig.builder();
     options.setRunner(FlinkRunner.class);
     FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);
-    flinkOptions.setMaxParallelism(getMaxWorkers());
     if (numThreads > 0) {
       flinkOptions.setParallelism(numThreads);
     }
@@ -179,6 +176,9 @@ public class DataProperties {
     }
     options.setViewDefinitionsDir(Strings.nullToEmpty(viewDefinitionsDir));
     options.setSinkDbConfigPath(Strings.nullToEmpty(sinkDbConfigPath));
+    if (rowGroupSizeForParquetFiles > 0) {
+      options.setRowGroupSizeForParquetFiles(rowGroupSizeForParquetFiles);
+    }
 
     // Using underscore for suffix as hyphens are discouraged in hive table names.
     String timestampSuffix =
@@ -210,11 +210,15 @@ public class DataProperties {
             "",
             ""),
         new ConfigFields("fhirdata.resourceList", resourceList, "", ""),
-        new ConfigFields("fhirdata.maxWorkers", String.valueOf(maxWorkers), "", ""),
         new ConfigFields("fhirdata.numThreads", String.valueOf(numThreads), "", ""),
         new ConfigFields("fhirdata.dbConfig", dbConfig, "", ""),
         new ConfigFields("fhirdata.viewDefinitionsDir", viewDefinitionsDir, "", ""),
-        new ConfigFields("fhirdata.sinkDbConfigPath", sinkDbConfigPath, "", ""));
+        new ConfigFields("fhirdata.sinkDbConfigPath", sinkDbConfigPath, "", ""),
+        new ConfigFields(
+            "fhirdata.rowGroupSizeForParquetFiles",
+            String.valueOf(rowGroupSizeForParquetFiles),
+            "",
+            ""));
   }
 
   ConfigFields getConfigFields(FhirEtlOptions options, Method getMethod) {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/FlinkConfiguration.java
@@ -233,7 +233,7 @@ public class FlinkConfiguration {
     // pipelines. Row group size is multiplied by inflation factor to accommodate the memory needed
     // when the parquet rows are read and decoded in memory.
     long memoryNeededForParquetRowGroups =
-        parallelism
+        (long) parallelism
             * EtlUtils.NO_OF_PARALLEL_PIPELINES
             * rowGroupSize
             * PARQUET_ROW_GROUP_INFLATION_FACTOR;

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -178,7 +178,6 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     cron = CronExpression.parse(dataProperties.getIncrementalSchedule());
     String rootPrefix = dataProperties.getDwhRootPrefix();
     Preconditions.checkState(rootPrefix != null && !rootPrefix.isEmpty());
-    Preconditions.checkArgument(dataProperties.getMaxWorkers() > 0, "maxWorkers should be > 0");
 
     String lastCompletedDwh = "";
     String lastDwh = "";
@@ -443,12 +442,14 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
             ? dataProperties.getNumThreads()
             : Runtime.getRuntime().availableProcessors();
     mergerOptions.setNumShards(numShards);
+    if (dataProperties.getRowGroupSizeForParquetFiles() > 0) {
+      mergerOptions.setRowGroupSizeForParquetFiles(dataProperties.getRowGroupSizeForParquetFiles());
+    }
     FlinkPipelineOptions flinkOptionsForMerge = mergerOptions.as(FlinkPipelineOptions.class);
     if (!Strings.isNullOrEmpty(flinkConfiguration.getFlinkConfDir())) {
       flinkOptionsForMerge.setFlinkConfDir(flinkConfiguration.getFlinkConfDir());
     }
     flinkOptionsForMerge.setFasterCopy(true);
-    flinkOptionsForMerge.setMaxParallelism(dataProperties.getMaxWorkers());
     if (dataProperties.getNumThreads() > 0) {
       flinkOptionsForMerge.setParallelism(dataProperties.getNumThreads());
     }


### PR DESCRIPTION
## Description of what I changed

Fixes #948 

Deprecated the `maxWorkers` param which was used to set the `maxParallelism` param in `FlinkPipelineOptions`. This param only gets used in a Streaming environment, since the pipelines doesn't use any streaming currently this parameter is not used and hence deprecated.

This PR also contains changes which were missed in the PR #935.

## E2E test

Relined on e2e.
Also, locally verified the `Parquet Row Group Sizes` for the newly created files.

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
