### PR TITLE
Added s3 in schema parsing

### DIFF
--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -47,9 +47,10 @@ fhirdata:
   # ./config/controller_DWH_ORIG_TIMESTAMP_2023-01-27T23-55-39.295824Z
   # Similar to the pipeline `outputParquetPath` parameter.
   #
-  # For GCS buckets, dwhRootPrefix must be of the format
-  # "gs://<bucket>/<baseDirPath>/<prefix>". <baseDirPath> is optional
-  # for GCS buckets and may contain 0 or more directory names.
+  # For GCS and S3 buckets, dwhRootPrefix must be of the format
+  # "scheme://<bucket>/<baseDirPath>/<prefix>" where `scheme` is either `gs`
+  # or `s3`. <baseDirPath> is optional for cloud buckets and may contain 0 or
+  # more directory names.
   #
   # For *nix file systems, dwhRootPrefix must be of the format
   # "/<baseDirPath>/<prefix>" and can be absolute or relative. <baseDirPath>

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/CloudDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/CloudDwhFilesManagerTest.java
@@ -52,7 +52,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(classes = DataProperties.class)
 @TestPropertySource("classpath:application-test.properties")
 @EnableConfigurationProperties(value = DataProperties.class)
-public class GcsDwhFilesManagerTest {
+public class CloudDwhFilesManagerTest {
 
   @Mock private GcsUtil mockGcsUtil;
   private AutoCloseable closeable;
@@ -210,7 +210,7 @@ public class GcsDwhFilesManagerTest {
         IllegalArgumentException.class,
         () -> {
           DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-          // GCS Path should end with a non-empty suffix string after the last occurrence of the
+          // S3 Path should end with a non-empty suffix string after the last occurrence of the
           // character '/'
           dwhFilesManager.getPrefix("s3://test-bucket/baseDir/");
         });

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/GcsDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/GcsDwhFilesManagerTest.java
@@ -162,6 +162,9 @@ public class GcsDwhFilesManagerTest {
 
     String baseDir2 = dwhFilesManager.getBaseDir("gs://test-bucket/baseDir/childDir/prefix");
     assertThat(baseDir2, equalTo("gs://test-bucket/baseDir/childDir"));
+
+    String s3BaseDir = dwhFilesManager.getBaseDir("s3://test-bucket/baseDir/childDir/prefix");
+    assertThat(s3BaseDir, equalTo("s3://test-bucket/baseDir/childDir"));
   }
 
   @Test
@@ -171,6 +174,16 @@ public class GcsDwhFilesManagerTest {
         () -> {
           DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
           dwhFilesManager.getBaseDir("gs://test-bucket");
+        });
+  }
+
+  @Test
+  public void testBaseDirForInvalidPathS3() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+          dwhFilesManager.getBaseDir("s3://test-bucket");
         });
   }
 
@@ -186,6 +199,21 @@ public class GcsDwhFilesManagerTest {
 
     String prefix3 = dwhFilesManager.getPrefix("gs://test-bucket/baseDir/childDir/prefix");
     assertThat(prefix3, equalTo("prefix"));
+
+    String s3Prefix = dwhFilesManager.getPrefix("s3://test-bucket/baseDir/childDir/prefix");
+    assertThat(s3Prefix, equalTo("prefix"));
+  }
+
+  @Test
+  public void testPrefixForInvalidPathS3() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
+          // GCS Path should end with a non-empty suffix string after the last occurrence of the
+          // character '/'
+          dwhFilesManager.getPrefix("s3://test-bucket/baseDir/");
+        });
   }
 
   @Test


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes the S3 schema parsing issue in the controller code. This is a piece that was missed in #1066 because I only tested the pipeline code directly (not through the controller).

Fixes #1011.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the controller locally but set the `dwhRootPrefix` to a `s3://` location and checked that parquet files are created both in full and incremental runs (like before this needed `AWS_REGION`, `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` to be set).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
