### PR TITLE
Added cacheBundleForParquetWrites option

### DIFF
--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -38,6 +38,16 @@ public interface BasePipelineOptions extends PipelineOptions {
   void setRowGroupSizeForParquetFiles(int value);
 
   @Description(
+      "This is an experimental feature which is intended for Dataflow runner only. The purpose is "
+          + "to cache output Parquet records for each Beam bundle such that the DoFn "
+          + "is idempotent, or to be more precise, can be retried for an incomplete "
+          + "bundle (Beam's bundle not FHIR) without corrupting the Parquet output.")
+  @Default.Boolean(false)
+  boolean getCacheBundleForParquetWrites();
+
+  void setCacheBundleForParquetWrites(boolean value);
+
+  @Description(
       "Directory containing the structure definition files for any custom profiles that needs to be"
           + " supported. If it starts with `classpath:` then the classpath is searched; and the"
           + " path should always start with `/`. Do not use this if custom profiles are not needed."

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -296,6 +296,11 @@ public class FhirEtl {
                 + options.getResourceList());
       }
     }
+    if (options.getCacheBundleForParquetWrites()
+        && !"DataflowRunner".equals(options.getRunner().getSimpleName())) {
+      throw new IllegalArgumentException(
+          "--cacheBundleForParquetWrites is intended to be used with Dataflow runner only!");
+    }
   }
 
   // TODO: Implement active period feature for JDBC mode with a HAPI source server (issue #278).

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
@@ -310,7 +310,6 @@ public class JdbcFetchHapi {
   @VisibleForTesting
   List<QueryParameterDescriptor> generateQueryParameters(
       FhirEtlOptions options, String resourceType, int numResources) {
-    log.info("Generating query parameters for " + resourceType);
 
     int jdbcFetchSize = options.getJdbcFetchSize();
     List<QueryParameterDescriptor> queryParameterList = new ArrayList<QueryParameterDescriptor>();
@@ -318,6 +317,11 @@ public class JdbcFetchHapi {
     if (numResources % jdbcFetchSize != 0) {
       numBatches += 1;
     }
+    log.info(
+        "Generating query parameters for resource type {}; numResources= {} numBatches= {} ",
+        resourceType,
+        numResources,
+        numBatches);
 
     for (int i = 0; i < numBatches; i++) {
       queryParameterList.add(QueryParameterDescriptor.create(resourceType, numBatches, i));

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -73,7 +73,8 @@ public class ParquetUtilTest {
             Resources.getResource("observation_bundle.json"), StandardCharsets.UTF_8);
     AvroConversionUtil.deRegisterMappingsFor(FhirVersionEnum.R4);
     avroConversionUtil = AvroConversionUtil.getInstance(FhirVersionEnum.R4, "", 1);
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_", 1);
+    parquetUtil =
+        new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "TEST_", 1, false);
   }
 
   @Test
@@ -107,7 +108,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutput() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -133,7 +134,7 @@ public class ParquetUtilTest {
   public void createMultipleOutputByTime()
       throws IOException, InterruptedException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 1, 0, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
@@ -159,7 +160,7 @@ public class ParquetUtilTest {
   @Test
   public void createSingleOutputWithRowGroupSize() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 1, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
     // There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
@@ -192,7 +193,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationWithBigDecimalValue() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     String observationStr =
         Resources.toString(
             Resources.getResource("observation_decimal.json"), StandardCharsets.UTF_8);
@@ -206,7 +207,7 @@ public class ParquetUtilTest {
   public void writeObservationBundleWithDecimalConversionIssue()
       throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
     String observationBundleStr =
         Resources.toString(
             Resources.getResource("observation_decimal_bundle.json"), StandardCharsets.UTF_8);
@@ -219,7 +220,7 @@ public class ParquetUtilTest {
   @Test
   public void writeObservationBundleWithMultipleProfiles() throws IOException, ProfileException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
-    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1);
+    parquetUtil = new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), 0, 0, "", 1, false);
 
     String patientStr =
         Resources.toString(Resources.getResource("patient_bundle.json"), StandardCharsets.UTF_8);
@@ -251,7 +252,8 @@ public class ParquetUtilTest {
             0,
             0,
             "",
-            1);
+            1,
+            false);
 
     String questionnaireResponseStr =
         Resources.toString(

--- a/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
+++ b/pipelines/streaming/src/main/java/com/google/fhir/analytics/DebeziumListener.java
@@ -96,7 +96,8 @@ public class DebeziumListener extends RouteBuilder {
             params.secondsToFlushParquetFiles,
             params.rowGroupSizeForParquetFiles,
             "streaming_",
-            1);
+            1,
+            false);
     DataSource jdbcSource =
         JdbcConnectionPools.getInstance()
             .getPooledDataSource(


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #1089 by adding an option to cache Parquet output and flush in `@FinishBundle`. This solution is limited to the Dataflow runner only because:
- With FlinkRunner, at least in the local mode, the bundle size seems to be huge and [`maxBundleSize`](https://beam.apache.org/documentation/runners/flink/) option does not seem to make any difference.
- In Flink local mode, i.e., when everything is run in a single process, I am not sure if recovery from a worker failure is important (or even properly handled by Flink).

Other outputs seem to be fine because:
- We use `PUT` for sending resources to a sink FHIR server.
- Updating views output in a sink DB, handles deletion of old rows.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:
Ran some Dataflow runs and made sure that there are several bundles per worker. A sample run is [here](https://console.cloud.google.com/dataflow/jobs/us-central1/2024-07-25_13_37_32-4551474485663479256;graphView=0;mainTab=JOB_METRICS?pageState=(%22dfTime%22:(%22s%22:%222024-07-25T20:37:33.150Z%22,%22e%22:%222024-07-25T20:45:22.872Z%22))&project=fhir-analytics-test) with corresponding log messages [here](https://cloudlogging.app.goo.gl/eiuzsGQBNWyQLTyU8).

Also did many tests with Flink and `--maxBundleSize` which was not successful (hence disabled the feature for Flink).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
