### PR TITLE
Fix the issue of DirectRunner generating too many Parquet files.

### DIFF
--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -226,6 +226,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
    */
   @FinishBundle
   public void finishBundle(FinishBundleContext context) {
+    /*
     try {
       if (parquetUtil != null) {
         parquetUtil.flushAll();
@@ -235,6 +236,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
       log.error("At finishBundle caught exception ", e);
       throw new IllegalStateException(e);
     }
+     */
   }
 
   @Teardown
@@ -243,7 +245,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     // stopped, the runner may choose not to call teardown. Only keep closing/cleanups here. See:
     // https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/transforms/DoFn.Teardown.html
     if (parquetUtil != null) {
-      parquetUtil.closeAllWriters();
+      // parquetUtil.closeAllWriters();
     }
   }
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -56,6 +56,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   private static final Logger log = LoggerFactory.getLogger(FetchSearchPageFn.class);
 
+  private static final String DATAFLOW_RUNNER = "DataflowRunner";
+
   private final Counter numFetchedResources;
 
   private final Counter totalFetchTimeMillis;
@@ -219,6 +221,12 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
   }
 
   /**
+   * Note this is a hacky solution to address a DataflowRunner specific issue where @Teardown
+   * method is not guaranteed to be called. Closing/flushing Parquet files in @FinishBundle is
+   * not a good idea in general because it makes the size of those files a function of how Beam
+   * divides the work into Bundles. That's why we only do this on DataflowRunner which tend to
+   * have very large Bundles.
+   *
    * This should be overridden by all subclasses because the `context` type is not fully specified
    * at this parent class (because of the T type argument). All subclass implementations should call
    * `super.finishBundle` though. TODO: implement a way to enforce this at compile time; this is
@@ -226,26 +234,27 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
    */
   @FinishBundle
   public void finishBundle(FinishBundleContext context) {
-    /*
-    try {
-      if (parquetUtil != null) {
-        parquetUtil.flushAll();
+    if (DATAFLOW_RUNNER.equals(context.getPipelineOptions().getRunner().getSimpleName())) {
+      try {
+        if (parquetUtil != null) {
+          parquetUtil.flushAll();
+        }
+      } catch (IOException | ProfileException e) {
+        // There is not much that we can do at finishBundle so just throw a RuntimeException
+        log.error("At finishBundle caught exception ", e);
+        throw new IllegalStateException(e);
       }
-    } catch (IOException | ProfileException e) {
-      // There is not much that we can do at finishBundle so just throw a RuntimeException
-      log.error("At finishBundle caught exception ", e);
-      throw new IllegalStateException(e);
     }
-     */
   }
 
   @Teardown
   public void teardown() throws IOException {
     // Note this is _not_ guaranteed to be called; for example when the worker process is being
-    // stopped, the runner may choose not to call teardown. Only keep closing/cleanups here. See:
+    // stopped, the runner may choose not to call teardown; currently this only happens for
+    // DataflowRunner and that's why we have the finishBundle method above:
     // https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/transforms/DoFn.Teardown.html
     if (parquetUtil != null) {
-      // parquetUtil.closeAllWriters();
+      parquetUtil.closeAllWriters();
     }
   }
 
@@ -264,6 +273,9 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
       numFetchedResources.inc(bundle.getEntry().size());
       if (parquetUtil != null) {
         long startTime = System.currentTimeMillis();
+        // TODO: The right way for writing Parquet records is to cache them and wait
+        //  until processing a Beam Bundle is done, i.e., write in @FinishBundle.
+        //  Otherwise, if a Beam Bundle fails in the middle, we will get duplicate records.
         parquetUtil.writeRecords(bundle, resourceTypes);
         totalGenerateTimeMillis.inc(System.currentTimeMillis() - startTime);
       }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -448,7 +448,8 @@ public class FhirEtl {
   }
 
   public static void main(String[] args)
-      throws IOException, SQLException, ViewDefinitionException, ProfileException {
+      throws IOException, SQLException, ViewDefinitionException, ProfileException,
+          InterruptedException {
 
     AvroConversionUtil.initializeAvroConverters();
 
@@ -465,7 +466,10 @@ public class FhirEtl {
     List<Pipeline> pipelines = setupAndBuildPipelines(options, avroConversionUtil);
     EtlUtils.runMultiplePipelinesWithTimestamp(
         pipelines, options, avroConversionUtil.getFhirContext());
-
+    // TODO this is a terrible method to force closure of Parquet files; this is
+    //  done for demonstration only and should be removed before merge!
+    System.gc();
+    Thread.sleep(10000);
     log.info("DONE!");
   }
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -448,8 +448,7 @@ public class FhirEtl {
   }
 
   public static void main(String[] args)
-      throws IOException, SQLException, ViewDefinitionException, ProfileException,
-          InterruptedException {
+      throws IOException, SQLException, ViewDefinitionException, ProfileException {
 
     AvroConversionUtil.initializeAvroConverters();
 
@@ -466,10 +465,7 @@ public class FhirEtl {
     List<Pipeline> pipelines = setupAndBuildPipelines(options, avroConversionUtil);
     EtlUtils.runMultiplePipelinesWithTimestamp(
         pipelines, options, avroConversionUtil.getFhirContext());
-    // TODO this is a terrible method to force closure of Parquet files; this is
-    //  done for demonstration only and should be removed before merge!
-    System.gc();
-    Thread.sleep(10000);
+
     log.info("DONE!");
   }
 }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.ref.Cleaner;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.HashMap;
@@ -55,38 +54,6 @@ public class ParquetUtil {
   private final Random random;
   private final String namePrefix;
   private boolean flushedInCurrentPeriod;
-  private static final Cleaner cleaner;
-
-  static {
-    cleaner = Cleaner.create();
-  }
-
-  // TODO this is a terrible method to force closure of Parquet files; this is
-  //  done for demonstration only and should be removed before merge! The same
-  //  can be achieved by using `finalize()` which is deprecated since Java 9.
-  private static class CleaningAction implements Runnable {
-    private Map<String, ParquetWriter<GenericRecord>> writerMap;
-    private Timer timer;
-
-    CleaningAction(Map<String, ParquetWriter<GenericRecord>> writerMap, Timer timer) {
-      // We cannot keep references to the ParquetUtil itself see:
-      // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ref/Cleaner.html
-      this.writerMap = writerMap;
-      this.timer = timer;
-    }
-
-    @Override
-    public void run() {
-      try {
-        log.info("******* DEBUG in run() BEFORE ********");
-        ParquetUtil.closeAllWriters(writerMap, timer);
-        log.info("******* DEBUG in run() AFTER ********");
-      } catch (IOException e) {
-        // There is not much else we can do at this stage.
-        log.error("IOException during cleaning: ", e);
-      }
-    }
-  }
 
   private synchronized void setFlushedInCurrentPeriod(boolean value) {
     flushedInCurrentPeriod = value;
@@ -130,8 +97,6 @@ public class ParquetUtil {
     this.rowGroupSize = rowGroupSize;
     this.namePrefix = namePrefix;
     setFlushedInCurrentPeriod(false);
-    // TODO remove timer and secondsToFlush option if using the `cleaner` is desired; note this
-    //  holds pointers to the enclosing ParqeutUtil instance hence the `clean` is never called!
     if (secondsToFlush > 0) {
       TimerTask task =
           new TimerTask() {
@@ -158,7 +123,6 @@ public class ParquetUtil {
       timer = null;
     }
     this.random = new Random(System.currentTimeMillis());
-    cleaner.register(this, new CleaningAction(writerMap, timer));
   }
 
   @VisibleForTesting
@@ -230,25 +194,14 @@ public class ParquetUtil {
     setFlushedInCurrentPeriod(true);
   }
 
-  private static void closeAllWriters(
-      Map<String, ParquetWriter<GenericRecord>> writerMap, Timer timer) throws IOException {
+  public synchronized void closeAllWriters() throws IOException {
     if (timer != null) {
-      synchronized (timer) {
-        timer.cancel();
-      }
+      timer.cancel();
     }
-    if (writerMap != null) {
-      synchronized (writerMap) {
-        for (Map.Entry<String, ParquetWriter<GenericRecord>> entry : writerMap.entrySet()) {
-          entry.getValue().close();
-          writerMap.put(entry.getKey(), null);
-        }
-      }
+    for (Map.Entry<String, ParquetWriter<GenericRecord>> entry : writerMap.entrySet()) {
+      entry.getValue().close();
+      writerMap.put(entry.getKey(), null);
     }
-  }
-
-  public void closeAllWriters() throws IOException {
-    closeAllWriters(writerMap, timer);
   }
 
   public void writeRecords(Bundle bundle, Set<String> resourceTypes)

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -41,7 +41,9 @@ import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Implementing AutoCloseable does not help much in the usage pattern we have with DoFns.
+// Implementing AutoCloseable does not help much in the usage pattern we have with DoFns. This is
+// because we cannot wrap single resource writes into a "try-with-resources" block, otherwise each
+// Parquet row-group will include only one record.
 public class ParquetUtil {
 
   private static final Logger log = LoggerFactory.getLogger(ParquetUtil.class);


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #1063 by reverting #1047 for non-Dataflow runners. The fix in #1047 made the size of Parqut files a function of Beam's Bundle size which is not a good idea (beside causing #1063 it also impacts the performance of queries on generated Parquet files). So we only do the FinishBundle flush for `DataflowRunner` which tend to have very large Bundle size.

I could force Parquet files to be closed on Dataflow and also avoid #1063 with `DirectRunner` by using `Cleaner` or `finalize()`. That solution is shown in the first commit of this PR but it is a brutal/hacky solution that depends on garbage-collector. So I reverted that fix and went with the conditional `@FinishBundle` idea. We may need to more carefully consider #288 again, i.e., to use `ParquetIO` instead of our own `ParquetUtil` but as mentioned in [this comment](https://github.com/google/fhir-data-pipes/issues/288#issuecomment-2093694118) it has its own challenges.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the pipeline with DirectRunner and confirmed that multiple records end up in a single Parquet files (as expected).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
