### PR TITLE
Migrate the unit test annotations to Junit 5

### DIFF
--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -184,6 +184,13 @@
       <version>4.12.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- This will make sure that the Junit 4 test cases will also be run along with Junit 5 test
+    cases-->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/FlinkConfigurationTest.java
@@ -28,16 +28,16 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlinkConfigurationTest {
 
   @ParameterizedTest

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/GcsDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/GcsDwhFilesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,11 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -45,9 +46,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = DataProperties.class)
 @TestPropertySource("classpath:application-test.properties")
 @EnableConfigurationProperties(value = DataProperties.class)
@@ -58,7 +59,7 @@ public class GcsDwhFilesManagerTest {
 
   @Autowired private DataProperties dataProperties;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     closeable = MockitoAnnotations.openMocks(this);
     GcsOptions gcsOptions = PipelineOptionsFactory.as(GcsOptions.class);
@@ -66,7 +67,7 @@ public class GcsDwhFilesManagerTest {
     FileSystems.setDefaultPipelineOptions(gcsOptions);
   }
 
-  @After
+  @AfterEach
   public void closeService() throws Exception {
     closeable.close();
   }
@@ -163,10 +164,14 @@ public class GcsDwhFilesManagerTest {
     assertThat(baseDir2, equalTo("gs://test-bucket/baseDir/childDir"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBaseDirForInvalidPath() {
-    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    dwhFilesManager.getBaseDir("gs://test-bucket");
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+          dwhFilesManager.getBaseDir("gs://test-bucket");
+        });
   }
 
   @Test
@@ -183,12 +188,16 @@ public class GcsDwhFilesManagerTest {
     assertThat(prefix3, equalTo("prefix"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testPrefixForInvalidPath() {
-    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    // GCS Path should end with a non-empty suffix string after the last occurrence of the
-    // character '/'
-    dwhFilesManager.getPrefix("gs://test-bucket/baseDir/");
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+          // GCS Path should end with a non-empty suffix string after the last occurrence of the
+          // character '/'
+          dwhFilesManager.getPrefix("gs://test-bucket/baseDir/");
+        });
   }
 
   private StorageObject createStorageObject(String gcsFilename, long fileSize) {


### PR DESCRIPTION
## Description of what I changed

Fixes #1085

Controller module unit tests have been migrated to `Junit 5` for proper coverage reporting.
Reference : [Migration to Junit 5](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4)

## E2E test

Not Applicable

TESTED:

Verified the coverage report in the codecov before and after the changes, and verified if the numbers now are correct.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
