### PR TITLE
Change canonical tables to views

### DIFF
--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
@@ -206,6 +206,8 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
 
   private Resource createNewFhirResource(String fhirVersion, String resourceType) {
     try {
+      // TODO create tests for this method and different versions of FHIR; casting to R4 resource
+      //  does not seem right!
       return (Resource)
           Class.forName(getFhirBasePackageName(fhirVersion) + "." + resourceType)
               .getConstructor()

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -94,7 +94,7 @@ fhirdata:
   # The number of DWH snapshots to retain when the purge job runs.
   # This must be > 0 or the purge job will not run. If a pipeline run fails
   # for any reason, any partial output must be manually removed.
-  numOfDwhSnapshotsToRetain: 4
+  numOfDwhSnapshotsToRetain: 2
 
   # The comma-separated list of FHIR resources to fetch/monitor.
   # Equivalent to pipeline `resourceList` parameter.
@@ -122,7 +122,7 @@ fhirdata:
 
   # Whether resource tables should be automatically created on a
   # Hive/Spark server. Primarily meant for single-machine deployment.
-  createHiveResourceTables: true
+  createHiveResourceTables: false
 
   # Path to a file with the settings used to create tables.
   # Required if createHiveResourceTables is `true`.

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -94,7 +94,7 @@ fhirdata:
   # The number of DWH snapshots to retain when the purge job runs.
   # This must be > 0 or the purge job will not run. If a pipeline run fails
   # for any reason, any partial output must be manually removed.
-  numOfDwhSnapshotsToRetain: 2
+  numOfDwhSnapshotsToRetain: 4
 
   # The comma-separated list of FHIR resources to fetch/monitor.
   # Equivalent to pipeline `resourceList` parameter.
@@ -122,7 +122,7 @@ fhirdata:
 
   # Whether resource tables should be automatically created on a
   # Hive/Spark server. Primarily meant for single-machine deployment.
-  createHiveResourceTables: false
+  createHiveResourceTables: true
 
   # Path to a file with the settings used to create tables.
   # Required if createHiveResourceTables is `true`.


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

Fixes #1140 
This should fix an edge case reported in #1140 where it seems a canonical table is being queried between `DROP` and `CREATE`; see that issue for more details.
The multiple commits on this PR are to show different solutions I tried, e.g.,
- `ALTER TABLE`
- Transactions
- `VIEW`
## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the controller locally against a local Thrift server and tested various scenarios.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
