### PR TITLE
Fixed an edge case for incremental run failures on cloud file-systems

### DIFF
--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -197,10 +196,11 @@ public class DwhFiles {
 
   /**
    * Also see {@link #newIncrementalRunPath()}
+   *
    * @return the current incremental run path if one found; null otherwise.
    */
   @Nullable
-  public ResourceId getIncrementalRunPath() throws IOException {
+  public ResourceId getLatestIncrementalRunPath() throws IOException {
     List<ResourceId> dirs =
         getAllChildDirectories(getRoot()).stream()
             .filter(dir -> dir.getFilename().contains(INCREMENTAL_DIR + TIMESTAMP_PREFIX))

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -35,7 +35,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -71,6 +73,8 @@ public class DwhFiles {
       "timestamp_bulk_transaction_time.txt";
 
   private static final String INCREMENTAL_DIR = "incremental_run";
+
+  static final String TIMESTAMP_PREFIX = "_TIMESTAMP_";
 
   // TODO: It is probably better if we build all DWH files related operations using Beam's
   //  filesystem API such that when a new filesystem is registered, it automatically works
@@ -121,6 +125,10 @@ public class DwhFiles {
     return new DwhFiles(dwhRoot, fhirContext);
   }
 
+  public static String safeTimestampSuffix() {
+    return Instant.now().toString().replace(":", "-").replace("-", "_").replace(".", "_");
+  }
+
   public String getRoot() {
     return dwhRoot;
   }
@@ -145,50 +153,75 @@ public class DwhFiles {
         "%s*%s", getResourcePath(resourceType).toString(), ParquetUtil.PARQUET_EXTENSION);
   }
 
+  // TODO: Move this to a util class and make it non-static.
   /**
-   * This returns the default incremental run path; each incremental run is relative to a full path,
-   * hence we put this directory under the full-run root.
+   * Returns all the child directories under the given base directory which are 1-level deep. Note
+   * in many cloud/distributed file-systems, we do not have "directories"; there are only buckets
+   * and files in those buckets. We use file-seprators (e.g., `/`) to simulate the concept of
+   * directories. So for example, this method returns an empty set if `baseDir` is `bucket/test` and
+   * the only file in that bucket is `bucket/test/dir1/dir2/file.txt`. If `baseDir` is
+   * `bucket/test/dir1`, in the above example, `dir2` is returned.
    *
-   * @return the default incremental run path
+   * @param baseDir the path under which "directories" are looked for.
+   * @return The list of all child directories under the base directory
+   * @throws IOException
    */
-  public ResourceId getIncrementalRunPath() {
-    return FileSystems.matchNewResource(getRoot(), true)
-        .resolve(INCREMENTAL_DIR, StandardResolveOptions.RESOLVE_DIRECTORY);
+  static Set<ResourceId> getAllChildDirectories(String baseDir) throws IOException {
+    String fileSeparator = getFileSeparatorForDwhFiles(baseDir);
+    // Avoid using ResourceId.resolve(..) method to resolve the files when the path contains glob
+    // expressions with multiple special characters like **, */* etc as this api only supports
+    // single special characters like `*` or `..`. Rather use the FileSystems.match(..) if the path
+    // contains glob expressions.
+    List<MatchResult> matchResultList =
+        FileSystems.match(
+            List.of(
+                getPathEndingWithFileSeparator(baseDir, fileSeparator)
+                    + "*"
+                    + fileSeparator
+                    + "*"));
+    Set<ResourceId> childDirectories = new HashSet<>();
+    for (MatchResult matchResult : matchResultList) {
+      if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
+        for (Metadata metadata : matchResult.metadata()) {
+          childDirectories.add(metadata.resourceId().getCurrentDirectory());
+        }
+      } else if (matchResult.status() == Status.ERROR) {
+        String errorMessage = String.format("Error matching files under directory %s", baseDir);
+        log.error(errorMessage);
+        throw new IOException(errorMessage);
+      }
+    }
+    log.info("Child directories of {} are {}", baseDir, childDirectories);
+    return childDirectories;
   }
 
-  /** This is used when we want to keep a backup of the old incremental run output. */
-  public ResourceId getIncrementalRunPathWithTimestamp() {
+  /**
+   * Also see {@link #newIncrementalRunPath()}
+   * @return the current incremental run path if one found; null otherwise.
+   */
+  @Nullable
+  public ResourceId getIncrementalRunPath() throws IOException {
+    List<ResourceId> dirs =
+        getAllChildDirectories(getRoot()).stream()
+            .filter(dir -> dir.getFilename().contains(INCREMENTAL_DIR + TIMESTAMP_PREFIX))
+            .collect(Collectors.toList());
+    if (dirs.isEmpty()) return null;
+
+    Collections.sort(dirs, Comparator.comparing(ResourceId::toString));
+    return dirs.get(dirs.size() - 1);
+  }
+
+  /**
+   * This returns a new incremental-run path based on the current timestamp. Note that each
+   * incremental-run is relative to a full-run, hence we put this directory under the full-run root.
+   *
+   * @return a new incremental run path based on the current timestamp.
+   */
+  public ResourceId newIncrementalRunPath() {
     return FileSystems.matchNewResource(getRoot(), true)
         .resolve(
-            String.format("%s_old_%d", INCREMENTAL_DIR, System.currentTimeMillis()),
+            String.format("%s%s%s", INCREMENTAL_DIR, TIMESTAMP_PREFIX, safeTimestampSuffix()),
             StandardResolveOptions.RESOLVE_DIRECTORY);
-  }
-
-  /**
-   * Similar to {@link #getIncrementalRunPath} but also checks if that directory exists and if so,
-   * moves it to {@link #getIncrementalRunPathWithTimestamp()}.
-   *
-   * @return same as {@link #getIncrementalRunPath()}
-   * @throws IOException if the directory move fails
-   */
-  public ResourceId newIncrementalRunPath() throws IOException {
-    ResourceId incPath = getIncrementalRunPath();
-    if (hasIncrementalDir()) {
-      ResourceId movePath = getIncrementalRunPathWithTimestamp();
-      log.info("Moving the old {} directory to {}", INCREMENTAL_DIR, movePath);
-      FileSystems.rename(Collections.singletonList(incPath), Collections.singletonList(movePath));
-    }
-    return incPath;
-  }
-
-  /**
-   * @return true iff there is already an incremental run subdirectory in this DWH.
-   */
-  public boolean hasIncrementalDir() throws IOException {
-    List<MatchResult> matches =
-        FileSystems.matchResources(Collections.singletonList(getIncrementalRunPath()));
-    MatchResult matchResult = Iterables.getOnlyElement(matches);
-    return matchResult.status() == Status.OK;
   }
 
   public Set<String> findNonEmptyResourceDirs() throws IOException {

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
@@ -71,7 +71,7 @@ public class LocalDwhFilesTest {
     FileSystems.create(file2, "test");
     // making sure that the last incremental path is returned
     assertThat(
-        instance.getIncrementalRunPath().toString(), equalTo(incrementalRunPath2.toString()));
+        instance.getLatestIncrementalRunPath().toString(), equalTo(incrementalRunPath2.toString()));
   }
 
   @Test

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/LocalDwhFilesTest.java
@@ -17,6 +17,7 @@ package com.google.fhir.analytics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.google.common.io.Resources;
@@ -33,6 +34,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
@@ -55,11 +58,30 @@ public class LocalDwhFilesTest {
   }
 
   @Test
+  public void getIncrementalRunPathTest() throws IOException {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    DwhFiles instance = new DwhFiles("/tmp", FhirContext.forR4Cached());
+    ResourceId incrementalRunPath1 = instance.newIncrementalRunPath();
+    ResourceId file1 =
+        incrementalRunPath1.resolve("file1.txt", StandardResolveOptions.RESOLVE_FILE);
+    FileSystems.create(file1, "test");
+    ResourceId incrementalRunPath2 = instance.newIncrementalRunPath();
+    ResourceId file2 =
+        incrementalRunPath2.resolve("file2.txt", StandardResolveOptions.RESOLVE_FILE);
+    FileSystems.create(file2, "test");
+    // making sure that the last incremental path is returned
+    assertThat(
+        instance.getIncrementalRunPath().toString(), equalTo(incrementalRunPath2.toString()));
+  }
+
+  @Test
   public void newIncrementalRunPathTestNonWindows() throws IOException {
     Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
     DwhFiles instance = new DwhFiles("/tmp", FhirContext.forR4Cached());
     ResourceId incrementalRunPath = instance.newIncrementalRunPath();
-    assertThat(incrementalRunPath.toString(), equalTo("/tmp/incremental_run/"));
+    assertThat(
+        incrementalRunPath.toString(),
+        startsWith("/tmp/incremental_run" + DwhFiles.TIMESTAMP_PREFIX));
   }
 
   @Test
@@ -241,5 +263,35 @@ public class LocalDwhFilesTest {
 
   private void createFile(Path path, byte[] bytes) throws IOException {
     Files.write(path, bytes);
+  }
+
+  @Test
+  public void testGetAllChildDirectoriesOneLevelDeep() throws IOException {
+    Path rootDir = Files.createTempDirectory("DWH_FILES_TEST");
+    Path childDir1 = Paths.get(rootDir.toString(), "childDir1");
+    Files.createDirectories(childDir1);
+    Path fileAtChildDir1 = Path.of(childDir1.toString(), "file1.txt");
+    createFile(fileAtChildDir1, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
+    Path childDir2 = Paths.get(rootDir.toString(), "childDir2");
+    Files.createDirectories(childDir2);
+    Path fileAtChildDir2 = Path.of(childDir2.toString(), "file2.txt");
+    createFile(fileAtChildDir2, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
+
+    // The following directory should not appear in the results of `getAllChildDirectories`
+    // because only dirs at one-level deep should be returned.
+    Path childDir21 = Paths.get(childDir2.toString(), "childDir21");
+    Files.createDirectories(childDir21);
+    Path fileAtChildDir21 = Path.of(childDir21.toString(), "file3.txt");
+    createFile(fileAtChildDir21, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
+
+    Set<ResourceId> childDirectories = DwhFiles.getAllChildDirectories(rootDir.toString());
+
+    assertThat(childDirectories.size(), equalTo(2));
+    assertThat(
+        childDirectories.contains(FileSystems.matchNewResource(childDir1.toString(), true)),
+        equalTo(true));
+    assertThat(
+        childDirectories.contains(FileSystems.matchNewResource(childDir2.toString(), true)),
+        equalTo(true));
   }
 }

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -52,8 +51,6 @@ import org.springframework.stereotype.Component;
 public class DataProperties {
 
   private static final Logger logger = LoggerFactory.getLogger(DataProperties.class.getName());
-
-  static final String TIMESTAMP_PREFIX = "_TIMESTAMP_";
 
   private static final String GET_PREFIX = "get";
 
@@ -212,9 +209,8 @@ public class DataProperties {
     }
 
     // Using underscore for suffix as hyphens are discouraged in hive table names.
-    String timestampSuffix =
-        Instant.now().toString().replace(":", "-").replace("-", "_").replace(".", "_");
-    options.setOutputParquetPath(dwhRootPrefix + TIMESTAMP_PREFIX + timestampSuffix);
+    String timestampSuffix = DwhFiles.safeTimestampSuffix();
+    options.setOutputParquetPath(dwhRootPrefix + DwhFiles.TIMESTAMP_PREFIX + timestampSuffix);
 
     PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = addFlinkOptions(options);
 
@@ -222,7 +218,7 @@ public class DataProperties {
     String thriftServerParquetPathPrefix =
         dwhRootPrefix.substring(dwhRootPrefix.lastIndexOf("/") + 1, dwhRootPrefix.length());
     pipelineConfigBuilder.thriftServerParquetPath(
-        thriftServerParquetPathPrefix + TIMESTAMP_PREFIX + timestampSuffix);
+        thriftServerParquetPathPrefix + DwhFiles.TIMESTAMP_PREFIX + timestampSuffix);
     pipelineConfigBuilder.timestampSuffix(timestampSuffix);
 
     return pipelineConfigBuilder.build();

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -194,12 +194,12 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     try {
       String prefix = dwhFilesManager.getPrefix(rootPrefix);
       List<ResourceId> paths =
-          dwhFilesManager.getAllChildDirectories(baseDir).stream()
+          DwhFiles.getAllChildDirectories(baseDir).stream()
               .filter(dir -> dir.getFilename().startsWith(prefix))
               .collect(Collectors.toList());
 
       for (ResourceId path : paths) {
-        if (!path.getFilename().startsWith(prefix + DataProperties.TIMESTAMP_PREFIX)) {
+        if (!path.getFilename().startsWith(prefix + DwhFiles.TIMESTAMP_PREFIX)) {
           // This is not necessarily an error; the user may want to bootstrap from an already
           // created DWH outside the control-panel framework, e.g., by running the batch pipeline
           // directly.
@@ -207,7 +207,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
               "DWH directory {} does not start with {}{}",
               paths,
               prefix,
-              DataProperties.TIMESTAMP_PREFIX);
+              DwhFiles.TIMESTAMP_PREFIX);
         }
         if (lastDwh.isEmpty() || lastDwh.compareTo(path.getFilename()) < 0) {
           logger.debug("Found a more recent DWH {}", path.getFilename());
@@ -262,16 +262,16 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
    * This method initialises the lastRunDetails based on the dwh snapshot created recently. In case
    * an incremental run exists in the snapshot, the status is set based on the incremental run.
    */
-  private void initialiseLastRunDetails(String baseDir, String dwhDirectory)
-      throws ProfileException {
+  private void initialiseLastRunDetails(String baseDir, String dwhDirectory) {
     try {
       ResourceId dwhDirectoryPath =
           FileSystems.matchNewResource(baseDir, true)
               .resolve(dwhDirectory, StandardResolveOptions.RESOLVE_DIRECTORY);
       DwhFiles dwhFiles =
           DwhFiles.forRoot(dwhDirectoryPath.toString(), avroConversionUtil.getFhirContext());
-      if (dwhFiles.hasIncrementalDir()) {
-        updateLastRunDetails(dwhFiles.getIncrementalRunPath());
+      ResourceId incPath = dwhFiles.getIncrementalRunPath();
+      if (incPath != null) {
+        updateLastRunDetails(incPath);
         return;
       }
       // In case of no incremental run, the status is set based on the dwhDirectory snapshot.
@@ -428,7 +428,6 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     PipelineConfig pipelineConfig = dataProperties.createBatchOptions();
     FhirEtlOptions options = pipelineConfig.getFhirEtlOptions();
     String finalDwhRoot = options.getOutputParquetPath();
-    // TODO move old incremental_run dir if there is one
     String incrementalDwhRoot = currentDwh.newIncrementalRunPath().toString();
     options.setOutputParquetPath(incrementalDwhRoot);
     String since = fetchSinceTimestamp(options);
@@ -553,8 +552,8 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
 
     try {
       List<ResourceId> paths =
-          dwhFilesManager.getAllChildDirectories(baseDir).stream()
-              .filter(dir -> dir.getFilename().startsWith(prefix + DataProperties.TIMESTAMP_PREFIX))
+          DwhFiles.getAllChildDirectories(baseDir).stream()
+              .filter(dir -> dir.getFilename().startsWith(prefix + DwhFiles.TIMESTAMP_PREFIX))
               .filter(
                   dir -> {
                     try {
@@ -571,8 +570,10 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
       // Sort snapshots directories.
       Collections.sort(paths, Comparator.comparing(ResourceId::toString));
 
+      // TODO: Why are we creating these tables for all paths and not just the most recent? If all
+      //  are needed, why are we doing the above `sort`?
       for (ResourceId path : paths) {
-        String[] tokens = path.getFilename().split(prefix + DataProperties.TIMESTAMP_PREFIX);
+        String[] tokens = path.getFilename().split(prefix + DwhFiles.TIMESTAMP_PREFIX);
         if (tokens.length > 1) {
           String timestamp = tokens[1];
           logger.info("Creating resource tables for relative path {}", path.getFilename());

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -269,7 +269,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
               .resolve(dwhDirectory, StandardResolveOptions.RESOLVE_DIRECTORY);
       DwhFiles dwhFiles =
           DwhFiles.forRoot(dwhDirectoryPath.toString(), avroConversionUtil.getFhirContext());
-      ResourceId incPath = dwhFiles.getIncrementalRunPath();
+      ResourceId incPath = dwhFiles.getLatestIncrementalRunPath();
       if (incPath != null) {
         updateLastRunDetails(incPath);
         return;

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/CloudDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/CloudDwhFilesManagerTest.java
@@ -18,14 +18,12 @@ package com.google.fhir.analytics;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.extensions.gcp.util.GcsUtil;
 import org.apache.beam.sdk.extensions.gcp.util.GcsUtil.StorageObjectOrIOException;
@@ -119,39 +117,6 @@ public class CloudDwhFilesManagerTest {
 
     ResourceId dwhRoot = FileSystems.matchNewResource("gs://testbucket/testdirectory", true);
     assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(false));
-  }
-
-  @Test
-  public void testGetAllChildDirectoriesOneLevelDeep() throws IOException {
-    Objects modelObjects = new Objects();
-    List<StorageObject> items = new ArrayList<>();
-    // Files within the directory
-    items.add(
-        createStorageObject(
-            "gs://testbucket/testdirectory/Patient/patient.parquet", 1L /* fileSize */));
-    items.add(
-        createStorageObject(
-            "gs://testbucket/testdirectory/Observation/observation.parquet", 2L /* fileSize */));
-    modelObjects.setItems(items);
-
-    Mockito.when(
-            mockGcsUtil.listObjects(
-                Mockito.eq("testbucket"), Mockito.anyString(), Mockito.isNull()))
-        .thenReturn(modelObjects);
-
-    DwhFilesManager dwhFilesManager = new DwhFilesManager(dataProperties);
-    Set<ResourceId> childDirectories =
-        dwhFilesManager.getAllChildDirectories("gs://testbucket/testdirectory");
-
-    assertThat(childDirectories.size(), equalTo(2));
-    assertThat(
-        childDirectories.contains(
-            FileSystems.matchNewResource("gs://testbucket/testdirectory/Patient", true)),
-        equalTo(true));
-    assertThat(
-        childDirectories.contains(
-            FileSystems.matchNewResource("gs://testbucket/testdirectory/Observation", true)),
-        equalTo(true));
   }
 
   @Test

--- a/pipelines/controller/src/test/java/com/google/fhir/analytics/LocalDwhFilesManagerTest.java
+++ b/pipelines/controller/src/test/java/com/google/fhir/analytics/LocalDwhFilesManagerTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -102,29 +101,6 @@ public class LocalDwhFilesManagerTest {
     ResourceId dwhRoot = FileSystems.matchNewResource(root.toString(), true);
 
     assertThat(dwhFilesManager.isDwhComplete(dwhRoot), equalTo(false));
-  }
-
-  @Test
-  public void testGetAllChildDirectoriesOneLevelDeep() throws IOException {
-    Path rootDir = testPath.resolve("rootDir");
-    Path childDir1 = Paths.get(rootDir.toString(), "childDir1");
-    Files.createDirectories(childDir1);
-    Path fileAtChildDir1 = Path.of(childDir1.toString(), "file1.txt");
-    createFile(fileAtChildDir1, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
-    Path childDir2 = Paths.get(rootDir.toString(), "childDir2");
-    Files.createDirectories(childDir2);
-    Path fileAtChildDir2 = Path.of(childDir2.toString(), "file2.txt");
-    createFile(fileAtChildDir2, "SAMPLE TEXT".getBytes(StandardCharsets.UTF_8));
-
-    Set<ResourceId> childDirectories = dwhFilesManager.getAllChildDirectories(rootDir.toString());
-
-    assertThat(childDirectories.size(), equalTo(2));
-    assertThat(
-        childDirectories.contains(FileSystems.matchNewResource(childDir1.toString(), true)),
-        equalTo(true));
-    assertThat(
-        childDirectories.contains(FileSystems.matchNewResource(childDir2.toString(), true)),
-        equalTo(true));
   }
 
   @Test


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

The bug was discovered as part of [this report](https://github.com/google/fhir-data-pipes/issues/1011#issuecomment-2259752302) (see item 4). The actual bug is _not_ what is reported there but for whatever [other] reasons, an incremental-run has failed. That failure has blocked the following incremental-runs (which are supposed to repeat the old failed one). The reason this edge-case fails on cloud files-systems (e.g., GCS, S3), is because there is not really a concept of "directory" there. We have buckets and files in them. As a consequence of this bug-fix, the `incremental_run` directories now have a timestamp suffix as well.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Beside updating unit-tests, I rant the controller locally with  `dwhRootPrefix` set to a `s3://...` path; then created an artificial failure by creating an `error.log` in an incremental run (and removing some other files). I reran the incremental-build and verified that the controller can recover from that situation (previously it could not).

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
