### PR TITLE
Revert "Bump com.mchange:c3p0 from 0.10.2 to 0.11.0-pre2"

### DIFF
--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>common</artifactId>
 
   <properties>
-    <c3p0.version>0.11.0-pre2</c3p0.version>
+    <c3p0.version>0.10.2</c3p0.version>
     <guava.version>33.4.0-jre</guava.version>
   </properties>
 


### PR DESCRIPTION
Reverts google/fhir-data-pipes#1301
This seems to have made the build more flaky as a lot of e2e builds failed after this (but some passed too!) It is also a `pre` version, so maybe it is better to revert.

![image](https://github.com/user-attachments/assets/6f4f80e9-17ca-4f84-bc6a-872bf1a49737)
