### PR TITLE
Merges StructureDefinition paths, adds `recursiveDepth` option, and makes ID columns consistent

### DIFF
--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -847,7 +847,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
   @Override
   public int getMaxDepth(String elementTypeUrl, String path) {
-    return this.recursiveDepth;
+    return Math.max(1, this.recursiveDepth);
   }
 
   private static HapiCompositeConverter createCompositeConverter(

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/NoOpConverter.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/NoOpConverter.java
@@ -39,7 +39,7 @@ public class NoOpConverter extends HapiConverter<Schema> {
   }
 
   @Override
-  public HapiConverter merge(HapiConverter other) throws ProfileException {
+  public HapiConverter<Schema> merge(HapiConverter<Schema> other) throws ProfileException {
     HapiConverterUtil.validateIfImplementationClassesAreSame(this, other);
     return this;
   }

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
@@ -97,7 +97,8 @@ public class GenerateAggregatedSchemas {
       List<String> resourceTypeURLs =
           ProfileMapperFhirContexts.getInstance()
               .getMappedProfilesForResource(FhirVersionEnum.R4, resourceType);
-      AvroConverter aggregatedConverter = AvroConverter.forResources(fhirContext, resourceTypeURLs);
+      AvroConverter aggregatedConverter =
+          AvroConverter.forResources(fhirContext, resourceTypeURLs, 1, false);
       createOutputFile(resourceType, aggregatedConverter.getSchema(), outputDir);
     }
   }

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
@@ -98,7 +98,7 @@ public class GenerateAggregatedSchemas {
           ProfileMapperFhirContexts.getInstance()
               .getMappedProfilesForResource(FhirVersionEnum.R4, resourceType);
       AvroConverter aggregatedConverter =
-          AvroConverter.forResources(fhirContext, resourceTypeURLs, 1, false);
+          AvroConverter.forResources(fhirContext, resourceTypeURLs, 1);
       createOutputFile(resourceType, aggregatedConverter.getSchema(), outputDir);
     }
   }

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateAggregatedSchemas.java
@@ -44,18 +44,18 @@ public class GenerateAggregatedSchemas {
       }
       String outputDir = pairs.get(OUTPUT_DIR);
       generateAggregatedSchemas(
-          fhirVersionEnum, structureDefinitionsPath, isClasspath, resourceTypes, outputDir);
+          fhirVersionEnum, structureDefinitionsPath, resourceTypes, outputDir);
     } catch (Exception e) {
       System.out.println("Unable to generate aggregated schema, error=" + e.getMessage());
       System.out.println(
           "The arguments should be of the format: fhirVersion=<fhirVersion>"
-              + " structureDefinitionsPath=<Path for structure definitions> isClasspath=<Boolean>"
+              + " structureDefinitionsPath=<Path for structure definitions>"
               + " resourceTypes=<Comma Separated resource types> outputDir=<Path for generated"
               + " schemas>");
       System.out.println("Example Arguments:");
       System.out.println(
           "fhirVersion=R4"
-              + " structureDefinitionsPath=/r4-us-core-definitions isClasspath=true"
+              + " structureDefinitionsPath=classpath:/r4-us-core-definitions"
               + " resourceTypes=Patient,Observation outputDir=/usr/tmp");
       System.out.println();
       e.printStackTrace();
@@ -78,7 +78,6 @@ public class GenerateAggregatedSchemas {
   private static void generateAggregatedSchemas(
       FhirVersionEnum fhirVersionEnum,
       String structureDefinitionsPath,
-      boolean isClasspath,
       List<String> resourceTypes,
       String outputDir)
       throws ProfileException, IOException {
@@ -90,15 +89,9 @@ public class GenerateAggregatedSchemas {
         String.format("%s cannot be empty", RESOURCE_TYPES));
     Preconditions.checkNotNull(outputDir, String.format("%s cannot be empty", OUTPUT_DIR));
     FhirContext fhirContext;
-    if (isClasspath) {
-      fhirContext =
-          ProfileMapperFhirContexts.getInstance()
-              .contextFromClasspathFor(fhirVersionEnum, structureDefinitionsPath);
-    } else {
-      fhirContext =
-          ProfileMapperFhirContexts.getInstance()
-              .contextFor(fhirVersionEnum, structureDefinitionsPath);
-    }
+    fhirContext =
+        ProfileMapperFhirContexts.getInstance()
+            .contextFor(fhirVersionEnum, structureDefinitionsPath);
 
     for (String resourceType : resourceTypes) {
       List<String> resourceTypeURLs =

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -65,7 +65,7 @@ public class GenerateSchemas {
 
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(fhirVersionEnum, structureDefinitionsPath);
+            .contextFor(fhirVersionEnum, structureDefinitionsPath);
     List<Schema> schemas = AvroConverter.generateSchemas(fhirContext, resourceTypeUrls);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -66,7 +66,7 @@ public class GenerateSchemas {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
             .contextFor(fhirVersionEnum, structureDefinitionsPath);
-    List<Schema> schemas = AvroConverter.generateSchemas(fhirContext, resourceTypeUrls);
+    List<Schema> schemas = AvroConverter.generateSchemas(fhirContext, resourceTypeUrls, 1, false);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol =

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -66,7 +66,7 @@ public class GenerateSchemas {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
             .contextFor(fhirVersionEnum, structureDefinitionsPath);
-    List<Schema> schemas = AvroConverter.generateSchemas(fhirContext, resourceTypeUrls, 1, false);
+    List<Schema> schemas = AvroConverter.generateSchemas(fhirContext, resourceTypeUrls, 1);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol =

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
@@ -40,8 +40,7 @@ public class AvroConverterMergeTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
 
-    AvroConverter mergedConverter =
-        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
+    AvroConverter mergedConverter = AvroConverter.forResources(fhirContext, patientProfiles, 1);
 
     InputStream inputStream =
         this.getClass().getResourceAsStream("/r4-custom-schemas/bunsen-test-patient-schema.json");
@@ -61,8 +60,7 @@ public class AvroConverterMergeTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
 
-    AvroConverter mergedConverter =
-        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
+    AvroConverter mergedConverter = AvroConverter.forResources(fhirContext, patientProfiles, 1);
 
     InputStream inputStream =
         this.getClass().getResourceAsStream("/stu3-custom-schemas/bunsen-test-patient-schema.json");
@@ -113,13 +111,14 @@ public class AvroConverterMergeTest {
 
     // We keep the fullId such that after HAPI->Avro->HAPI conversion, we get the same object.
     AvroConverter patientConverter =
-        AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, true);
+        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
     Patient patient =
         (Patient)
             loadResource(fhirContext, "/r4-us-core-resources/patient_us_core.json", Patient.class);
     IndexedRecord avroRecord = patientConverter.resourceToAvro(patient);
     Patient patientDecoded = (Patient) patientConverter.avroToResource(avroRecord);
+    // For why this is needed, see: https://github.com/google/fhir-data-pipes/issues/1003
+    patientDecoded.setId(patient.getIdElement());
     Assert.assertTrue(patient.equalsDeep(patientDecoded));
   }
 
@@ -131,8 +130,7 @@ public class AvroConverterMergeTest {
             .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(
-            fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
     org.hl7.fhir.dstu3.model.Patient patient =
         (org.hl7.fhir.dstu3.model.Patient)
             loadResource(
@@ -152,8 +150,7 @@ public class AvroConverterMergeTest {
   private void validateSchema(
       String expectedSchemaFile, List<String> profileResourceTypeUrls, FhirContext fhirContext)
       throws ProfileException, IOException {
-    AvroConverter converter =
-        AvroConverter.forResources(fhirContext, profileResourceTypeUrls, 1, false);
+    AvroConverter converter = AvroConverter.forResources(fhirContext, profileResourceTypeUrls, 1);
     InputStream inputStream = this.getClass().getResourceAsStream(expectedSchemaFile);
     Schema expectedSchema = new Parser().parse(inputStream);
     Assert.assertEquals(expectedSchema, converter.getSchema());

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
@@ -33,7 +33,7 @@ public class AvroConverterMergeTest {
   public void validateMergedR4CustomPatientSchema() throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.R4, "/r4-custom-profile-definitions");
+            .contextFor(FhirVersionEnum.R4, "classpath:/r4-custom-profile-definitions");
 
     List<String> patientProfiles =
         Arrays.asList(
@@ -53,7 +53,7 @@ public class AvroConverterMergeTest {
   public void validateMergedStu3CustomPatientSchema() throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.DSTU3, "/stu3-custom-profile-definitions");
+            .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-custom-profile-definitions");
 
     List<String> patientProfiles =
         Arrays.asList(
@@ -73,7 +73,7 @@ public class AvroConverterMergeTest {
   public void validateMergedR4UsCoreSchemas() throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.R4, "/r4-us-core-definitions");
+            .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
     validateSchema(
         "/r4-us-core-schemas/us-core-patient-schema.json",
         R4UsCoreProfileData.US_CORE_PATIENT_PROFILES,
@@ -92,7 +92,7 @@ public class AvroConverterMergeTest {
   public void validateMergedStu3UsCoreSchemas() throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.DSTU3, "/stu3-us-core-definitions");
+            .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
     validateSchema(
         "/stu3-us-core-schemas/us-core-patient-schema.json",
         Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES,
@@ -107,7 +107,7 @@ public class AvroConverterMergeTest {
   public void validateR4UsCoreResourceWithExtension() throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.R4, "/r4-us-core-definitions");
+            .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
 
     AvroConverter patientConverter =
         AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES);
@@ -128,7 +128,7 @@ public class AvroConverterMergeTest {
       throws ProfileException, IOException {
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.DSTU3, "/stu3-us-core-definitions");
+            .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
 
     AvroConverter patientConverter =
         AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
@@ -109,7 +109,6 @@ public class AvroConverterMergeTest {
         ProfileMapperFhirContexts.getInstance()
             .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
 
-    // We keep the fullId such that after HAPI->Avro->HAPI conversion, we get the same object.
     AvroConverter patientConverter =
         AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
     Patient patient =

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterMergeTest.java
@@ -40,7 +40,8 @@ public class AvroConverterMergeTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
 
-    AvroConverter mergedConverter = AvroConverter.forResources(fhirContext, patientProfiles);
+    AvroConverter mergedConverter =
+        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
 
     InputStream inputStream =
         this.getClass().getResourceAsStream("/r4-custom-schemas/bunsen-test-patient-schema.json");
@@ -60,7 +61,8 @@ public class AvroConverterMergeTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
 
-    AvroConverter mergedConverter = AvroConverter.forResources(fhirContext, patientProfiles);
+    AvroConverter mergedConverter =
+        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
 
     InputStream inputStream =
         this.getClass().getResourceAsStream("/stu3-custom-schemas/bunsen-test-patient-schema.json");
@@ -109,17 +111,15 @@ public class AvroConverterMergeTest {
         ProfileMapperFhirContexts.getInstance()
             .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
 
+    // We keep the fullId such that after HAPI->Avro->HAPI conversion, we get the same object.
     AvroConverter patientConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, true);
     Patient patient =
         (Patient)
             loadResource(fhirContext, "/r4-us-core-resources/patient_us_core.json", Patient.class);
     IndexedRecord avroRecord = patientConverter.resourceToAvro(patient);
     Patient patientDecoded = (Patient) patientConverter.avroToResource(avroRecord);
-    // TODO: When the objects are converted from HAPI->Avro->HAPI, in the resource ID only the
-    //  IDElement part is retained. This needs to be consistent and is tracked here:
-    // https://github.com/google/fhir-data-pipes/issues/1003
-    patientDecoded.setId(patient.getIdElement());
     Assert.assertTrue(patient.equalsDeep(patientDecoded));
   }
 
@@ -131,7 +131,8 @@ public class AvroConverterMergeTest {
             .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
     org.hl7.fhir.dstu3.model.Patient patient =
         (org.hl7.fhir.dstu3.model.Patient)
             loadResource(
@@ -151,7 +152,8 @@ public class AvroConverterMergeTest {
   private void validateSchema(
       String expectedSchemaFile, List<String> profileResourceTypeUrls, FhirContext fhirContext)
       throws ProfileException, IOException {
-    AvroConverter converter = AvroConverter.forResources(fhirContext, profileResourceTypeUrls);
+    AvroConverter converter =
+        AvroConverter.forResources(fhirContext, profileResourceTypeUrls, 1, false);
     InputStream inputStream = this.getClass().getResourceAsStream(expectedSchemaFile);
     Schema expectedSchema = new Parser().parse(inputStream);
     Assert.assertEquals(expectedSchema, converter.getSchema());

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
@@ -35,7 +35,7 @@ public class R4AvroConverterCustomProfileTest {
     ProfileMapperFhirContexts.getInstance().deRegisterFhirContexts(FhirVersionEnum.R4);
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.R4, "/r4-custom-profile-definitions");
+            .contextFor(FhirVersionEnum.R4, "classpath:/r4-custom-profile-definitions");
     List<String> patientProfiles =
         Arrays.asList(
             "http://hl7.org/fhir/StructureDefinition/Patient",

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
@@ -41,7 +41,7 @@ public class R4AvroConverterCustomProfileTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
     AvroConverter converterBunsenTestProfilePatient =
-        AvroConverter.forResources(fhirContext, patientProfiles);
+        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
 
     avroBunsenTestProfilePatient =
         (Record) converterBunsenTestProfilePatient.resourceToAvro(testBunsenTestProfilePatient);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterCustomProfileTest.java
@@ -41,7 +41,7 @@ public class R4AvroConverterCustomProfileTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
     AvroConverter converterBunsenTestProfilePatient =
-        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
+        AvroConverter.forResources(fhirContext, patientProfiles, 1);
 
     avroBunsenTestProfilePatient =
         (Record) converterBunsenTestProfilePatient.resourceToAvro(testBunsenTestProfilePatient);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
@@ -118,7 +118,7 @@ public class R4AvroConverterUsCoreTest {
 
     AvroConverter observationConverter =
         AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1, false);
+            fhirContext, R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1);
 
     avroObservation = (Record) observationConverter.resourceToAvro(testObservation);
 
@@ -130,31 +130,28 @@ public class R4AvroConverterUsCoreTest {
     testObservationDecodedNullStatus =
         (Observation) observationConverter.avroToResource(avroObservationNullStatus);
 
-    AvroConverter taskConverter = AvroConverter.forResource(fhirContext, "Task", 1, false);
+    AvroConverter taskConverter = AvroConverter.forResource(fhirContext, "Task", 1);
 
     avroTask = (Record) taskConverter.resourceToAvro(testTask);
 
     testTaskDecoded = (Task) taskConverter.avroToResource(avroTask);
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
 
     avroPatient = (Record) patientConverter.resourceToAvro(testPatient);
 
     testPatientDecoded = (Patient) patientConverter.avroToResource(avroPatient);
 
     AvroConverter conditionConverter =
-        AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1);
 
     avroCondition = (Record) conditionConverter.resourceToAvro(testCondition);
 
     testConditionDecoded = (Condition) conditionConverter.avroToResource(avroCondition);
 
     AvroConverter medicationConverter =
-        AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1);
 
     Record avroMedication = (Record) medicationConverter.resourceToAvro(testMedicationOne);
 
@@ -166,8 +163,7 @@ public class R4AvroConverterUsCoreTest {
             fhirContext,
             TestData.US_CORE_MEDICATION_REQUEST,
             Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE),
-            1,
-            false);
+            1);
 
     avroMedicationRequest =
         (Record) medicationRequestConverter.resourceToAvro(testMedicationRequest);
@@ -176,8 +172,7 @@ public class R4AvroConverterUsCoreTest {
         (MedicationRequest) medicationRequestConverter.avroToResource(avroMedicationRequest);
 
     AvroConverter encounterConverter =
-        AvroConverter.forResources(
-            fhirContext, R4UsCoreProfileData.US_CORE_ENCOUNTER_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_ENCOUNTER_PROFILES, 1);
     avroEncounter = (Record) encounterConverter.resourceToAvro(testEncounter);
     testEncounterDecoded = (Encounter) encounterConverter.avroToResource(avroEncounter);
   }
@@ -496,8 +491,7 @@ public class R4AvroConverterUsCoreTest {
                 Collections.emptyList(),
                 TestData.US_CORE_MEDICATION_REQUEST,
                 ImmutableList.of(TestData.US_CORE_MEDICATION)),
-            1,
-            false);
+            1);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol = new Protocol("fhir-test", "FHIR Resources for Testing", null);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
@@ -117,7 +117,8 @@ public class R4AvroConverterUsCoreTest {
             .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
 
     AvroConverter observationConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1, false);
 
     avroObservation = (Record) observationConverter.resourceToAvro(testObservation);
 
@@ -129,28 +130,31 @@ public class R4AvroConverterUsCoreTest {
     testObservationDecodedNullStatus =
         (Observation) observationConverter.avroToResource(avroObservationNullStatus);
 
-    AvroConverter taskConverter = AvroConverter.forResource(fhirContext, "Task");
+    AvroConverter taskConverter = AvroConverter.forResource(fhirContext, "Task", 1, false);
 
     avroTask = (Record) taskConverter.resourceToAvro(testTask);
 
     testTaskDecoded = (Task) taskConverter.avroToResource(avroTask);
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
 
     avroPatient = (Record) patientConverter.resourceToAvro(testPatient);
 
     testPatientDecoded = (Patient) patientConverter.avroToResource(avroPatient);
 
     AvroConverter conditionConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_CONDITION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1, false);
 
     avroCondition = (Record) conditionConverter.resourceToAvro(testCondition);
 
     testConditionDecoded = (Condition) conditionConverter.avroToResource(avroCondition);
 
     AvroConverter medicationConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_MEDICATION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1, false);
 
     Record avroMedication = (Record) medicationConverter.resourceToAvro(testMedicationOne);
 
@@ -161,7 +165,9 @@ public class R4AvroConverterUsCoreTest {
         AvroConverter.forResource(
             fhirContext,
             TestData.US_CORE_MEDICATION_REQUEST,
-            Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE));
+            Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE),
+            1,
+            false);
 
     avroMedicationRequest =
         (Record) medicationRequestConverter.resourceToAvro(testMedicationRequest);
@@ -170,7 +176,8 @@ public class R4AvroConverterUsCoreTest {
         (MedicationRequest) medicationRequestConverter.avroToResource(avroMedicationRequest);
 
     AvroConverter encounterConverter =
-        AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_ENCOUNTER_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, R4UsCoreProfileData.US_CORE_ENCOUNTER_PROFILES, 1, false);
     avroEncounter = (Record) encounterConverter.resourceToAvro(testEncounter);
     testEncounterDecoded = (Encounter) encounterConverter.avroToResource(avroEncounter);
   }
@@ -488,7 +495,9 @@ public class R4AvroConverterUsCoreTest {
                 TestData.VALUE_SET,
                 Collections.emptyList(),
                 TestData.US_CORE_MEDICATION_REQUEST,
-                ImmutableList.of(TestData.US_CORE_MEDICATION)));
+                ImmutableList.of(TestData.US_CORE_MEDICATION)),
+            1,
+            false);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol = new Protocol("fhir-test", "FHIR Resources for Testing", null);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/R4AvroConverterUsCoreTest.java
@@ -114,7 +114,7 @@ public class R4AvroConverterUsCoreTest {
     ProfileMapperFhirContexts.getInstance().deRegisterFhirContexts(FhirVersionEnum.R4);
     fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.R4, "/r4-us-core-definitions");
+            .contextFor(FhirVersionEnum.R4, "classpath:/r4-us-core-definitions");
 
     AvroConverter observationConverter =
         AvroConverter.forResources(fhirContext, R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
@@ -43,7 +43,7 @@ public class Stu3AvroConverterCustomProfileTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
     AvroConverter converterBunsenTestProfilePatient =
-        AvroConverter.forResources(fhirContext, patientProfiles);
+        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
 
     avroBunsenTestProfilePatient =
         (Record) converterBunsenTestProfilePatient.resourceToAvro(testBunsenTestProfilePatient);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
@@ -37,7 +37,7 @@ public class Stu3AvroConverterCustomProfileTest {
     ProfileMapperFhirContexts.getInstance().deRegisterFhirContexts(FhirVersionEnum.DSTU3);
     FhirContext fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.DSTU3, "/stu3-custom-profile-definitions");
+            .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-custom-profile-definitions");
     List<String> patientProfiles =
         Arrays.asList(
             "http://hl7.org/fhir/StructureDefinition/Patient",

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterCustomProfileTest.java
@@ -43,7 +43,7 @@ public class Stu3AvroConverterCustomProfileTest {
             "http://hl7.org/fhir/StructureDefinition/Patient",
             "http://hl7.org/fhir/bunsen/test/StructureDefinition/bunsen-test-patient");
     AvroConverter converterBunsenTestProfilePatient =
-        AvroConverter.forResources(fhirContext, patientProfiles, 1, false);
+        AvroConverter.forResources(fhirContext, patientProfiles, 1);
 
     avroBunsenTestProfilePatient =
         (Record) converterBunsenTestProfilePatient.resourceToAvro(testBunsenTestProfilePatient);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
@@ -96,7 +96,8 @@ public class Stu3AvroConverterUsCoreTest {
         ProfileMapperFhirContexts.getInstance()
             .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
     AvroConverter observationConverter =
-        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_OBSERVATION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, Stu3UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1, false);
 
     avroObservation = (Record) observationConverter.resourceToAvro(testObservation);
 
@@ -109,21 +110,24 @@ public class Stu3AvroConverterUsCoreTest {
         (Observation) observationConverter.avroToResource(avroObservationNullStatus);
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
 
     avroPatient = (Record) patientConverter.resourceToAvro(testPatient);
 
     testPatientDecoded = (Patient) patientConverter.avroToResource(avroPatient);
 
     AvroConverter conditionConverter =
-        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_CONDITION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, Stu3UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1, false);
 
     avroCondition = (Record) conditionConverter.resourceToAvro(testCondition);
 
     testConditionDecoded = (Condition) conditionConverter.avroToResource(avroCondition);
 
     AvroConverter medicationConverter =
-        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_MEDICATION_PROFILES);
+        AvroConverter.forResources(
+            fhirContext, Stu3UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1, false);
 
     Record avroMedication = (Record) medicationConverter.resourceToAvro(testMedicationOne);
 
@@ -134,7 +138,9 @@ public class Stu3AvroConverterUsCoreTest {
         AvroConverter.forResource(
             fhirContext,
             TestData.US_CORE_MEDICATION_REQUEST,
-            Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE));
+            Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE),
+            1,
+            false);
 
     avroMedicationRequest =
         (Record) medicationRequestConverter.resourceToAvro(testMedicationRequest);
@@ -449,7 +455,9 @@ public class Stu3AvroConverterUsCoreTest {
                 TestData.VALUE_SET,
                 Collections.emptyList(),
                 TestData.US_CORE_MEDICATION_REQUEST,
-                ImmutableList.of(TestData.US_CORE_MEDICATION)));
+                ImmutableList.of(TestData.US_CORE_MEDICATION)),
+            1,
+            false);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol = new Protocol("fhir-test", "FHIR Resources for Testing", null);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
@@ -97,7 +97,7 @@ public class Stu3AvroConverterUsCoreTest {
             .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
     AvroConverter observationConverter =
         AvroConverter.forResources(
-            fhirContext, Stu3UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1, false);
+            fhirContext, Stu3UsCoreProfileData.US_CORE_OBSERVATION_PROFILES, 1);
 
     avroObservation = (Record) observationConverter.resourceToAvro(testObservation);
 
@@ -110,8 +110,7 @@ public class Stu3AvroConverterUsCoreTest {
         (Observation) observationConverter.avroToResource(avroObservationNullStatus);
 
     AvroConverter patientConverter =
-        AvroConverter.forResources(
-            fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1, false);
+        AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
 
     avroPatient = (Record) patientConverter.resourceToAvro(testPatient);
 
@@ -119,7 +118,7 @@ public class Stu3AvroConverterUsCoreTest {
 
     AvroConverter conditionConverter =
         AvroConverter.forResources(
-            fhirContext, Stu3UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1, false);
+            fhirContext, Stu3UsCoreProfileData.US_CORE_CONDITION_PROFILES, 1);
 
     avroCondition = (Record) conditionConverter.resourceToAvro(testCondition);
 
@@ -127,7 +126,7 @@ public class Stu3AvroConverterUsCoreTest {
 
     AvroConverter medicationConverter =
         AvroConverter.forResources(
-            fhirContext, Stu3UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1, false);
+            fhirContext, Stu3UsCoreProfileData.US_CORE_MEDICATION_PROFILES, 1);
 
     Record avroMedication = (Record) medicationConverter.resourceToAvro(testMedicationOne);
 
@@ -139,8 +138,7 @@ public class Stu3AvroConverterUsCoreTest {
             fhirContext,
             TestData.US_CORE_MEDICATION_REQUEST,
             Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE),
-            1,
-            false);
+            1);
 
     avroMedicationRequest =
         (Record) medicationRequestConverter.resourceToAvro(testMedicationRequest);
@@ -456,8 +454,7 @@ public class Stu3AvroConverterUsCoreTest {
                 Collections.emptyList(),
                 TestData.US_CORE_MEDICATION_REQUEST,
                 ImmutableList.of(TestData.US_CORE_MEDICATION)),
-            1,
-            false);
+            1);
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol = new Protocol("fhir-test", "FHIR Resources for Testing", null);

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/Stu3AvroConverterUsCoreTest.java
@@ -94,7 +94,7 @@ public class Stu3AvroConverterUsCoreTest {
     ProfileMapperFhirContexts.getInstance().deRegisterFhirContexts(FhirVersionEnum.DSTU3);
     fhirContext =
         ProfileMapperFhirContexts.getInstance()
-            .contextFromClasspathFor(FhirVersionEnum.DSTU3, "/stu3-us-core-definitions");
+            .contextFor(FhirVersionEnum.DSTU3, "classpath:/stu3-us-core-definitions");
     AvroConverter observationConverter =
         AvroConverter.forResources(fhirContext, Stu3UsCoreProfileData.US_CORE_OBSERVATION_PROFILES);
 

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitorTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitorTest.java
@@ -1,8 +1,6 @@
 package com.cerner.bunsen.avro.converters;
 
 import com.cerner.bunsen.definitions.StructureDefinitions;
-import java.util.HashSet;
-import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -10,8 +8,7 @@ public class DefinitionToAvroVisitorTest {
 
   @Test
   public void checkPrimitivesMap() {
-    Set<String> primitives = new HashSet<>(DefinitionToAvroVisitor.TYPE_TO_CONVERTER.keySet());
-    primitives.add("id");
-    Assert.assertEquals(primitives, StructureDefinitions.PRIMITIVE_TYPES);
+    Assert.assertEquals(
+        DefinitionToAvroVisitor.TYPE_TO_CONVERTER.keySet(), StructureDefinitions.PRIMITIVE_TYPES);
   }
 }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitorTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitorTest.java
@@ -1,6 +1,8 @@
 package com.cerner.bunsen.avro.converters;
 
 import com.cerner.bunsen.definitions.StructureDefinitions;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -8,7 +10,8 @@ public class DefinitionToAvroVisitorTest {
 
   @Test
   public void checkPrimitivesMap() {
-    Assert.assertEquals(
-        DefinitionToAvroVisitor.TYPE_TO_CONVERTER.keySet(), StructureDefinitions.PRIMITIVE_TYPES);
+    Set<String> primitives = new HashSet<>(DefinitionToAvroVisitor.TYPE_TO_CONVERTER.keySet());
+    primitives.add("id");
+    Assert.assertEquals(primitives, StructureDefinitions.PRIMITIVE_TYPES);
   }
 }

--- a/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
+++ b/bunsen/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
@@ -34,7 +34,7 @@ public class GenerateSchemasTest {
         new String[] {
           outputFile.toString(),
           "DSTU3",
-          "/stu3-us-core-definitions",
+          "classpath:/stu3-us-core-definitions",
           TestData.US_CORE_PATIENT,
           TestData.US_CORE_CONDITION,
           TestData.US_CORE_MEDICATION,

--- a/bunsen/bunsen-avro/src/test/resources/r4-us-core-resources/patient_us_core.json
+++ b/bunsen/bunsen-avro/src/test/resources/r4-us-core-resources/patient_us_core.json
@@ -1,6 +1,6 @@
 {
   "resourceType" : "Patient",
-  "id" : "http://example.com/Patient/123",
+  "id" : "123",
   "meta" : {
     "profile" : [
       "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|7.0.0-ballot"

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/ProfileMapperFhirContexts.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/ProfileMapperFhirContexts.java
@@ -80,8 +80,8 @@ public class ProfileMapperFhirContexts {
     if (!Objects.equals(fhirContextData.structureDefinitionsPath, structureDefinitionsPath)) {
       String errorMsg =
           String.format(
-              "Failed to initialise FhirContext with configs structureDefinitionsPath=%s, it is"
-                  + " already initialised with different configs structureDefinitionsPath=%s",
+              "Failed to initialise FhirContext with structureDefinitionsPath=%s, it is"
+                  + " already initialised with different structureDefinitionsPath=%s",
               structureDefinitionsPath, fhirContextData.structureDefinitionsPath);
       logger.error(errorMsg);
       throw new ProfileException(errorMsg);

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
@@ -103,5 +103,6 @@ public abstract class HapiConverter<T> {
    * @return the merged HapiConverter
    * @throws ProfileException
    */
-  public abstract HapiConverter merge(HapiConverter other) throws ProfileException;
+  // TODO this should have type parameter, i.e., HapiConverter<T>
+  public abstract HapiConverter<T> merge(HapiConverter<T> other) throws ProfileException;
 }

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
@@ -103,6 +103,5 @@ public abstract class HapiConverter<T> {
    * @return the merged HapiConverter
    * @throws ProfileException
    */
-  // TODO this should have type parameter, i.e., HapiConverter<T>
   public abstract HapiConverter<T> merge(HapiConverter<T> other) throws ProfileException;
 }

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IdConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IdConverter.java
@@ -5,18 +5,15 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 public class IdConverter<T> extends StringConverter<T> {
 
-  private final boolean fullId;
-
-  public IdConverter(T dataType, boolean fullId) {
+  public IdConverter(T dataType) {
     super(dataType);
-    this.fullId = fullId;
   }
 
   @Override
   protected Object fromHapi(IPrimitiveType primitive) {
     // We do this hack to work around the issue that `id` has type `System.String` in R4 (not `id`).
     // Note `id` elements of FHIR _types_ (not resources) are strings, not `IIdType`!
-    if (primitive instanceof IIdType && !this.fullId) {
+    if (primitive instanceof IIdType) {
       return ((IIdType) primitive).getIdPart();
     }
     return super.fromHapi(primitive);

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IdConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/IdConverter.java
@@ -5,15 +5,18 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 public class IdConverter<T> extends StringConverter<T> {
 
-  public IdConverter(T dataType) {
+  private final boolean fullId;
+
+  public IdConverter(T dataType, boolean fullId) {
     super(dataType);
+    this.fullId = fullId;
   }
 
   @Override
   protected Object fromHapi(IPrimitiveType primitive) {
     // We do this hack to work around the issue that `id` has type `System.String` in R4 (not `id`).
     // Note `id` elements of FHIR _types_ (not resources) are strings, not `IIdType`!
-    if (primitive instanceof IIdType) {
+    if (primitive instanceof IIdType && !this.fullId) {
       return ((IIdType) primitive).getIdPart();
     }
     return super.fromHapi(primitive);

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/LeafExtensionConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/LeafExtensionConverter.java
@@ -135,7 +135,7 @@ public class LeafExtensionConverter<T> extends HapiConverter<T> {
   }
 
   @Override
-  public HapiConverter merge(HapiConverter other) throws ProfileException {
+  public HapiConverter<T> merge(HapiConverter<T> other) throws ProfileException {
     HapiConverterUtil.validateIfImplementationClassesAreSame(this, other);
     if (Strings.isNullOrEmpty(this.extensionUrl())
         || Strings.isNullOrEmpty(other.extensionUrl())

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
@@ -78,7 +78,7 @@ public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
   }
 
   @Override
-  public HapiConverter merge(HapiConverter other) throws ProfileException {
+  public HapiConverter<T> merge(HapiConverter<T> other) throws ProfileException {
     HapiConverterUtil.validateIfImplementationClassesAreSame(this, other);
     validateIfElementTypesAreSame(other);
     return this;

--- a/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/ProfileMapperProviderTest.java
+++ b/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/ProfileMapperProviderTest.java
@@ -20,7 +20,7 @@ public class ProfileMapperProviderTest {
     ProfileMappingProvider profileMappingProvider = new ProfileMappingProvider();
     FhirContext fhirContext = new FhirContext(FhirVersionEnum.R4);
     Map<String, List<String>> profileMapping =
-        profileMappingProvider.loadStructureDefinitions(fhirContext, null, false);
+        profileMappingProvider.loadStructureDefinitions(fhirContext, null);
     assertThat(profileMapping.get("Patient"), Matchers.notNullValue());
     assertThat(
         profileMapping.get("Patient").toArray(),
@@ -40,7 +40,7 @@ public class ProfileMapperProviderTest {
     FhirContext fhirContext = new FhirContext(FhirVersionEnum.R4);
     Map<String, List<String>> profileMapping =
         profileMappingProvider.loadStructureDefinitions(
-            fhirContext, "/r4-us-core-definitions", true);
+            fhirContext, "classpath:/r4-us-core-definitions");
 
     assertThat(profileMapping.get("Patient"), Matchers.notNullValue());
     assertThat(
@@ -61,7 +61,7 @@ public class ProfileMapperProviderTest {
     FhirContext fhirContext = new FhirContext(FhirVersionEnum.DSTU3);
     Map<String, List<String>> profileMapping =
         profileMappingProvider.loadStructureDefinitions(
-            fhirContext, "/stu3-us-core-definitions", true);
+            fhirContext, "classpath:/stu3-us-core-definitions");
 
     assertThat(profileMapping.get("Patient"), Matchers.notNullValue());
     assertThat(

--- a/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/definitions/IdConverterTest.java
+++ b/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/definitions/IdConverterTest.java
@@ -10,32 +10,25 @@ import org.junit.Test;
 public class IdConverterTest {
 
   private IdConverter<ArbitraryDataType> idConverter;
-  private IdConverter<ArbitraryDataType> fullIdConverter;
 
   @Before
   public void setUp() {
-    idConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType(), false);
-    fullIdConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType(), true);
+    idConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType());
   }
 
   @Test
   public void relativePathTest() {
     assertThat(idConverter.fromHapi(new IdType("Patient/123")), equalTo("123"));
-    assertThat(fullIdConverter.fromHapi(new IdType("Patient/123")), equalTo("Patient/123"));
   }
 
   @Test
   public void absoluteUrlTest() {
     assertThat(idConverter.fromHapi(new IdType("http://fhir.server/Patient/123")), equalTo("123"));
-    assertThat(
-        fullIdConverter.fromHapi(new IdType("http://fhir.server/Patient/123")),
-        equalTo("http://fhir.server/Patient/123"));
   }
 
   @Test
   public void idPartTest() {
     assertThat(idConverter.fromHapi(new IdType("123")), equalTo("123"));
-    assertThat(fullIdConverter.fromHapi(new IdType("123")), equalTo("123"));
   }
 
   // In real scenarios this would be the specific type to/from which the HAPI conversion happens,

--- a/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/definitions/IdConverterTest.java
+++ b/bunsen/bunsen-core/src/test/java/com/cerner/bunsen/definitions/IdConverterTest.java
@@ -10,25 +10,32 @@ import org.junit.Test;
 public class IdConverterTest {
 
   private IdConverter<ArbitraryDataType> idConverter;
+  private IdConverter<ArbitraryDataType> fullIdConverter;
 
   @Before
   public void setUp() {
-    idConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType());
+    idConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType(), false);
+    fullIdConverter = new IdConverter<ArbitraryDataType>(new ArbitraryDataType(), true);
   }
 
   @Test
   public void relativePathTest() {
-    assertThat(idConverter.fromHapi(new IdType("Patinet/123")), equalTo("123"));
+    assertThat(idConverter.fromHapi(new IdType("Patient/123")), equalTo("123"));
+    assertThat(fullIdConverter.fromHapi(new IdType("Patient/123")), equalTo("Patient/123"));
   }
 
   @Test
   public void absoluteUrlTest() {
-    assertThat(idConverter.fromHapi(new IdType("http://fhir.server/Patinet/123")), equalTo("123"));
+    assertThat(idConverter.fromHapi(new IdType("http://fhir.server/Patient/123")), equalTo("123"));
+    assertThat(
+        fullIdConverter.fromHapi(new IdType("http://fhir.server/Patient/123")),
+        equalTo("http://fhir.server/Patient/123"));
   }
 
   @Test
   public void idPartTest() {
     assertThat(idConverter.fromHapi(new IdType("123")), equalTo("123"));
+    assertThat(fullIdConverter.fromHapi(new IdType("123")), equalTo("123"));
   }
 
   // In real scenarios this would be the specific type to/from which the HAPI conversion happens,

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -43,6 +43,8 @@ fhirdata:
   rowGroupSizeForParquetFiles: 33554432   # 32mb
   viewDefinitionsDir: "config/views"
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
+  recursiveDepth: 1
+  fullId: false
 
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -44,7 +44,6 @@ fhirdata:
   viewDefinitionsDir: "config/views"
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
   recursiveDepth: 1
-  fullId: false
 
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -37,8 +37,8 @@ fhirdata:
   createHiveResourceTables: true
   thriftserverHiveConfig: "config/thriftserver-hive-config_local.json"
   hiveResourceViewsDir: "config/views"
-  # structureDefinitionsDir: "config/profile-definitions"
-  structureDefinitionsClasspath: "/r4-us-core-definitions"
+  # structureDefinitionsPath: "config/profile-definitions"
+  structureDefinitionsPath: "classpath:/r4-us-core-definitions"
   fhirVersion: "R4"
   rowGroupSizeForParquetFiles: 33554432   # 32mb
   viewDefinitionsDir: "config/views"

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -55,9 +55,10 @@ public interface BasePipelineOptions extends PipelineOptions {
   void setFhirVersion(FhirVersionEnum fhirVersionEnum);
 
   @Description(
-      "The maximum depth for traversing StructureDefinitions in Parquet schema generation."
-          + " Please note in most cases, the default 1 is sufficient and increasing that can"
-          + " result in significantly larger schema and more complexity. For details see:"
+      "The maximum depth for traversing StructureDefinitions in Parquet schema generation"
+          + " (if it is non-positive, the default 1 will be used). Note in most cases, "
+          + " the default 1 is sufficient and increasing that can result in significantly "
+          + " larger schema and more complexity. For details see:"
           + " https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures")
   @Default.Integer(1)
   Integer getRecursiveDepth();

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -39,24 +39,14 @@ public interface BasePipelineOptions extends PipelineOptions {
 
   @Description(
       "Directory containing the structure definition files for any custom profiles that needs to be"
-          + " supported")
+          + " supported. If it starts with `classpath:` then the classpath is searched; and the"
+          + " path should always start with `/`. Do not use this if custom profiles are not needed."
+          + " Example: `classpath:/r4-us-core-definitions` is the classpath name under the"
+          + " resources folder of module `extension-structure-definitions`.")
   @Default.String("")
-  String getStructureDefinitionsDir();
+  String getStructureDefinitionsPath();
 
-  void setStructureDefinitionsDir(String value);
-
-  @Description(
-      "Similar to the structureDefinitionsDir, this path should also contain the structure"
-          + " definition files for any custom profiles that needs to be supported. But the"
-          + " difference is that, this is the classpath name instead of a directory name and should"
-          + " always start with a '/'. Also, only one of the structureDefinitionsDir or"
-          + " structureDefinitionsClasspath parameters can be configured, do not configure anything"
-          + " if custom profiles are not needed. e.g., /r4-us-core-definitions is the"
-          + " classpath name under the resources folder of module extension-structure-definitions")
-  @Default.String("")
-  String getStructureDefinitionsClasspath();
-
-  void setStructureDefinitionsClasspath(String value);
+  void setStructureDefinitionsPath(String value);
 
   @Description("The fhir version to be used for the FHIR Context APIs")
   @Default.Enum("R4")

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -53,4 +53,20 @@ public interface BasePipelineOptions extends PipelineOptions {
   FhirVersionEnum getFhirVersion();
 
   void setFhirVersion(FhirVersionEnum fhirVersionEnum);
+
+  @Description(
+      "The maximum depth for traversing StructureDefinitions in Parquet schema generation."
+          + " Please note in most cases, the default 1 is sufficient and increasing that can"
+          + " result in significantly larger schema and more complexity. For details see:"
+          + " https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures")
+  @Default.Integer(1)
+  Integer getRecursiveDepth();
+
+  void setRecursiveDepth(Integer value);
+
+  @Description("Whether to generate the full ID (including type) or only the logical part.")
+  @Default.Boolean(false)
+  Boolean getFullId();
+
+  void setFullId(Boolean value);
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -63,10 +63,4 @@ public interface BasePipelineOptions extends PipelineOptions {
   Integer getRecursiveDepth();
 
   void setRecursiveDepth(Integer value);
-
-  @Description("Whether to generate the full ID (including type) or only the logical part.")
-  @Default.Boolean(false)
-  Boolean getFullId();
-
-  void setFullId(Boolean value);
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -110,9 +110,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   private FhirVersionEnum fhirVersionEnum;
 
-  private String structureDefinitionsDir;
-
-  private String structureDefinitionsClasspath;
+  private String structureDefinitionsPath;
 
   protected AvroConversionUtil avroConversionUtil;
 
@@ -131,8 +129,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     this.secondsToFlush = options.getSecondsToFlushParquetFiles();
     this.rowGroupSize = options.getRowGroupSizeForParquetFiles();
     this.viewDefinitionsDir = options.getViewDefinitionsDir();
-    this.structureDefinitionsDir = options.getStructureDefinitionsDir();
-    this.structureDefinitionsClasspath = options.getStructureDefinitionsClasspath();
+    this.structureDefinitionsPath = options.getStructureDefinitionsPath();
     this.fhirVersionEnum = options.getFhirVersion();
     if (options.getSinkDbConfigPath().isEmpty()) {
       this.sinkDbConfig = null;
@@ -170,9 +167,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
   @Setup
   public void setup() throws SQLException, PropertyVetoException, ProfileException {
     log.debug("Starting setup for stage " + stageIdentifier);
-    avroConversionUtil =
-        AvroConversionUtil.getInstance(
-            fhirVersionEnum, structureDefinitionsDir, structureDefinitionsClasspath);
+    avroConversionUtil = AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath);
     FhirContext fhirContext = avroConversionUtil.getFhirContext();
     // The documentation for `FhirContext` claims that it is thread-safe but looking at the code,
     // it is not obvious if it is. This might be an issue when we write to it, like the next line.
@@ -204,8 +199,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
       parquetUtil =
           new ParquetUtil(
               fhirContext.getVersion().getVersion(),
-              structureDefinitionsDir,
-              structureDefinitionsClasspath,
+              structureDefinitionsPath,
               parquetFile,
               secondsToFlush,
               rowGroupSize,

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -90,8 +90,6 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   private final int recursiveDepth;
 
-  private final boolean fullId;
-
   protected final DataSourceConfig sinkDbConfig;
 
   protected final String viewDefinitionsDir;
@@ -136,7 +134,6 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     this.structureDefinitionsPath = options.getStructureDefinitionsPath();
     this.fhirVersionEnum = options.getFhirVersion();
     this.recursiveDepth = options.getRecursiveDepth();
-    this.fullId = options.getFullId();
     if (options.getSinkDbConfigPath().isEmpty()) {
       this.sinkDbConfig = null;
     } else {
@@ -174,8 +171,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
   public void setup() throws SQLException, PropertyVetoException, ProfileException {
     log.debug("Starting setup for stage " + stageIdentifier);
     avroConversionUtil =
-        AvroConversionUtil.getInstance(
-            fhirVersionEnum, structureDefinitionsPath, recursiveDepth, fullId);
+        AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath, recursiveDepth);
     FhirContext fhirContext = avroConversionUtil.getFhirContext();
     // The documentation for `FhirContext` claims that it is thread-safe but looking at the code,
     // it is not obvious if it is. This might be an issue when we write to it, like the next line.
@@ -212,8 +208,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
               secondsToFlush,
               rowGroupSize,
               stageIdentifier + "_",
-              recursiveDepth,
-              fullId);
+              recursiveDepth);
     }
     if (sinkDbConfig != null) {
       DataSource jdbcSink =

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -444,9 +444,7 @@ public class FhirEtl {
     validateOptions(options);
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            options.getFhirVersion(),
-            options.getStructureDefinitionsDir(),
-            options.getStructureDefinitionsClasspath());
+            options.getFhirVersion(), options.getStructureDefinitionsPath());
     List<Pipeline> pipelines = setupAndBuildPipelines(options, avroConversionUtil);
     EtlUtils.runMultiplePipelinesWithTimestamp(
         pipelines, options, avroConversionUtil.getFhirContext());

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -444,7 +444,10 @@ public class FhirEtl {
     validateOptions(options);
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            options.getFhirVersion(), options.getStructureDefinitionsPath());
+            options.getFhirVersion(),
+            options.getStructureDefinitionsPath(),
+            options.getRecursiveDepth(),
+            options.getFullId());
     List<Pipeline> pipelines = setupAndBuildPipelines(options, avroConversionUtil);
     EtlUtils.runMultiplePipelinesWithTimestamp(
         pipelines, options, avroConversionUtil.getFhirContext());

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -446,8 +446,7 @@ public class FhirEtl {
         AvroConversionUtil.getInstance(
             options.getFhirVersion(),
             options.getStructureDefinitionsPath(),
-            options.getRecursiveDepth(),
-            options.getFullId());
+            options.getRecursiveDepth());
     List<Pipeline> pipelines = setupAndBuildPipelines(options, avroConversionUtil);
     EtlUtils.runMultiplePipelinesWithTimestamp(
         pipelines, options, avroConversionUtil.getFhirContext());

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -260,8 +260,7 @@ public class ParquetMerger {
         AvroConversionUtil.getInstance(
             options.getFhirVersion(),
             options.getStructureDefinitionsPath(),
-            options.getRecursiveDepth(),
-            options.getFullId());
+            options.getRecursiveDepth());
     if (options.getDwh1().isEmpty()
         || options.getDwh2().isEmpty()
         || options.getMergedDwh().isEmpty()) {

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -258,9 +258,7 @@ public class ParquetMerger {
     log.info("Flags: " + options);
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            options.getFhirVersion(),
-            options.getStructureDefinitionsDir(),
-            options.getStructureDefinitionsClasspath());
+            options.getFhirVersion(), options.getStructureDefinitionsPath());
     if (options.getDwh1().isEmpty()
         || options.getDwh2().isEmpty()
         || options.getMergedDwh().isEmpty()) {

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -258,7 +258,10 @@ public class ParquetMerger {
     log.info("Flags: " + options);
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            options.getFhirVersion(), options.getStructureDefinitionsPath());
+            options.getFhirVersion(),
+            options.getStructureDefinitionsPath(),
+            options.getRecursiveDepth(),
+            options.getFullId());
     if (options.getDwh1().isEmpty()
         || options.getDwh2().isEmpty()
         || options.getMergedDwh().isEmpty()) {

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ReadJsonFilesFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ReadJsonFilesFn.java
@@ -19,7 +19,6 @@ import ca.uhn.fhir.parser.DataFormatException;
 import com.cerner.bunsen.exception.ProfileException;
 import com.google.common.collect.Sets;
 import com.google.fhir.analytics.view.ViewApplicationException;
-import java.beans.PropertyVetoException;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.sql.SQLException;

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchOpenMrsTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchOpenMrsTest.java
@@ -71,8 +71,6 @@ public class JdbcFetchOpenMrsTest extends TestCase {
 
   private JdbcFetchOpenMrs jdbcFetchUtil;
 
-  private ParquetUtil parquetUtil;
-
   private String basePath = "/tmp/JUNIT/Parquet/TEST/";
 
   private DataSource mockedDataSource;
@@ -97,7 +95,6 @@ public class JdbcFetchOpenMrsTest extends TestCase {
 
     mockedDataSource = mock(DataSource.class, withSettings().serializable());
     jdbcFetchUtil = new JdbcFetchOpenMrs(mockedDataSource);
-    parquetUtil = new ParquetUtil(fhirContext.getVersion().getVersion(), basePath);
     // clean up if folder exists
     File file = new File(basePath);
     if (file.exists()) FileUtils.cleanDirectory(file);

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/AvroConversionUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/AvroConversionUtil.java
@@ -54,15 +54,13 @@ public class AvroConversionUtil {
 
   private final Map<String, AvroConverter> converterMap;
 
-  private ProfileMapperFhirContexts profileMapperFhirContexts;
+  private final ProfileMapperFhirContexts profileMapperFhirContexts;
 
   private final FhirContext fhirContext;
 
-  private FhirVersionEnum fhirVersionEnum;
+  private final FhirVersionEnum fhirVersionEnum;
 
-  private String structureDefinitionsDir;
-
-  private String structureDefinitionsClasspath;
+  private final String structureDefinitionsPath;
 
   /**
    * This is to fix the logical type conversions for BigDecimal. This should be called once before
@@ -79,64 +77,36 @@ public class AvroConversionUtil {
   }
 
   private AvroConversionUtil(
-      FhirVersionEnum fhirVersionEnum,
-      @Nullable String structureDefinitionsDir,
-      @Nullable String structureDefinitionsClasspath)
+      FhirVersionEnum fhirVersionEnum, @Nullable String structureDefinitionsPath)
       throws ProfileException {
     this.fhirVersionEnum = fhirVersionEnum;
-    this.structureDefinitionsDir = structureDefinitionsDir;
-    this.structureDefinitionsClasspath = structureDefinitionsClasspath;
+    this.structureDefinitionsPath = structureDefinitionsPath;
     this.converterMap = Maps.newHashMap();
     this.profileMapperFhirContexts = ProfileMapperFhirContexts.getInstance();
-    if (!Strings.isNullOrEmpty(structureDefinitionsClasspath)) {
-      this.fhirContext =
-          profileMapperFhirContexts.contextFromClasspathFor(
-              fhirVersionEnum, structureDefinitionsClasspath);
-    } else {
-      this.fhirContext =
-          profileMapperFhirContexts.contextFor(fhirVersionEnum, structureDefinitionsDir);
-    }
+    this.fhirContext =
+        profileMapperFhirContexts.contextFor(fhirVersionEnum, structureDefinitionsPath);
   }
 
   static synchronized AvroConversionUtil getInstance(
-      FhirVersionEnum fhirVersionEnum,
-      @Nullable String structureDefinitionsDir,
-      @Nullable String structureDefinitionsClasspath)
+      FhirVersionEnum fhirVersionEnum, @Nullable String structureDefinitionsPath)
       throws ProfileException {
     Preconditions.checkNotNull(fhirVersionEnum, "fhirVersionEnum cannot be null");
-    structureDefinitionsDir = Strings.nullToEmpty(structureDefinitionsDir);
-    structureDefinitionsClasspath = Strings.nullToEmpty(structureDefinitionsClasspath);
-    if (!structureDefinitionsDir.isEmpty() && !structureDefinitionsClasspath.isEmpty()) {
-      String errorMsg =
-          String.format(
-              "Please configure only one of the parameter between structureDefinitionsDir=%s and"
-                  + " structureDefinitionsClasspath=%s, leave both empty if custom profiles are not"
-                  + " needed.",
-              structureDefinitionsDir, structureDefinitionsClasspath);
-      log.error(errorMsg);
-      throw new ProfileException(errorMsg);
-    }
+    structureDefinitionsPath = Strings.nullToEmpty(structureDefinitionsPath);
 
     if (instance == null) {
-      instance =
-          new AvroConversionUtil(
-              fhirVersionEnum, structureDefinitionsDir, structureDefinitionsClasspath);
+      instance = new AvroConversionUtil(fhirVersionEnum, structureDefinitionsPath);
     } else if (!fhirVersionEnum.equals(instance.fhirVersionEnum)
-        || !structureDefinitionsDir.equals(instance.structureDefinitionsDir)
-        || !structureDefinitionsClasspath.equals(instance.structureDefinitionsClasspath)) {
+        || !structureDefinitionsPath.equals(instance.structureDefinitionsPath)) {
       String errorMsg =
           String.format(
               "AvroConversionUtil has been initialised with different set of parameters earlier"
-                  + " with fhirVersionEnum=%s, structureDefinitionsDir=%s and"
-                  + " structureDefinitionsClasspath=%s, compared to what is being passed now with"
-                  + " fhirVersionEnum=%s, structureDefinitionsDir=%s and"
-                  + " structureDefinitionsClasspath=%s",
+                  + " with fhirVersionEnum=%s, structureDefinitionsPath=%s"
+                  + " compared to what is being passed now with"
+                  + " fhirVersionEnum=%s, structureDefinitionsPath=%s",
               instance.fhirVersionEnum,
-              instance.structureDefinitionsDir,
-              instance.structureDefinitionsClasspath,
+              instance.structureDefinitionsPath,
               fhirVersionEnum,
-              structureDefinitionsDir,
-              structureDefinitionsClasspath);
+              structureDefinitionsPath);
       log.error(errorMsg);
       throw new ProfileException(errorMsg);
     }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -57,19 +57,6 @@ public class ParquetUtil {
     return dwhFiles.getRoot();
   }
 
-  /**
-   * Note using this constructor may cause the files not be flushed until `closeAllWriters` is
-   * called.
-   *
-   * @param fhirVersionEnum the FHIR version
-   * @param parquetFilePath The directory under which the Parquet files are written.
-   * @throws ProfileException if any errors are encountered during initialisation of FhirContext
-   */
-  public ParquetUtil(FhirVersionEnum fhirVersionEnum, String parquetFilePath)
-      throws ProfileException {
-    this(fhirVersionEnum, "", parquetFilePath, 0, 0, "");
-  }
-
   // TODO remove this constructor and only expose a similar one in `DwhFiles` (for testing).
   /**
    * @param fhirVersionEnum This should match the resources intended to be converted.
@@ -90,11 +77,14 @@ public class ParquetUtil {
       String parquetFilePath,
       int secondsToFlush,
       int rowGroupSize,
-      String namePrefix)
+      String namePrefix,
+      int recursiveDepth,
+      boolean fullId)
       throws ProfileException {
     if (fhirVersionEnum == FhirVersionEnum.DSTU3 || fhirVersionEnum == FhirVersionEnum.R4) {
       this.conversionUtil =
-          AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath);
+          AvroConversionUtil.getInstance(
+              fhirVersionEnum, structureDefinitionsPath, recursiveDepth, fullId);
     } else {
       throw new IllegalArgumentException("Only versions 3 and 4 of FHIR are supported!");
     }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -67,16 +67,14 @@ public class ParquetUtil {
    */
   public ParquetUtil(FhirVersionEnum fhirVersionEnum, String parquetFilePath)
       throws ProfileException {
-    this(fhirVersionEnum, "", "", parquetFilePath, 0, 0, "");
+    this(fhirVersionEnum, "", parquetFilePath, 0, 0, "");
   }
 
   // TODO remove this constructor and only expose a similar one in `DwhFiles` (for testing).
   /**
    * @param fhirVersionEnum This should match the resources intended to be converted.
-   * @param structureDefinitionsDir Directory path containing the structure definitions for custom
-   *     fhir profiles
-   * @param structureDefinitionsClasspath Classpath name containing the structure definitions for
-   *     custom fhir profiles
+   * @param structureDefinitionsPath Directory path containing the structure definitions for custom
+   *     fhir profiles; if it starts with `classpath:` then classpath will be searched instead.
    * @param parquetFilePath The directory under which the Parquet files are written.
    * @param secondsToFlush The interval after which the content of Parquet writers is flushed to
    *     disk.
@@ -88,8 +86,7 @@ public class ParquetUtil {
   @VisibleForTesting
   ParquetUtil(
       FhirVersionEnum fhirVersionEnum,
-      String structureDefinitionsDir,
-      String structureDefinitionsClasspath,
+      String structureDefinitionsPath,
       String parquetFilePath,
       int secondsToFlush,
       int rowGroupSize,
@@ -97,8 +94,7 @@ public class ParquetUtil {
       throws ProfileException {
     if (fhirVersionEnum == FhirVersionEnum.DSTU3 || fhirVersionEnum == FhirVersionEnum.R4) {
       this.conversionUtil =
-          AvroConversionUtil.getInstance(
-              fhirVersionEnum, structureDefinitionsDir, structureDefinitionsClasspath);
+          AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath);
     } else {
       throw new IllegalArgumentException("Only versions 3 and 4 of FHIR are supported!");
     }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -78,13 +78,11 @@ public class ParquetUtil {
       int secondsToFlush,
       int rowGroupSize,
       String namePrefix,
-      int recursiveDepth,
-      boolean fullId)
+      int recursiveDepth)
       throws ProfileException {
     if (fhirVersionEnum == FhirVersionEnum.DSTU3 || fhirVersionEnum == FhirVersionEnum.R4) {
       this.conversionUtil =
-          AvroConversionUtil.getInstance(
-              fhirVersionEnum, structureDefinitionsPath, recursiveDepth, fullId);
+          AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath, recursiveDepth);
     } else {
       throw new IllegalArgumentException("Only versions 3 and 4 of FHIR are supported!");
     }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewApplicator.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewApplicator.java
@@ -586,7 +586,11 @@ public class ViewApplicator {
     public String getString() {
       IPrimitiveType primitiveType = getPrimitiveType();
       if (primitiveType != null) {
-        return primitiveType.getValueAsString();
+        // TODO: This is a temporary solution to handle IDs properly. We should implement proper
+        //  polymorphism to properly handle primitive types when we add type inference. This can
+        //  be similar to how we convert primitives to Avro fields in Bunsen.
+        String maybeId = getSingleIdPart();
+        return maybeId != null ? maybeId : primitiveType.getValueAsString();
       }
       return getSingleValue() == null ? null : getSingleValue().toString();
     }
@@ -620,7 +624,7 @@ public class ViewApplicator {
     }
 
     @Nullable
-    public String getSingleIdPart() {
+    private String getSingleIdPart() {
       Preconditions.checkState(!isCollection());
       if (values != null && !values.isEmpty() && ID_TYPE.equals(columnInfo.getInferredType())) {
         IBase elem = values.get(0);

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
@@ -117,6 +117,9 @@ public class ViewSchema {
         // TODO add unit-tests for all cases and add extra cases too if needed!
         if (ViewApplicator.ID_TYPE.equals(re.getColumnInfo().getInferredType())) {
           statement.setString(ind, re.getSingleIdPart());
+          // TODO remove the following and also the `fullId` option (before merge).
+          // statement.setString(ind, re.getSingleValue().toString());
+          // statement.setString(ind, re.getString());
         } else {
           switch (fhirTypeToDb(re.getColumnInfo().getType())) {
             case BOOLEAN:

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
@@ -116,10 +116,7 @@ public class ViewSchema {
       if (re.getPrimitive() != null) {
         // TODO add unit-tests for all cases and add extra cases too if needed!
         if (ViewApplicator.ID_TYPE.equals(re.getColumnInfo().getInferredType())) {
-          statement.setString(ind, re.getSingleIdPart());
-          // TODO remove the following and also the `fullId` option (before merge).
-          // statement.setString(ind, re.getSingleValue().toString());
-          // statement.setString(ind, re.getString());
+          statement.setString(ind, re.getString());
         } else {
           switch (fhirTypeToDb(re.getColumnInfo().getType())) {
             case BOOLEAN:

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
@@ -75,7 +75,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Patient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     Schema schema = avroConversionUtil.getResourceSchema("Patient");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -85,7 +85,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Observation() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     Schema schema = avroConversionUtil.getResourceSchema("Observation");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -97,7 +97,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Encounter() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     Schema schema = avroConversionUtil.getResourceSchema("Encounter");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -108,7 +108,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfPatients() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
 
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
@@ -124,7 +124,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfObservations() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     List<GenericRecord> recordList = avroConversionUtil.generateRecords(bundle);
@@ -134,7 +134,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecordForPatient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
     GenericRecord record = avroConversionUtil.convertToAvro(bundle.getEntry().get(0).getResource());
@@ -150,7 +150,7 @@ public class AvroConversionUtilTest {
   @Test
   public void convertObservationWithBigDecimalValue() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -166,16 +166,13 @@ public class AvroConversionUtilTest {
   public void checkForCorrectAvroConverterWithMultipleProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1, false);
+            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
     AvroConverter patientConverterFetchedDirectly =
         AvroConverter.forResources(
-            avroConversionUtil.getFhirContext(),
-            R4UsCoreProfileData.US_CORE_PATIENT_PROFILES,
-            1,
-            false);
+            avroConversionUtil.getFhirContext(), R4UsCoreProfileData.US_CORE_PATIENT_PROFILES, 1);
     // Check if the schemas are equal
     assertThat(
         patientConverterFromAvroConversionUtil.getSchema(),
@@ -187,8 +184,7 @@ public class AvroConversionUtilTest {
         AvroConverter.forResources(
             avroConversionUtil.getFhirContext(),
             R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES,
-            1,
-            false);
+            1);
     // Check if the schemas are equal
     assertThat(
         obsConverterFromAvroConversionUtil.getSchema(),
@@ -198,12 +194,12 @@ public class AvroConversionUtilTest {
   @Test
   public void checkForCorrectAvroConverterWithBaseProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
     AvroConverter patientConverterFetchedDirectly =
-        AvroConverter.forResource(avroConversionUtil.getFhirContext(), BASE_PATIENT, 1, false);
+        AvroConverter.forResource(avroConversionUtil.getFhirContext(), BASE_PATIENT, 1);
     // Check if the schemas are equal
     assertThat(
         patientConverterFromAvroConversionUtil.getSchema(),
@@ -212,7 +208,7 @@ public class AvroConversionUtilTest {
     AvroConverter obsConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Observation");
     AvroConverter obsConverterFetchedDirectly =
-        AvroConverter.forResource(avroConversionUtil.getFhirContext(), "Observation", 1, false);
+        AvroConverter.forResource(avroConversionUtil.getFhirContext(), "Observation", 1);
     // Check if the schemas are equal
     assertThat(
         obsConverterFromAvroConversionUtil.getSchema(),
@@ -223,7 +219,7 @@ public class AvroConversionUtilTest {
   public void testForAvroRecords() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
-            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1, false);
+            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1);
     IBaseResource baseResource = loadResource("patient_us_core.json", Patient.class);
     GenericRecord avroRecord = avroConversionUtil.convertToAvro((Resource) baseResource);
 

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
@@ -75,7 +75,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Patient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     Schema schema = avroConversionUtil.getResourceSchema("Patient");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -85,7 +85,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Observation() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     Schema schema = avroConversionUtil.getResourceSchema("Observation");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -97,7 +97,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Encounter() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     Schema schema = avroConversionUtil.getResourceSchema("Encounter");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -108,7 +108,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfPatients() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
 
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
@@ -124,7 +124,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfObservations() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     List<GenericRecord> recordList = avroConversionUtil.generateRecords(bundle);
@@ -134,7 +134,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecordForPatient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
     GenericRecord record = avroConversionUtil.convertToAvro(bundle.getEntry().get(0).getResource());
@@ -150,7 +150,7 @@ public class AvroConversionUtilTest {
   @Test
   public void convertObservationWithBigDecimalValue() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -165,13 +165,17 @@ public class AvroConversionUtilTest {
   @Test
   public void checkForCorrectAvroConverterWithMultipleProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath);
+        AvroConversionUtil.getInstance(
+            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1, false);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
     AvroConverter patientConverterFetchedDirectly =
         AvroConverter.forResources(
-            avroConversionUtil.getFhirContext(), R4UsCoreProfileData.US_CORE_PATIENT_PROFILES);
+            avroConversionUtil.getFhirContext(),
+            R4UsCoreProfileData.US_CORE_PATIENT_PROFILES,
+            1,
+            false);
     // Check if the schemas are equal
     assertThat(
         patientConverterFromAvroConversionUtil.getSchema(),
@@ -181,7 +185,10 @@ public class AvroConversionUtilTest {
         avroConversionUtil.getConverter("Observation");
     AvroConverter obsConverterFetchedDirectly =
         AvroConverter.forResources(
-            avroConversionUtil.getFhirContext(), R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES);
+            avroConversionUtil.getFhirContext(),
+            R4UsCoreProfileData.US_CORE_OBSERVATION_PROFILES,
+            1,
+            false);
     // Check if the schemas are equal
     assertThat(
         obsConverterFromAvroConversionUtil.getSchema(),
@@ -191,12 +198,12 @@ public class AvroConversionUtilTest {
   @Test
   public void checkForCorrectAvroConverterWithBaseProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, 1, false);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
     AvroConverter patientConverterFetchedDirectly =
-        AvroConverter.forResource(avroConversionUtil.getFhirContext(), BASE_PATIENT);
+        AvroConverter.forResource(avroConversionUtil.getFhirContext(), BASE_PATIENT, 1, false);
     // Check if the schemas are equal
     assertThat(
         patientConverterFromAvroConversionUtil.getSchema(),
@@ -205,7 +212,7 @@ public class AvroConversionUtilTest {
     AvroConverter obsConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Observation");
     AvroConverter obsConverterFetchedDirectly =
-        AvroConverter.forResource(avroConversionUtil.getFhirContext(), "Observation");
+        AvroConverter.forResource(avroConversionUtil.getFhirContext(), "Observation", 1, false);
     // Check if the schemas are equal
     assertThat(
         obsConverterFromAvroConversionUtil.getSchema(),
@@ -215,7 +222,8 @@ public class AvroConversionUtilTest {
   @Test
   public void testForAvroRecords() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath);
+        AvroConversionUtil.getInstance(
+            FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath, 1, false);
     IBaseResource baseResource = loadResource("patient_us_core.json", Patient.class);
     GenericRecord avroRecord = avroConversionUtil.convertToAvro((Resource) baseResource);
 

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/AvroConversionUtilTest.java
@@ -66,7 +66,7 @@ public class AvroConversionUtilTest {
     observationBundle =
         Resources.toString(
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
-    usCoreProfilesStructureDefinitionsPath = "/r4-us-core-definitions";
+    usCoreProfilesStructureDefinitionsPath = "classpath:/r4-us-core-definitions";
     // This is needed because the mappings are carried across unit test classes due to the static
     // instance being used.
     AvroConversionUtil.deRegisterMappingsFor(FhirVersionEnum.R4);
@@ -75,7 +75,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Patient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     Schema schema = avroConversionUtil.getResourceSchema("Patient");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -85,7 +85,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Observation() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     Schema schema = avroConversionUtil.getResourceSchema("Observation");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -97,7 +97,7 @@ public class AvroConversionUtilTest {
   @Test
   public void getResourceSchema_Encounter() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     Schema schema = avroConversionUtil.getResourceSchema("Encounter");
     assertThat(schema.getField("id").toString(), notNullValue());
     assertThat(schema.getField("identifier").toString(), notNullValue());
@@ -108,7 +108,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfPatients() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
 
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
@@ -124,7 +124,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecords_BundleOfObservations() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     List<GenericRecord> recordList = avroConversionUtil.generateRecords(bundle);
@@ -134,7 +134,7 @@ public class AvroConversionUtilTest {
   @Test
   public void generateRecordForPatient() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, patientBundle);
     GenericRecord record = avroConversionUtil.convertToAvro(bundle.getEntry().get(0).getResource());
@@ -150,7 +150,7 @@ public class AvroConversionUtilTest {
   @Test
   public void convertObservationWithBigDecimalValue() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -165,8 +165,7 @@ public class AvroConversionUtilTest {
   @Test
   public void checkForCorrectAvroConverterWithMultipleProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(
-            FhirVersionEnum.R4, null, usCoreProfilesStructureDefinitionsPath);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
@@ -192,7 +191,7 @@ public class AvroConversionUtilTest {
   @Test
   public void checkForCorrectAvroConverterWithBaseProfiles() throws ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null, null);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, null);
 
     AvroConverter patientConverterFromAvroConversionUtil =
         avroConversionUtil.getConverter("Patient");
@@ -216,8 +215,7 @@ public class AvroConversionUtilTest {
   @Test
   public void testForAvroRecords() throws IOException, ProfileException {
     AvroConversionUtil avroConversionUtil =
-        AvroConversionUtil.getInstance(
-            FhirVersionEnum.R4, null, usCoreProfilesStructureDefinitionsPath);
+        AvroConversionUtil.getInstance(FhirVersionEnum.R4, usCoreProfilesStructureDefinitionsPath);
     IBaseResource baseResource = loadResource("patient_us_core.json", Patient.class);
     GenericRecord avroRecord = avroConversionUtil.convertToAvro((Resource) baseResource);
 

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -71,8 +71,8 @@ public class ParquetUtilTest {
         Resources.toString(
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
     AvroConversionUtil.deRegisterMappingsFor(FhirVersionEnum.R4);
-    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "", "");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 0, "TEST_");
+    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_");
   }
 
   @Test
@@ -106,7 +106,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutput() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -132,7 +132,7 @@ public class ParquetUtilTest {
   public void createMultipleOutputByTime()
       throws IOException, InterruptedException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 1, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "");
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -158,7 +158,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutputWithRowGroupSize() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 1, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "");
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     // There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
@@ -191,7 +191,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationWithBigDecimalValue() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -205,7 +205,7 @@ public class ParquetUtilTest {
   public void writeObservationBundleWithDecimalConversionIssue()
       throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
     String observationBundleStr =
         Resources.toString(
             Resources.getResource("observation_decimal_bundle.json"), StandardCharsets.UTF_8);
@@ -218,7 +218,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationBundleWithMultipleProfiles() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
 
     String patientStr =
         Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -71,8 +71,9 @@ public class ParquetUtilTest {
         Resources.toString(
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
     AvroConversionUtil.deRegisterMappingsFor(FhirVersionEnum.R4);
-    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_");
+    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "", 1, false);
+    parquetUtil =
+        new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_", 1, false);
   }
 
   @Test
@@ -106,7 +107,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutput() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -132,7 +133,7 @@ public class ParquetUtilTest {
   public void createMultipleOutputByTime()
       throws IOException, InterruptedException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -158,7 +159,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutputWithRowGroupSize() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     // There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
@@ -191,7 +192,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationWithBigDecimalValue() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -205,7 +206,7 @@ public class ParquetUtilTest {
   public void writeObservationBundleWithDecimalConversionIssue()
       throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     String observationBundleStr =
         Resources.toString(
             Resources.getResource("observation_decimal_bundle.json"), StandardCharsets.UTF_8);
@@ -218,7 +219,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationBundleWithMultipleProfiles() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "");
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
 
     String patientStr =
         Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -71,9 +71,8 @@ public class ParquetUtilTest {
         Resources.toString(
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
     AvroConversionUtil.deRegisterMappingsFor(FhirVersionEnum.R4);
-    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "", 1, false);
-    parquetUtil =
-        new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_", 1, false);
+    avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_", 1);
   }
 
   @Test
@@ -107,7 +106,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutput() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -133,7 +132,7 @@ public class ParquetUtilTest {
   public void createMultipleOutputByTime()
       throws IOException, InterruptedException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "", 1);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -159,7 +158,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutputWithRowGroupSize() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "", 1);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     // There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
@@ -192,7 +191,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationWithBigDecimalValue() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -206,7 +205,7 @@ public class ParquetUtilTest {
   public void writeObservationBundleWithDecimalConversionIssue()
       throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
     String observationBundleStr =
         Resources.toString(
             Resources.getResource("observation_decimal_bundle.json"), StandardCharsets.UTF_8);
@@ -219,7 +218,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationBundleWithMultipleProfiles() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
 
     String patientStr =
         Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/view/ViewApplicatorTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/view/ViewApplicatorTest.java
@@ -96,7 +96,7 @@ public class ViewApplicatorTest {
     assertThat(rows.getRows().size(), equalTo(2));
     assertThat(rows.getRows().get(1).getElements().get(0).getName(), equalTo("patient_id"));
     assertFalse(rows.getRows().get(1).getElements().get(0).isCollection());
-    assertThat(rows.getRows().get(1).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(1).getElements().get(0).getString(), equalTo("12345"));
     assertFalse(rows.getRows().get(1).getElements().get(1).isCollection());
     assertThat(rows.getRows().get(1).getElements().get(1).getName(), equalTo("multiple_birth"));
     assertThat(rows.getRows().get(1).getElements().get(1).getSingleValue(), equalTo(null));
@@ -135,7 +135,7 @@ public class ViewApplicatorTest {
             "patient_multiple_foreach_view.json", "patient_with_address.json", Patient.class);
     assertThat(rows.getRows().size(), equalTo(8));
     assertThat(rows.getRows().get(3).getElements().get(0).getName(), equalTo("patient_id"));
-    assertThat(rows.getRows().get(3).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(3).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(6).getElements().get(4).getName(), equalTo("languages"));
     assertThat(rows.getRows().get(6).getElements().get(4).getSingleValue(), equalTo(null));
     assertThat(rows.getRows().get(6).getElements().get(5).getName(), equalTo("street"));
@@ -154,7 +154,7 @@ public class ViewApplicatorTest {
             Patient.class);
     assertThat(rows.getRows().size(), equalTo(4));
     assertThat(rows.getRows().get(1).getElements().get(0).getName(), equalTo("patient_id"));
-    assertThat(rows.getRows().get(1).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(1).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(1).getElements().get(1).getName(), equalTo("street"));
     assertThat(
         rows.getRows().get(1).getElements().get(1).getPrimitive(), equalTo("10\nParliament st."));
@@ -169,11 +169,10 @@ public class ViewApplicatorTest {
             "observation_patient_id_view.json", "observation_decimal.json", Observation.class);
     assertThat(rows.getRows().size(), equalTo(1));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(0).getElements().get(0).getSingleIdPart(), equalTo("obs1"));
+    assertThat(rows.getRows().get(0).getElements().get(0).getString(), equalTo("obs1"));
     assertThat(rows.getRows().get(0).getElements().get(1).getName(), equalTo("patient_id"));
     assertThat(
-        rows.getRows().get(0).getElements().get(1).getSingleIdPart(),
-        equalTo("7_SOME_PATIENT_REF"));
+        rows.getRows().get(0).getElements().get(1).getString(), equalTo("7_SOME_PATIENT_REF"));
     assertThat(
         rows.getRows().get(0).getElements().get(2).getName(), equalTo("effective_date_time"));
     assertThat(
@@ -200,19 +199,19 @@ public class ViewApplicatorTest {
             "patient_practitioner_id_view.json", "patient_with_practitioner.json", Patient.class);
     assertThat(rows.getRows().size(), equalTo(3));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(0).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(0).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(0).getElements().get(1).getName(), equalTo("practitioner_id"));
-    assertThat(rows.getRows().get(0).getElements().get(1).getSingleIdPart(), equalTo("prac1"));
+    assertThat(rows.getRows().get(0).getElements().get(1).getString(), equalTo("prac1"));
     assertThat(rows.getRows().get(1).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(1).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(1).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(1).getElements().get(1).getName(), equalTo("practitioner_id"));
     // The second `generalPractitioner` is of type `Organization` hence it should not match
     // `getReferenceKey('Practitioner')`.
-    assertThat(rows.getRows().get(1).getElements().get(1).getSingleIdPart(), equalTo(null));
+    assertThat(rows.getRows().get(1).getElements().get(1).getString(), equalTo(null));
     assertThat(rows.getRows().get(2).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(2).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(2).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(2).getElements().get(1).getName(), equalTo("practitioner_id"));
-    assertThat(rows.getRows().get(2).getElements().get(1).getSingleIdPart(), equalTo("prac2"));
+    assertThat(rows.getRows().get(2).getElements().get(1).getString(), equalTo("prac2"));
   }
 
   @Test
@@ -222,7 +221,7 @@ public class ViewApplicatorTest {
             "observation_many_constants_view.json", "observation_decimal.json", Observation.class);
     assertThat(rows.getRows().size(), equalTo(1));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(0).getElements().get(0).getSingleIdPart(), equalTo("obs1"));
+    assertThat(rows.getRows().get(0).getElements().get(0).getString(), equalTo("obs1"));
     assertThat(
         rows.getRows().get(0).getElements().get(1).getName(), equalTo("effective_date_time"));
     assertThat(
@@ -255,7 +254,7 @@ public class ViewApplicatorTest {
             "patient_flat_view.json", "patient_with_practitioner.json", Patient.class);
     assertThat(rows.getRows().size(), equalTo(3));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("pat_id"));
-    assertThat(rows.getRows().get(0).getElements().get(0).getSingleIdPart(), equalTo("12345"));
+    assertThat(rows.getRows().get(0).getElements().get(0).getString(), equalTo("12345"));
     assertThat(rows.getRows().get(0).getElements().get(2).getName(), equalTo("gender"));
     assertThat(rows.getRows().get(0).getElements().get(2).getString(), equalTo("female"));
   }
@@ -268,9 +267,9 @@ public class ViewApplicatorTest {
     StringBuilder expected = new StringBuilder();
     expected
         .append("pat_id,active,gender,deceased,organization_id,practitioner_id,family,given\n")
-        .append("Patient/12345,null,female,null,null,Practitioner/prac1,Emily,Stevenson\n")
-        .append("Patient/12345,null,female,null,null,null,Emily,Stevenson\n")
-        .append("Patient/12345,null,female,null,null,Practitioner/prac2,Emily,Stevenson");
+        .append("12345,null,female,null,null,prac1,Emily,Stevenson\n")
+        .append("12345,null,female,null,null,null,Emily,Stevenson\n")
+        .append("12345,null,female,null,null,prac2,Emily,Stevenson");
     assertThat(rows.toCsv(), equalTo(expected.toString()));
   }
 
@@ -285,12 +284,12 @@ public class ViewApplicatorTest {
         .append("<tr><td>pat_id</td><td>active</td><td>gender</td><td>deceased</td>")
         .append("<td>organization_id</td><td>practitioner_id</td><td>family</td><td>given</td>")
         .append("</tr></thead><tbody>")
-        .append("<tr><td>Patient/12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
-        .append("<td>Practitioner/prac1</td><td>Emily</td><td>Stevenson</td></tr>")
-        .append("<tr><td>Patient/12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
+        .append("<tr><td>12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
+        .append("<td>prac1</td><td>Emily</td><td>Stevenson</td></tr>")
+        .append("<tr><td>12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
         .append("<td>null</td><td>Emily</td><td>Stevenson</td></tr>")
-        .append("<tr><td>Patient/12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
-        .append("<td>Practitioner/prac2</td><td>Emily</td><td>Stevenson</td></tr></tbody>");
+        .append("<tr><td>12345</td><td>null</td><td>female</td><td>null</td><td>null</td>")
+        .append("<td>prac2</td><td>Emily</td><td>Stevenson</td></tr></tbody>");
     assertThat(rows.toHtml(), equalTo(expected.toString()));
   }
 
@@ -301,10 +300,10 @@ public class ViewApplicatorTest {
     assertThat(rows.getRows().size(), equalTo(3));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
     assertThat(
-        rows.getRows().get(0).getElements().get(0).getSingleIdPart(),
+        rows.getRows().get(0).getElements().get(0).getString(),
         equalTo("46f919e2-2d3c-c055-e97b-f3ad7bbf110e"));
     assertThat(rows.getRows().get(2).getElements().get(3).getName(), equalTo("service_org_id"));
-    assertThat(rows.getRows().get(2).getElements().get(3).getSingleIdPart(), equalTo("1"));
+    assertThat(rows.getRows().get(2).getElements().get(3).getString(), equalTo("1"));
   }
 
   @Test
@@ -314,7 +313,7 @@ public class ViewApplicatorTest {
             "observation_flat_view.json", "observation_codeable_concept.json", Observation.class);
     assertThat(rows.getRows().size(), equalTo(2));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
-    assertThat(rows.getRows().get(0).getElements().get(0).getSingleIdPart(), equalTo("obs1"));
+    assertThat(rows.getRows().get(0).getElements().get(0).getString(), equalTo("obs1"));
     assertThat(rows.getRows().get(0).getElements().get(9).getName(), equalTo("val_sys"));
     assertThat(rows.getRows().get(0).getElements().get(9).getPrimitive(), equalTo("VAL_SYS1"));
     assertThat(rows.getRows().get(1).getElements().get(8).getName(), equalTo("val_code"));
@@ -328,7 +327,7 @@ public class ViewApplicatorTest {
     assertThat(rows.getRows().size(), equalTo(4));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
     assertThat(
-        rows.getRows().get(0).getElements().get(0).getSingleIdPart(),
+        rows.getRows().get(0).getElements().get(0).getString(),
         equalTo("610e4380-aa0d-4d86-0104-479010ef0471"));
     assertThat(rows.getRows().get(2).getElements().get(7).getName(), equalTo("clinical_status"));
     assertThat(rows.getRows().get(2).getElements().get(7).getPrimitive(), equalTo("active"));
@@ -341,11 +340,11 @@ public class ViewApplicatorTest {
     assertThat(rows.getRows().size(), equalTo(2));
     assertThat(rows.getRows().get(0).getElements().get(0).getName(), equalTo("id"));
     assertThat(
-        rows.getRows().get(0).getElements().get(0).getSingleIdPart(),
+        rows.getRows().get(0).getElements().get(0).getString(),
         equalTo("8db297e1-658f-6612-0e3a-7f9c0943b877"));
     assertThat(rows.getRows().get(0).getElements().get(9).getName(), equalTo("practitioner_id"));
-    assertThat(rows.getRows().get(0).getElements().get(9).getSingleIdPart(), equalTo("9999999899"));
+    assertThat(rows.getRows().get(0).getElements().get(9).getString(), equalTo("9999999899"));
     assertThat(rows.getRows().get(1).getElements().get(10).getName(), equalTo("organization_id"));
-    assertThat(rows.getRows().get(1).getElements().get(10).getSingleIdPart(), equalTo("199"));
+    assertThat(rows.getRows().get(1).getElements().get(10).getString(), equalTo("199"));
   }
 }

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -135,15 +135,11 @@ fhirdata:
   hiveResourceViewsDir: "config/views"
 
   # Directory path containing the structure definition files for any custom profiles that needs to be
-  # supported. Currently only one profile is supported for any given resource type.
-  #structureDefinitionsDir: "config/r4-us-core-definitions"
-
-  # Similar to the structureDefinitionsDir, this path should also contain the structure definition
-  # files for any custom profiles that needs to be supported. But the difference is that this is the
-  # classpath name instead of a directory name and should always start with a '/'. Also, only one of
-  # the structureDefinitionsDir or structureDefinitionsClasspath parameters can be configured, do
-  # not configure anything if custom profiles are not needed.
-  structureDefinitionsClasspath: "/r4-us-core-definitions"
+  # supported. If this starts with `classpath:` then the a classpath resource is
+  # assumed and the path should always start with a `/`.
+  # Do not configure anything if custom profiles are not needed.
+  #structureDefinitionsPath: "config/r4-us-core-definitions"
+  structureDefinitionsPath: "classpath:/r4-us-core-definitions"
 
   # The fhir version to be used for the FHIR Context APIs. This is an enum value and the possible
   # values should be one from the list mentioned in the below link

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -167,6 +167,15 @@ fhirdata:
   # empty string disables this feature.
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
 
+  #  The maximum depth for traversing StructureDefinitions in Parquet schema generation.
+  #  Please note in most cases, the default 1 is sufficient and increasing that can
+  #  result in significantly larger schema and more complexity. For details see:
+  #  https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures
+  recursiveDepth: 1
+
+  # Whether to generate the full ID (including type) or only the logical part.
+  fullId: false
+
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -167,10 +167,11 @@ fhirdata:
   # empty string disables this feature.
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
 
-  #  The maximum depth for traversing StructureDefinitions in Parquet schema generation.
-  #  Please note in most cases, the default 1 is sufficient and increasing that can
-  #  result in significantly larger schema and more complexity. For details see:
-  #  https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures
+  # The maximum depth for traversing StructureDefinitions in Parquet schema
+  # generation (if it is non-positive, the default 1 will be used). Note in most
+  # cases, the default 1 is sufficient and increasing that can result in
+  # significantly larger schema and more complexity. For details see:
+  # https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures
   recursiveDepth: 1
 
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -173,9 +173,6 @@ fhirdata:
   #  https://github.com/FHIR/sql-on-fhir/blob/master/sql-on-fhir.md#recursive-structures
   recursiveDepth: 1
 
-  # Whether to generate the full ID (including type) or only the logical part.
-  fullId: false
-
 # Enable spring boot actuator end points, use "*" to expose all endpoints, or a comma-separated
 # list to expose selected ones
 management:

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -110,6 +110,10 @@ public class DataProperties {
 
   private FhirVersionEnum fhirVersion;
 
+  private int recursiveDepth;
+
+  private boolean fullId;
+
   @PostConstruct
   void validateProperties() {
     CronExpression.parse(incrementalSchedule);
@@ -233,7 +237,9 @@ public class DataProperties {
             "fhirdata.rowGroupSizeForParquetFiles",
             String.valueOf(rowGroupSizeForParquetFiles),
             "",
-            ""));
+            ""),
+        new ConfigFields("fhirdata.recursiveDepth", String.valueOf(recursiveDepth), "", ""),
+        new ConfigFields("fhirdata.fullId", String.valueOf(fullId), "", ""));
   }
 
   ConfigFields getConfigFields(FhirEtlOptions options, Method getMethod) {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -112,8 +112,6 @@ public class DataProperties {
 
   private int recursiveDepth;
 
-  private boolean fullId;
-
   @PostConstruct
   void validateProperties() {
     CronExpression.parse(incrementalSchedule);
@@ -194,7 +192,6 @@ public class DataProperties {
     options.setStructureDefinitionsPath(Strings.nullToEmpty(structureDefinitionsPath));
     options.setFhirVersion(fhirVersion);
     options.setRecursiveDepth(recursiveDepth);
-    // options.setFullId(fullId);
     if (rowGroupSizeForParquetFiles > 0) {
       options.setRowGroupSizeForParquetFiles(rowGroupSizeForParquetFiles);
     }
@@ -240,8 +237,7 @@ public class DataProperties {
             String.valueOf(rowGroupSizeForParquetFiles),
             "",
             ""),
-        new ConfigFields("fhirdata.recursiveDepth", String.valueOf(recursiveDepth), "", ""),
-        new ConfigFields("fhirdata.fullId", String.valueOf(fullId), "", ""));
+        new ConfigFields("fhirdata.recursiveDepth", String.valueOf(recursiveDepth), "", ""));
   }
 
   ConfigFields getConfigFields(FhirEtlOptions options, Method getMethod) {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -104,9 +104,7 @@ public class DataProperties {
 
   private String fhirServerOAuthClientSecret;
 
-  private String structureDefinitionsDir;
-
-  private String structureDefinitionsClasspath;
+  private String structureDefinitionsPath;
 
   private int rowGroupSizeForParquetFiles;
 
@@ -160,8 +158,7 @@ public class DataProperties {
     options.setViewDefinitionsDir(viewDefinitionsDir);
     options.setSinkDbConfigPath(sinkDbConfigPath);
     options.setRecreateSinkTables(true);
-    options.setStructureDefinitionsDir(Strings.nullToEmpty(structureDefinitionsDir));
-    options.setStructureDefinitionsClasspath(Strings.nullToEmpty(structureDefinitionsClasspath));
+    options.setStructureDefinitionsPath(Strings.nullToEmpty(structureDefinitionsPath));
     options.setFhirVersion(fhirVersion);
     if (rowGroupSizeForParquetFiles > 0) {
       options.setRowGroupSizeForParquetFiles(rowGroupSizeForParquetFiles);
@@ -190,8 +187,7 @@ public class DataProperties {
     }
     options.setViewDefinitionsDir(Strings.nullToEmpty(viewDefinitionsDir));
     options.setSinkDbConfigPath(Strings.nullToEmpty(sinkDbConfigPath));
-    options.setStructureDefinitionsDir(Strings.nullToEmpty(structureDefinitionsDir));
-    options.setStructureDefinitionsClasspath(Strings.nullToEmpty(structureDefinitionsClasspath));
+    options.setStructureDefinitionsPath(Strings.nullToEmpty(structureDefinitionsPath));
     options.setFhirVersion(fhirVersion);
     if (rowGroupSizeForParquetFiles > 0) {
       options.setRowGroupSizeForParquetFiles(rowGroupSizeForParquetFiles);
@@ -231,9 +227,7 @@ public class DataProperties {
         new ConfigFields("fhirdata.dbConfig", dbConfig, "", ""),
         new ConfigFields("fhirdata.viewDefinitionsDir", viewDefinitionsDir, "", ""),
         new ConfigFields("fhirdata.sinkDbConfigPath", sinkDbConfigPath, "", ""),
-        new ConfigFields("fhirdata.structureDefinitionsDir", structureDefinitionsDir, "", ""),
-        new ConfigFields(
-            "fhirdata.structureDefinitionsClasspath", structureDefinitionsClasspath, "", ""),
+        new ConfigFields("fhirdata.structureDefinitionsPath", structureDefinitionsPath, "", ""),
         new ConfigFields("fhirdata.fhirVersion", fhirVersion.name(), "", ""),
         new ConfigFields(
             "fhirdata.rowGroupSizeForParquetFiles",

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -193,6 +193,8 @@ public class DataProperties {
     options.setSinkDbConfigPath(Strings.nullToEmpty(sinkDbConfigPath));
     options.setStructureDefinitionsPath(Strings.nullToEmpty(structureDefinitionsPath));
     options.setFhirVersion(fhirVersion);
+    options.setRecursiveDepth(recursiveDepth);
+    // options.setFullId(fullId);
     if (rowGroupSizeForParquetFiles > 0) {
       options.setRowGroupSizeForParquetFiles(rowGroupSizeForParquetFiles);
     }

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -174,7 +174,10 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     initialiseFlinkConfiguration();
     avroConversionUtil =
         AvroConversionUtil.getInstance(
-            dataProperties.getFhirVersion(), dataProperties.getStructureDefinitionsPath());
+            dataProperties.getFhirVersion(),
+            dataProperties.getStructureDefinitionsPath(),
+            dataProperties.getRecursiveDepth(),
+            dataProperties.isFullId());
 
     PipelineConfig pipelineConfig = dataProperties.createBatchOptions();
     FileSystems.setDefaultPipelineOptions(pipelineConfig.getFhirEtlOptions());

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -176,8 +176,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         AvroConversionUtil.getInstance(
             dataProperties.getFhirVersion(),
             dataProperties.getStructureDefinitionsPath(),
-            dataProperties.getRecursiveDepth(),
-            dataProperties.isFullId());
+            dataProperties.getRecursiveDepth());
 
     PipelineConfig pipelineConfig = dataProperties.createBatchOptions();
     FileSystems.setDefaultPipelineOptions(pipelineConfig.getFhirEtlOptions());

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -174,9 +174,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     initialiseFlinkConfiguration();
     avroConversionUtil =
         AvroConversionUtil.getInstance(
-            dataProperties.getFhirVersion(),
-            dataProperties.getStructureDefinitionsDir(),
-            dataProperties.getStructureDefinitionsClasspath());
+            dataProperties.getFhirVersion(), dataProperties.getStructureDefinitionsPath());
 
     PipelineConfig pipelineConfig = dataProperties.createBatchOptions();
     FileSystems.setDefaultPipelineOptions(pipelineConfig.getFhirEtlOptions());
@@ -459,10 +457,8 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
             ? dataProperties.getNumThreads()
             : Runtime.getRuntime().availableProcessors();
     mergerOptions.setNumShards(numShards);
-    mergerOptions.setStructureDefinitionsDir(
-        Strings.nullToEmpty(dataProperties.getStructureDefinitionsDir()));
-    mergerOptions.setStructureDefinitionsClasspath(
-        Strings.nullToEmpty(dataProperties.getStructureDefinitionsClasspath()));
+    mergerOptions.setStructureDefinitionsPath(
+        Strings.nullToEmpty(dataProperties.getStructureDefinitionsPath()));
     mergerOptions.setFhirVersion(dataProperties.getFhirVersion());
     if (dataProperties.getRowGroupSizeForParquetFiles() > 0) {
       mergerOptions.setRowGroupSizeForParquetFiles(dataProperties.getRowGroupSizeForParquetFiles());

--- a/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
+++ b/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
@@ -92,7 +92,6 @@ public class DebeziumListener extends RouteBuilder {
         new ParquetUtil(
             fhirContext.getVersion().getVersion(),
             "",
-            "",
             params.outputParquetPath,
             params.secondsToFlushParquetFiles,
             params.rowGroupSizeForParquetFiles,

--- a/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
+++ b/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
@@ -95,7 +95,9 @@ public class DebeziumListener extends RouteBuilder {
             params.outputParquetPath,
             params.secondsToFlushParquetFiles,
             params.rowGroupSizeForParquetFiles,
-            "streaming_");
+            "streaming_",
+            1,
+            false);
     DataSource jdbcSource =
         JdbcConnectionPools.getInstance()
             .getPooledDataSource(

--- a/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
+++ b/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
@@ -96,8 +96,7 @@ public class DebeziumListener extends RouteBuilder {
             params.secondsToFlushParquetFiles,
             params.rowGroupSizeForParquetFiles,
             "streaming_",
-            1,
-            false);
+            1);
     DataSource jdbcSource =
         JdbcConnectionPools.getInstance()
             .getPooledDataSource(


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This PR does the following:
- It adds a `recursiveDepth` to address the issue originally raised in #757.
- It also merges the two options for setting StructureDefinition paths (for extensions) into one to simplify the API/options.
- This makes the id fields in views consistent with the first option proposed in the [spec here](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-ViewDefinition.html#suggested-implementations-for-getresourcekey-and-getreferencekey), i.e., keep the `id` field only.
- This also fixes some type warnings recently introduced.

To simplify the review, I have split this PR into multiple commits. The first one is just for merging paths. The second one adds two new options `recursiveDepth` and `fullId` options.  `fullId` was meant to address #1003 but I reverted that in the third commit for reasons explained in [this comment](https://github.com/google/fhir-data-pipes/issues/1003#issuecomment-2067274209). The third commit also makes the id columns in views consistent with Parquet and the spec suggestion.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the controller locally.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
