### PR TITLE
Update Hibernate.dialect for latest HAPI version

### DIFF
--- a/docker/hapi-compose.yml
+++ b/docker/hapi-compose.yml
@@ -39,7 +39,7 @@ services:
       - spring.datasource.username=admin
       - spring.datasource.password=admin
       - spring.datasource.driverClassName=org.postgresql.Driver
-      - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect
+      - spring.jpa.properties.hibernate.dialect=ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
       - hapi.fhir.bulk_export_enabled=true
 
     restart: unless-stopped


### PR DESCRIPTION
## Description of what I changed

HAPI has released a latest [docker image](https://hub.docker.com/layers/hapiproject/hapi/latest/images/sha256-c3df28c706f1d7565df595ef9aef75ce65e744f19be6b5acc00c5610c9635657?context=explore) on 27-Feb-2023. In this version due to some upgrades on the `hibernate` dependencies, the earlier [hibernate dialect ](https://github.com/google/fhir-data-pipes/blob/2fe486e36aecf77194b5f7df9d7dfdde48cf487d/docker/hapi-compose.yml#L42) setting `spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect` is not working anymore. It results in the below error. 

Error logs on start of HAPI server
--------------------------------
```
hapi-server    | Caused by: org.hibernate.boot.registry.selector.spi.StrategySelectionException: Unable to resolve name [org.hibernate.dialect.PostgreSQL95Dialect] as strategy [org.hibernate.dialect.Dialect]
hapi-server    | 	at org.hibernate.boot.registry.selector.internal.StrategySelectorImpl.selectStrategyImplementor(StrategySelectorImpl.java:154)
hapi-server    | 	at org.hibernate.boot.registry.internal.StandardServiceRegistryImpl.initiateService(StandardServiceRegistryImpl.java:129)
hapi-server    | 	at org.hibernate.service.internal.AbstractServiceRegistryImpl.createService(AbstractServiceRegistryImpl.java:263)
hapi-server    | 	... 118 common frames omitted
hapi-server    | Caused by: org.hibernate.boot.registry.classloading.spi.ClassLoadingException: Unable to load class [org.hibernate.dialect.PostgreSQL95Dialect]
hapi-server    | 	at org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl.classForName(ClassLoaderServiceImpl.java:126)
hapi-server    | 	at org.hibernate.boot.registry.selector.internal.StrategySelectorImpl.selectStrategyImplementor(StrategySelectorImpl.java:150)
hapi-server    | 	... 128 common frames omitted
hapi-server    | Caused by: java.lang.ClassNotFoundException: Could not load requested class : org.hibernate.dialect.PostgreSQL95Dialect
hapi-server    | 	at org.hibernate.boot.registry.classloading.internal.AggregatedClassLoader.findClass(AggregatedClassLoader.java:216)
hapi-server    | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
hapi-server    | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
hapi-server    | 	at java.base/java.lang.Class.forName0(Native Method)
hapi-server    | 	at java.base/java.lang.Class.forName(Class.java:467)
hapi-server    | 	at org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl.classForName(ClassLoaderServiceImpl.java:123)
hapi-server    | 	... 129 common frames omitted
```

Fix
---
The latest `hapi` release supports this dialect [ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect](https://hapifhir.io/hapi-fhir/docs/server_jpa/database_support.html) which is the recommended dialect by hapi-fhir. 


More details
------------
In the latest hapi release, the artifact `ca.uhn.hapi.fhir:hapi-fhir` has been upgraded to version [7.0.0](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/blob/3ea85a05aaf2c2768a3aaf4414d4af2ef90dfa5d/pom.xml#L17). In this `7.0.0` version the [HIbernate.version](https://github.com/hapifhir/hapi-fhir/blob/0c3deda267f73892366c6e7b70bb0eee46de82f4/pom.xml#L952) used in `6.4.1.Final`. Support for the dialect `org.hibernate.dialect.PostgreSQL95Dialect` has been removed in this hibernate version and is replaced with `org.hibernate.dialect.PostgreSQLDialect`. We could have used this dialect instead, but hapi recommends using this
[ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect](https://hapifhir.io/hapi-fhir/docs/server_jpa/database_support.html)

<br class="Apple-interchange-newline">

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
