### PR TITLE
Removed long WARN logs

### DIFF
--- a/pipelines/batch/pom.xml
+++ b/pipelines/batch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2024 Google LLC
+    Copyright 2020-2025 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2024 Google LLC
+    Copyright 2020-2025 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -29,11 +29,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.List;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.w3c.dom.stylesheets.LinkStyle;
 
 // TODO add testes for DSTU3 resources too.
 

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/ParquetUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,17 +172,29 @@ public class ParquetUtilTest {
     assertThat(files.count(), equalTo(7L));
   }
 
+  /**
+   * The point of this test is to reduce the row-group size and show we still get a single file when
+   * there are multiple groups.
+   */
   @Test
   public void createSingleOutputWithRowGroupSize()
       throws IOException, ProfileException, ViewApplicationException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
+    // This came from debugging `InternalParquetRecordWriter`!
+    final int approximateRecordMemSize = 458;
+    // We could also set a very small rowGroupSize to force multiple groups but because
+    // each group has at least 100 records (regardless of its size), then setting a very
+    // small number will trigger this warning which creates thousands of log lines:
+    // https://github.com/apache/parquet-java/blob/fb6f0be0323f5f52715b54b8c6602763d8d0128d/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java#L203
+    final int rowGroupSize = approximateRecordMemSize * 90;
     parquetUtil =
-        new ParquetUtil(FhirVersionEnum.R4, "", rootPath.toString(), "", false, 0, 1, "", 1, false);
+        new ParquetUtil(
+            FhirVersionEnum.R4, "", rootPath.toString(), "", false, 0, rowGroupSize, "", 1, false);
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
     Bundle bundle = parser.parseResource(Bundle.class, observationBundle);
-    // There are 7 resources in the bundle so we write 15*7 (>100) resources, such that the page
+    // There are 6 resources in the bundle, so we write 17*6 (>100) resources, such that the page
     // group size check is triggered but still it is expected to generate one file only.
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 17; i++) {
       for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
         parquetUtil.write(entry.getResource());
       }
@@ -200,19 +212,20 @@ public class ParquetUtilTest {
                                 + "Observation"
                                 + fileSeparator
                                 + "Observation_output-"));
+    // TODO only checking the number of files is not enough; we should also check it is not empty.
     assertThat(files.count(), equalTo(1L));
   }
 
   /** Tests the ParquetUtil write method for Materialized ViewDefinitions */
   @Test
-  public void createOutputWithRowGroupSizeViewToParquet()
+  public void createOutputViewToParquet()
       throws IOException, ProfileException, ViewApplicationException, ViewDefinitionException {
     rootPath = Files.createTempDirectory("PARQUET_TEST");
     String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(rootPath.toString());
     String path = Resources.getResource("parquet-util-view-test").getFile();
     parquetUtil =
         new ParquetUtil(
-            FhirVersionEnum.R4, "", rootPath.toString(), path, true, 0, 1, "", 1, false);
+            FhirVersionEnum.R4, "", rootPath.toString(), path, true, 0, 0, "", 1, false);
 
     IParser parser = avroConversionUtil.getFhirContext().newJsonParser();
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2024 Google LLC
+    Copyright 2020-2025 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pipelines/streaming/pom.xml
+++ b/pipelines/streaming/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2024 Google LLC
+    Copyright 2020-2025 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

This change reduces the size of a `mvn clean package` output by over 20K lines by preventing [this](https://github.com/apache/parquet-java/blob/fb6f0be0323f5f52715b54b8c6602763d8d0128d/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java#L203).

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the tests locally and checked log size.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
