### PR TITLE
Advances hapi versions and skips xhtml fields

### DIFF
--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 /** Converter to change HAPI objects into Avro structures and vice versa. */

--- a/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -140,6 +140,8 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           .put("time", STRING_CONVERTER)
           .put("string", STRING_CONVERTER)
           .put("oid", STRING_CONVERTER)
+          // Note `xhtml` types are currently skipped because of:
+          // https://github.com/google/fhir-data-pipes/issues/1014
           .put("xhtml", STRING_CONVERTER)
           .put("decimal", DOUBLE_CONVERTER)
           .put("integer", INTEGER_CONVERTER)

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
@@ -63,7 +63,13 @@ public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
 
   @Override
   public Object fromHapi(Object input) {
-
+    // TODO: remove this hack! It is added to address this bug:
+    // https://github.com/google/fhir-data-pipes/issues/1014
+    // with root cause being:
+    // https://github.com/hapifhir/org.hl7.fhir.core/issues/1800
+    if (!(input instanceof IPrimitiveType)) {
+      return "";
+    }
     return fromHapi((IPrimitiveType) input);
   }
 

--- a/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
+++ b/bunsen/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
@@ -36,6 +36,8 @@ public abstract class StructureDefinitions {
           .add("time")
           .add("string")
           .add("oid")
+          // Note `xhtml` types are currently skipped because of:
+          // https://github.com/google/fhir-data-pipes/issues/1014
           .add("xhtml")
           .add("decimal")
           .add("integer")

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <compile.source>11</compile.source>
-    <hapi.fhir.version>7.2.2</hapi.fhir.version>
+    <hapi.fhir.version>7.4.5</hapi.fhir.version>
     <avro.version>1.12.0</avro.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>3.0</hamcrest.version>
@@ -89,6 +89,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.18.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.5.0-M2</version>
     </dependency>
   </dependencies>
 

--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.5.0-M2</version>
+      <version>4.4</version>
     </dependency>
   </dependencies>
 

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/view/SQLonFHIRv2Test.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/view/SQLonFHIRv2Test.java
@@ -55,7 +55,6 @@ import org.hl7.fhir.instance.model.api.IBaseDecimalDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.hl7.fhir.r4.utils.FHIRLexer.FHIRLexerException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -144,7 +143,7 @@ public class SQLonFHIRv2Test {
                 String.format(
                     "Number of rows does not match %d vs %d", totalRows, expectedRows.getNumRows()),
                 totalRows == expectedRows.getNumRows());
-          } catch (ViewApplicationException | ViewDefinitionException | FHIRLexerException e) {
+          } catch (ViewApplicationException | ViewDefinitionException e) {
             assertThat(
                 "View exceptions were thrown while none was expected!", expectedRows == null);
           }

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -237,7 +237,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.5.0-M2</version>
+      <version>4.4</version>
     </dependency>
   </dependencies>
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -45,7 +45,7 @@
     <junit.version>4.13.2</junit.version>
     <slf4j.version>2.0.16</slf4j.version>
     <logback.version>1.5.12</logback.version>
-    <hapi.fhir.version>7.2.2</hapi.fhir.version>
+    <hapi.fhir.version>7.4.5</hapi.fhir.version>
     <hamcrest.version>3.0</hamcrest.version>
     <mockito.version>5.2.0</mockito.version>
     <jcommander.version>1.82</jcommander.version>
@@ -232,6 +232,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.18.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.5.0-M2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

For why we are doing this, see #1014 and in particular [this comment](https://github.com/google/fhir-data-pipes/issues/1014#issuecomment-2455453171).

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Relied on unit/e2e tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
