### PR TITLE
Handle HAPI FHIR's MDM service in HAPI JDBC mode

### DIFF
--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -321,10 +321,12 @@ public class FhirEtl {
 
     JdbcFetchHapi jdbcFetchHapi = new JdbcFetchHapi(jdbcSource);
     Map<String, Integer> resourceCount =
-        jdbcFetchHapi.searchResourceCounts(options.getResourceList(), options.getSince());
+        jdbcFetchHapi.searchResourceCounts(
+            options.getResourceList(), options.getSince(), options.getMdmResourceList());
 
     List<Pipeline> pipelines = new ArrayList<>();
     long totalNumOfResources = 0l;
+    List<String> mdmResourceTypes = Arrays.asList(options.getMdmResourceList().split(","));
     for (String resourceType : options.getResourceList().split(",")) {
       int numResources = resourceCount.get(resourceType);
       if (numResources == 0) {
@@ -346,7 +348,9 @@ public class FhirEtl {
               new JdbcFetchHapi.FetchRowsJdbcIo(
                   options.getResourceList(),
                   JdbcIO.DataSourceConfiguration.create(jdbcSource),
-                  options.getSince()));
+                  options.getSince(),
+                  mdmResourceTypes.contains(resourceType),
+                  options.getMapToGoldenResources()));
 
       payload.apply(
           "Convert to parquet for " + resourceType,

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
@@ -265,4 +265,18 @@ public interface FhirEtlOptions extends BasePipelineOptions {
   String getSourceNdjsonFilePatternList();
 
   void setSourceNdjsonFilePatternList(String value);
+
+  @Description(
+      "Whether to use HAPI-FHIR's MDM service to replace Resource references with their Golden"
+          + " Resource counterparts")
+  @Default.Boolean(false)
+  Boolean getMapToGoldenResources();
+
+  void setMapToGoldenResources(Boolean mapToGoldenResources);
+
+  @Description("Comma separated list of resources to treat as MDM Resources.")
+  @Default.String("Patient")
+  String getMdmResourceList();
+
+  void setMdmResourceList(String mdmResourceList);
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/HapiRowDescriptor.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/HapiRowDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ abstract class HapiRowDescriptor implements Serializable {
 
   static HapiRowDescriptor create(
       String resourceId,
+      String fhirId,
       String forcedId,
       String resourceType,
       String lastUpdated,
@@ -40,6 +41,7 @@ abstract class HapiRowDescriptor implements Serializable {
       String jsonResource) {
     return new AutoValue_HapiRowDescriptor(
         resourceId,
+        fhirId,
         forcedId,
         resourceType,
         lastUpdated,
@@ -49,6 +51,8 @@ abstract class HapiRowDescriptor implements Serializable {
   }
 
   abstract String resourceId();
+
+  abstract String fhirId();
 
   @Nullable
   abstract String forcedId();
@@ -65,4 +69,8 @@ abstract class HapiRowDescriptor implements Serializable {
 
   // FHIR tags.
   List<ResourceTag> tags;
+
+  List<MdmLink> mdmLinks;
+
+  List<SourceIdentifier> sourceIdentifiers;
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/MdmLink.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/MdmLink.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Data;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+
+@DefaultCoder(SerializableCoder.class)
+@Data
+@Builder
+public class MdmLink implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  // the resource that contains references to golden resources, e.g. Encounter
+  String resourceId;
+
+  // the resource that is the golden resource, e.g. Patient
+  String sourceFhirId;
+  String goldenFhirId;
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof MdmLink)) {
+      return false;
+    }
+
+    MdmLink mdmLink = (MdmLink) other;
+
+    return sourceFhirId.equals(mdmLink.sourceFhirId)
+        && goldenFhirId.equals(mdmLink.goldenFhirId)
+        && resourceId.equals(mdmLink.resourceId);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 1;
+    hash = 31 * hash + (sourceFhirId == null ? 0 : sourceFhirId.hashCode());
+    hash = 31 * hash + (goldenFhirId == null ? 0 : goldenFhirId.hashCode());
+    hash = 31 * hash + (resourceId == null ? 0 : resourceId.hashCode());
+    return hash;
+  }
+}

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/SourceIdentifier.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/SourceIdentifier.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Data;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+
+@DefaultCoder(SerializableCoder.class)
+@Data
+@Builder
+public class SourceIdentifier implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  String resourceId;
+  String system;
+  String value;
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof SourceIdentifier)) {
+      return false;
+    }
+
+    SourceIdentifier sourceIdentifier = (SourceIdentifier) other;
+
+    return resourceId.equals(sourceIdentifier.resourceId)
+        && system.equals(sourceIdentifier.system)
+        && value.equals(sourceIdentifier.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 1;
+    hash = 31 * hash + (resourceId == null ? 0 : resourceId.hashCode());
+    hash = 31 * hash + (system == null ? 0 : system.hashCode());
+    hash = 31 * hash + (value == null ? 0 : value.hashCode());
+    return hash;
+  }
+}

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
@@ -16,8 +16,7 @@
 package com.google.fhir.analytics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -33,6 +32,8 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.codesystems.ActionType;
@@ -79,13 +80,20 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", null, "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
+            "123",
+            "my-patient-id",
+            null,
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "1",
+            patientResourceStr);
     convertResourceFn.writeResource(element);
 
     // Verify the resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("123"));
+    assertThat(capturedResource.getId(), equalTo("my-patient-id"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
     assertThat(
         capturedResource.getMeta().getLastUpdated(),
@@ -105,6 +113,7 @@ public class ConvertResourceFnTest {
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
             "123",
+            "my-patient-id",
             "forced-id-123",
             "Patient",
             "2020-09-19 12:09:23",
@@ -134,7 +143,14 @@ public class ConvertResourceFnTest {
     // Deleted Patient resource
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+            "123",
+            "my-patient-id",
+            "forced-id-123",
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "2",
+            "");
     convertResourceFn.writeResource(element);
     // Verify that the ParquetUtil writer is not invoked for the deleted resource.
     verify(mockParquetUtil, times(0)).write(Mockito.any());
@@ -149,7 +165,14 @@ public class ConvertResourceFnTest {
     // Deleted Patient resource
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+            "123",
+            "my-patient-id",
+            "forced-id-123",
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "2",
+            "");
     convertResourceFn.writeResource(element);
 
     // Verify the deleted resource is sent to the writer.
@@ -179,6 +202,7 @@ public class ConvertResourceFnTest {
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
             "123",
+            "my-patient-id",
             "forced-id-123",
             "Patient",
             "2020-09-19 12:09:23",
@@ -212,5 +236,96 @@ public class ConvertResourceFnTest {
     assertThat(capturedResource.getMeta().getSecurity().get(0).getCode(), equalTo("code2"));
     assertThat(capturedResource.getMeta().getSecurity().get(0).getSystem(), equalTo("system2"));
     assertThat(capturedResource.getMeta().getSecurity().get(0).getDisplay(), equalTo("display2"));
+  }
+
+  @Test
+  public void testProcessEncounterResource_withMdmLinks()
+      throws IOException, java.text.ParseException, SQLException, PropertyVetoException,
+          ViewApplicationException, ProfileException {
+    String[] args = {"--outputParquetPath=SOME_PATH"};
+    setUp(args);
+    String encounterResourceStr =
+        Resources.toString(Resources.getResource("encounter.json"), StandardCharsets.UTF_8);
+    HapiRowDescriptor element =
+        HapiRowDescriptor.create(
+            "456",
+            "mock-id",
+            null,
+            "Encounter",
+            "2020-09-19 12:09:23",
+            "R4",
+            "1",
+            encounterResourceStr);
+
+    // Add MdmLinks to the HapiRowDescriptor
+    MdmLink mdmLink1 =
+        MdmLink.builder()
+            .resourceId("456")
+            .sourceFhirId("f71e5b02-4a5a-44f8-82ec-c5a215ad886c")
+            .goldenFhirId("golden-id-1")
+            .build();
+    element.setMdmLinks(List.of(mdmLink1));
+
+    convertResourceFn.writeResource(element);
+
+    // Verify the resource is sent to the writer.
+    verify(mockParquetUtil).write(resourceCaptor.capture());
+    Resource capturedResource = resourceCaptor.getValue();
+    assertThat(capturedResource.getId(), equalTo("mock-id"));
+    assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
+    assertThat(
+        capturedResource.getMeta().getLastUpdated(),
+        equalTo(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2020-09-19 12:09:23")));
+    assertThat(capturedResource.getResourceType().toString(), equalTo("Encounter"));
+    assertThat(
+        ((Encounter) capturedResource).getSubject().getReference(), equalTo("Patient/golden-id-1"));
+  }
+
+  @Test
+  public void testProcessPatientResource_withSourceIdentifiers()
+      throws IOException, java.text.ParseException, SQLException, PropertyVetoException,
+          ViewApplicationException, ProfileException {
+    String[] args = {"--outputParquetPath=SOME_PATH"};
+    setUp(args);
+    String patientResourceStr =
+        Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
+    HapiRowDescriptor element =
+        HapiRowDescriptor.create(
+            "123",
+            "my-patient-id",
+            "forced-id-123",
+            "Patient",
+            "2020-09-19 12:09:23",
+            "R4",
+            "1",
+            patientResourceStr);
+
+    SourceIdentifier sourceIdentifier1 =
+        SourceIdentifier.builder().resourceId("123").system("system-1").value("value-1").build();
+
+    SourceIdentifier sourceIdentifier2 =
+        SourceIdentifier.builder().resourceId("123").system("system-2").value("value-2").build();
+
+    element.setSourceIdentifiers(List.of(sourceIdentifier1, sourceIdentifier2));
+
+    convertResourceFn.writeResource(element);
+
+    // Verify the resource is sent to the writer.
+    verify(mockParquetUtil).write(resourceCaptor.capture());
+    Resource capturedResource = resourceCaptor.getValue();
+    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
+    assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
+    assertThat(
+        capturedResource.getMeta().getLastUpdated(),
+        equalTo(new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2020-09-19 12:09:23")));
+    assertThat(capturedResource.getResourceType().toString(), equalTo("Patient"));
+
+    List<Identifier> identifiers = ((Patient) capturedResource).getIdentifier();
+    assertThat(identifiers, notNullValue());
+    assertThat(identifiers.size(), equalTo(2));
+    assertThat(identifiers.get(0).getSystem(), equalTo("system-1"));
+    assertThat(identifiers.get(0).getValue(), equalTo("value-1"));
+    assertThat(identifiers.get(1).getSystem(), equalTo("system-2"));
+    assertThat(identifiers.get(1).getValue(), equalTo("value-2"));
   }
 }

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchHapiTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchHapiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Google LLC
+ * Copyright 2020-2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ public class JdbcFetchHapiTest extends TestCase {
   @Test
   public void testMapRow() throws Exception {
     Mockito.when(resultSet.getString("res_encoding")).thenReturn("DEL");
+    Mockito.when(resultSet.getString("fhir_id")).thenReturn("mock-id");
     Mockito.when(resultSet.getString("res_id")).thenReturn("101");
     Mockito.when(resultSet.getString("res_type")).thenReturn("Encounter");
     Mockito.when(resultSet.getString("res_updated")).thenReturn("2002-03-12 10:09:20");
@@ -90,6 +91,7 @@ public class JdbcFetchHapiTest extends TestCase {
         new JdbcFetchHapi.ResultSetToRowDescriptor(options.getResourceList()).mapRow(resultSet);
 
     assertNotNull(rowDescriptor);
+    assertEquals(rowDescriptor.fhirId(), "mock-id");
     assertEquals(rowDescriptor.resourceId(), "101");
     assertEquals(rowDescriptor.resourceType(), "Encounter");
     assertEquals(rowDescriptor.resourceVersion(), "1");
@@ -111,13 +113,14 @@ public class JdbcFetchHapiTest extends TestCase {
     Mockito.when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
     Mockito.when(
             mockedConnection.prepareStatement(
-                "SELECT count(*) as count FROM hfj_resource res where res.res_type = ? AND"
+                "SELECT count(*) as count FROM hfj_resource res WHERE res.res_type = ? AND"
                     + " res.res_updated > '"
                     + since
                     + "'"))
         .thenReturn(mockedPreparedStatement);
 
-    Map<String, Integer> resourceCountMap = jdbcFetchHapi.searchResourceCounts(resourceList, since);
+    Map<String, Integer> resourceCountMap =
+        jdbcFetchHapi.searchResourceCounts(resourceList, since, "");
 
     assertThat(resourceCountMap.get("Patient"), equalTo(100));
     assertThat(resourceCountMap.get("Encounter"), equalTo(100));

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -139,6 +139,16 @@ fhirdata:
   # you can use those predefined views in your dev. env. too.
   hiveResourceViewsDir: "config/views"
 
+  # Whether to use HAPI-FHIR's MDM service to replace resource references with
+  # their golden resource counterparts.
+  mapToGoldenResources: false
+
+  # Comma separated list of resources that are tracked by HAPI FHIR's MDM service.
+  mdmResourceList: ""
+
+  # Whether to treat possible matches as full matches when mapping resources to their golden resource.
+  treatPossibleMatchesAsMatches: true
+
   # Directory path containing the structure definition files for any custom profiles that needs to be
   # supported. If this starts with `classpath:` then the a classpath resource is
   # assumed and the path should always start with a `/`.

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -109,6 +109,12 @@ public class DataProperties {
 
   public String sinkUserName;
 
+  private boolean mapToGoldenResources;
+
+  private String mdmResourceList;
+
+  private String structureDefinitionsDir;
+
   public String sinkPassword;
 
   private String structureDefinitionsPath;
@@ -212,6 +218,9 @@ public class DataProperties {
     String timestampSuffix = DwhFiles.safeTimestampSuffix();
     options.setOutputParquetPath(dwhRootPrefix + DwhFiles.TIMESTAMP_PREFIX + timestampSuffix);
 
+    options.setMapToGoldenResources(mapToGoldenResources);
+    options.setMdmResourceList(mdmResourceList);
+
     PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = addFlinkOptions(options);
 
     // Get hold of thrift server parquet directory from dwhRootPrefix config.
@@ -254,8 +263,10 @@ public class DataProperties {
             "",
             ""),
         new ConfigFields("fhirdata.recursiveDepth", String.valueOf(recursiveDepth), "", ""),
+        new ConfigFields("fhirdata.createParquetViews", String.valueOf(createParquetViews), "", ""),
         new ConfigFields(
-            "fhirdata.createParquetViews", String.valueOf(createParquetViews), "", ""));
+            "fhirdata.mapToGoldenResources", String.valueOf(mapToGoldenResources), "", ""),
+        new ConfigFields("fhirdata.mdmResourceList", mdmResourceList, "", ""));
   }
 
   ConfigFields getConfigFields(FhirEtlOptions options, Method getMethod) {


### PR DESCRIPTION
## Description of what I changed

We use HAPI-FHIR's [MDM service](https://hapifhir.io/hapi-fhir/docs/server_jpa_mdm/mdm.html) to help deduplicate and handle patients (and other resources) from multiple healthcare systems. Essentially, every MDM tracked resource gets a "golden" version, which can have a link to multiple "source" resources. For ease in our own analysis, we've forked this project to add support for MDM (only with the HAPI JDBC mode) in the following ways:
* Only retrieve the golden version of MDM-configured resources
  * Additionally include the source resources' identifiers in the result (so source patients can be referred to during analysis)
* For all references to MDM-configured resources, replace their source FHIR id with the golden version's FHIR id

With the default parameters there should be no change to the pipeline. However, I've made an additional change:
* Changed the JDBC mode to use the FHIR id rather than the database primary key.

This is a breaking change and might require a flag? There are probably other things to clean up and more tests to add, but I am mostly opening this to see if these changes would be welcome.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:
Tests were done with ~150k patients, where roughly half were golden resources.

- Ran with default parameters and ensured all resources regardless of Golden status were fetched, and that resource mapping was not attempted.
- Ran with Patient,Location,Practitioner,PractitionerRole,Organization as MDM resources set mapToGoldenResources to true and manually checked some resources to ensure they were all golden, and that their source versions were mapped in other resources.
## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.