### PR TITLE
Turn sinkFhirServerUrl off by default but on in e2e

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -132,6 +132,7 @@ steps:
   env:
     - PIPELINE_CONFIG=/workspace/docker/config
     - DWH_ROOT=/workspace/e2e-tests/controller-spark/dwh
+    - FHIRDATA_SINKFHIRSERVERURL=http://sink-server:8080/fhir
   args: [ '-f', './docker/compose-controller-spark-sql-single.yaml', 'up',
           '--force-recreate', '-d' ]
 

--- a/docker/compose-controller-spark-sql-single.yaml
+++ b/docker/compose-controller-spark-sql-single.yaml
@@ -62,6 +62,8 @@ services:
       - ${DWH_ROOT}:/dwh
     environment:
       - JAVA_OPTS=$JAVA_OPTS
+      # This is to turn this on in e2e but leave it off in the default config.
+      - FHIRDATA_SINKFHIRSERVERURL=$FHIRDATA_SINKFHIRSERVERURL
     ports:
       - '8090:8080'
     networks:

--- a/docker/config/application.yaml
+++ b/docker/config/application.yaml
@@ -43,7 +43,7 @@ fhirdata:
   rowGroupSizeForParquetFiles: 33554432   # 32mb
   viewDefinitionsDir: "config/views"
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
-  sinkFhirServerUrl: "http://sink-server:8080/fhir"
+  #sinkFhirServerUrl: "http://sink-server:8080/fhir"
   #sinkUserName: "hapi"
   #sinkPassword: "hapi123"
   recursiveDepth: 1

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -167,7 +167,8 @@ fhirdata:
   # empty string disables this feature.
   sinkDbConfigPath: "config/hapi-postgres-config_local_views.json"
 
-  # The base URL of the sink FHIR  server .if not set ,only a parquet DWH is created
+  # The base URL of the sink FHIR server. If not set, the feature for sending
+  # resources to a sink FHIR server is disabled.
   sinkFhirServerUrl: "http://172.17.0.1:8098/fhir"
   # The following user-name/password should be set if the sink FHIR server supports Basic Auth.
   #sinkUserName: "hapi"

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -169,7 +169,7 @@ fhirdata:
 
   # The base URL of the sink FHIR server. If not set, the feature for sending
   # resources to a sink FHIR server is disabled.
-  sinkFhirServerUrl: "http://172.17.0.1:8098/fhir"
+  #sinkFhirServerUrl: "http://172.17.0.1:8098/fhir"
   # The following user-name/password should be set if the sink FHIR server supports Basic Auth.
   #sinkUserName: "hapi"
   #sinkPassword: "hapi123"

--- a/pipelines/streaming/pom.xml
+++ b/pipelines/streaming/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2023 Google LLC
+    Copyright 2020-2024 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

With #947 we have enabled sending FHIR resources to a sink server. Turning this on by default, requires an additional setup step of running a sink FHIR server which is not needed for most users (and also is an experimental feature). I am turning this off in the default config but turning it on in e2e since we have tests around it.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Built and ran the docker image locally in the "off case"; relying on e2e for the "on case".

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
