### PR TITLE
Delete resources in the sink DB and FHIR server

### DIFF
--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
@@ -149,15 +149,19 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
     }
     if (!sinkPath.isEmpty()) {
       startTime = System.currentTimeMillis();
-      // TODO : Remove the deleted resources from the sink fhir store
-      // https://github.com/google/fhir-data-pipes/issues/588
-      fhirStoreUtil.uploadResource(resource);
+      if (jsonResource == null || jsonResource.isBlank()) {
+        fhirStoreUtil.deleteResourceById(resourceType, resource.getId());
+      } else {
+        fhirStoreUtil.uploadResource(resource);
+      }
       totalPushTimeMillisMap.get(resourceType).inc(System.currentTimeMillis() - startTime);
     }
     if (sinkDbConfig != null) {
-      // TODO : Remove the deleted resources from the sink database
-      // https://github.com/google/fhir-data-pipes/issues/588
-      jdbcWriter.writeResource(resource);
+      if (jsonResource == null || jsonResource.isBlank()) {
+        jdbcWriter.deleteResourceById(resourceType, resource.getId());
+      } else {
+        jdbcWriter.writeResource(resource);
+      }
     }
   }
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
@@ -108,7 +108,8 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
     String jsonResource = element.jsonResource();
     long startTime = System.currentTimeMillis();
     Resource resource = null;
-    if (jsonResource == null || jsonResource.isBlank()) {
+    boolean isResourceDeleted = jsonResource == null || jsonResource.isBlank();
+    if (isResourceDeleted) {
       // The jsonResource field will be empty in case of deleted records and are ignored during
       // the initial batch run
       if (!processDeletedRecords) {
@@ -149,7 +150,7 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
     }
     if (!sinkPath.isEmpty()) {
       startTime = System.currentTimeMillis();
-      if (jsonResource == null || jsonResource.isBlank()) {
+      if (isResourceDeleted) {
         fhirStoreUtil.deleteResourceById(resourceType, resource.getId());
       } else {
         fhirStoreUtil.uploadResource(resource);
@@ -157,7 +158,7 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
       totalPushTimeMillisMap.get(resourceType).inc(System.currentTimeMillis() - startTime);
     }
     if (sinkDbConfig != null) {
-      if (jsonResource == null || jsonResource.isBlank()) {
+      if (isResourceDeleted) {
         jdbcWriter.deleteResourceById(resourceType, resource.getId());
       } else {
         jdbcWriter.writeResource(resource);

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
@@ -161,8 +161,7 @@ public class JdbcFetchHapi {
                   + " FROM hfj_resource res JOIN"
                   + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver "
                   + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid "
-                  + " WHERE res.res_type = ? AND res.res_id % ? = ? AND"
-                  + " ver.res_encoding != 'DEL'");
+                  + " WHERE res.res_type = ? AND res.res_id % ? = ?");
       // TODO do date sanity-checking on `since` (note this is partly done by HAPI client call).
       if (since != null && !since.isEmpty()) {
         builder.append(" AND res.res_updated > '").append(since).append("'");

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcResourceWriterTest.java
@@ -86,4 +86,15 @@ public class JdbcResourceWriterTest {
     assertThat(indexCaptor.getAllValues().get(2), equalTo(3));
     assertThat(idCaptor.getAllValues().get(2), equalTo("my-patient-id"));
   }
+
+  @Test
+  public void testDeleteResource() throws SQLException {
+    JdbcResourceWriter jdbcResourceWriter = new JdbcResourceWriter(dataSourceMock, "", fhirContext);
+    String resourceType = "Patient";
+    String id = "123456";
+    jdbcResourceWriter.deleteResourceById(resourceType, id);
+    verify(statementMock, times(1)).setString(indexCaptor.capture(), idCaptor.capture());
+    assertThat(indexCaptor.getAllValues().get(0), equalTo(1));
+    assertThat(idCaptor.getAllValues().get(0), equalTo("123456"));
+  }
 }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/FhirStoreUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/FhirStoreUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,25 @@ public class FhirStoreUtil {
     }
 
     return updateFhirResource(sinkUrl, resource, interceptors);
+  }
+
+  /**
+   * Deletes a resource using the given resourceType and id
+   *
+   * @param resourceType the type of resource to be deleted
+   * @param id the id of the resource to be deleted
+   * @return the output result of delete operation
+   */
+  public MethodOutcome deleteResourceById(String resourceType, String id) {
+    Collection<IClientInterceptor> interceptors = Collections.emptyList();
+    if (!isNullOrEmpty(sinkUsername) && !isNullOrEmpty(sinkPassword)) {
+      interceptors = Collections.singleton(new BasicAuthInterceptor(sinkUsername, sinkPassword));
+    }
+    IGenericClient client = createGenericClient(sinkUrl, interceptors);
+    // Initialize the client, which will be used to interact with the service.
+    MethodOutcome outcome = client.delete().resourceById(resourceType, id).execute();
+    log.debug("FHIR resource deleted at" + sinkUrl + "? " + outcome.getCreated());
+    return outcome;
   }
 
   public Collection<MethodOutcome> uploadBundle(Bundle bundle) {

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/FhirStoreUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/FhirStoreUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
+import ca.uhn.fhir.rest.gclient.IDeleteTyped;
 import ca.uhn.fhir.rest.gclient.IUpdateTyped;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +50,8 @@ public class FhirStoreUtilTest {
   private IGenericClient client;
 
   @Mock IUpdateTyped iexec;
+
+  @Mock IDeleteTyped iDeleteTyped;
 
   private FhirStoreUtil fhirStoreUtil;
 
@@ -118,5 +121,17 @@ public class FhirStoreUtilTest {
     assertThat(result, not(nullValue()));
     assertThat(result, not(Matchers.empty()));
     assertThat(result.iterator().next().getCreated(), equalTo(true));
+  }
+
+  @Test
+  public void testDeleteResource() {
+    String resourceType = "Patient";
+    String id = "patient-id";
+    when(client.delete().resourceById(resourceType, id)).thenReturn(iDeleteTyped);
+    MethodOutcome outcome = new MethodOutcome();
+    outcome.setCreated(true);
+    doReturn(outcome).when(iDeleteTyped).execute();
+    MethodOutcome result = fhirStoreUtil.deleteResourceById(resourceType, id);
+    assertThat(result.getCreated(), equalTo(true));
   }
 }


### PR DESCRIPTION
## Description of what I changed

Fixes #588 
Delete the FHIR resources in the Sink DB and Sink FHIR servers during export.

## E2E test

Relied on e2e tests.

TESTED:

Manually tested by deleting the resources from the source FHIR server and verifying the same from the sink systems.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
