### PR TITLE
Upgrade spring framework to 3.2.2

### DIFF
--- a/pipelines/controller/pom.xml
+++ b/pipelines/controller/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.1.5</spring-boot.version>
+    <spring-boot.version>3.2.2</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -372,13 +372,13 @@
         <configuration>
           <source>17</source>
           <target>17</target>
+          <!-- To retain parameter names for compiled classes, this is needed for Spring framework
+            with versions >= 6.1. See https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
+            for the details -->
+          <parameters>true</parameters>
           <compilerArgs>
             <!-- Enable access to the packages at compile time -->
             <arg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</arg>
-            <!-- To retain parameter names for compiled classes, this is needed for latest spring.
-            See https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
-            for the details -->
-            <arg>-parameters</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -375,6 +375,10 @@
           <compilerArgs>
             <!-- Enable access to the packages at compile time -->
             <arg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+            <!-- To retain parameter names for compiled classes, this is needed for latest spring.
+            See https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
+            for the details -->
+            <arg>-parameters</arg>
           </compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description of what I changed

This is to fix the upgrade issue caused by this [PR](https://github.com/google/fhir-data-pipes/pull/927).

The upgrade was failing because the latest Spring code as per this [documentation](https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention) needs to know the parameter names (embedded in the compiled classes) and does not deduce the names by parsing the bytecode. The compiler arg `-parameters` is enabled by default for `spring-boot-starter-parent`.

## E2E test

Relied on automated e2e tests.

TESTED:

NA

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
