### PR TITLE
Remove path variable when retrieving the error log file.

### DIFF
--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -749,7 +749,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         dwhRoot = dwhRoot.endsWith(fileSeparator) ? dwhRoot : dwhRoot + fileSeparator;
         ResourceId errorResource = FileSystems.matchNewResource(dwhRoot + ERROR_FILE_NAME, false);
         if (dwhFilesManager.doesFileExist(errorResource)) {
-          dwhRunDetails.setLogFilePath(dwhRoot + ERROR_FILE_NAME);
+          dwhRunDetails.setErrorLogPath(dwhRoot + ERROR_FILE_NAME);
         }
       }
       dwhRunDetails.setStatus(status);
@@ -772,6 +772,6 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     private String startTime;
     private String endTime;
     private String status;
-    private String logFilePath;
+    private String errorLogPath;
   }
 }

--- a/pipelines/controller/src/main/resources/templates/index.html
+++ b/pipelines/controller/src/main/resources/templates/index.html
@@ -15,8 +15,8 @@
           th:src="@{/bootstrap-5.0.2-dist/js/bootstrap.min.js}"></script>
 
   <script>
-    function openLogs(logPath) {
-      const url = "/download?path="+logPath;
+    function openErrorLog() {
+      const url = "/download-error-log";
       // Encode the special characters in the url
       const encodedURL = encodeURI(url);
       window.open(encodedURL, '_blank').focus();
@@ -232,13 +232,12 @@
         <div class="alert alert-danger alert-dismissible fade show"
              th:if="${lastRunDetails ne null AND lastRunDetails.status == 'FAILURE'}"
              style="color:red">
-          <div th:if="${#strings.isEmpty(lastRunDetails.logFilePath)}">
+          <div th:if="${#strings.isEmpty(lastRunDetails.errorLogPath)}">
             Last run failed and the logs are not available. Please contact the Administrator.
           </div>
-          <div th:unless="${#strings.isEmpty(lastRunDetails.logFilePath)}">
+          <div th:unless="${#strings.isEmpty(lastRunDetails.errorLogPath)}">
             Last run failed! Please find error logs here
-            <button type="submit"
-                    class="button btn btn-primary" th:onclick="openLogs([[${lastRunDetails.logFilePath}]])">
+            <button type="submit" class="button btn btn-primary" th:onclick="openErrorLog()">
               View Raw Logs
             </button>
           </div>


### PR DESCRIPTION
## Description of what I changed

Currently to retrieve the error log file associated with the latest pipeline run, we pass the log file path in the request as a path parameter, this is prone to vulnerability attacks as there are no checks to restrict the paths only to the data-warehouse directory.

This PR contains changes to remove the path parameter altogether and only retrieves the error log associated with the latest pipeline run if exists.

## E2E test

Tested the changed api and it works as expected. Also, the path parameter to accept file path is no more valid.

TESTED:

relied on e2e tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
