### PR TITLE
Adds functionality for parquet view regeneration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -107,6 +107,7 @@ steps:
   env:
   - FHIR_SERVER_URL=http://hapi-server:8080/fhir
   - PARQUET_PATH=/workspace/e2e-tests/FHIR_SEARCH_HAPI
+  - OUTPUT_PARQUET_VIEW_PATH=/workspace/e2e-tests/FHIR_SEARCH_HAPI/VIEWS_TIMESTAMP_1
   - SINK_PATH=http://sink-server-search:8080/fhir
   - SINK_USERNAME=hapi
   - SINK_PASSWORD=hapi
@@ -132,6 +133,7 @@ steps:
     - SINK_PASSWORD=hapi
     - FHIR_DATABASE_CONFIG_PATH=/workspace/utils/hapi-postgres-config.json
     - PARQUET_PATH=/workspace/e2e-tests/JDBC_HAPI
+    - OUTPUT_PARQUET_VIEW_PATH=/workspace/e2e-tests/JDBC_HAPI/VIEWS_TIMESTAMP_1
     - JDBC_FETCH_SIZE=1000
   waitFor: ['Build Pipeline Images', 'Upload to HAPI']
 
@@ -150,6 +152,7 @@ steps:
     - FHIR_FETCH_MODE=BULK_EXPORT
     - FHIR_SERVER_URL=http://hapi-server:8080/fhir
     - PARQUET_PATH=/workspace/e2e-tests/BULK_EXPORT
+    - OUTPUT_PARQUET_VIEW_PATH=/workspace/e2e-tests/BULK_EXPORT/VIEWS_TIMESTAMP_1
   waitFor: ['Run E2E Test for JDBC mode with HAPI source']
 
 - name: '${_REPOSITORY}/e2e-tests:${_TAG}'
@@ -294,6 +297,7 @@ steps:
   id: 'Run Batch Pipeline FHIR-search mode with OpenMRS source'
   env:
     - PARQUET_PATH=/workspace/e2e-tests/FHIR_SEARCH_OPENMRS
+    - OUTPUT_PARQUET_VIEW_PATH=/workspace/e2e-tests/FHIR_SEARCH_OPENMRS/VIEWS_TIMESTAMP_1
     - SINK_PATH=http://sink-server-for-openmrs:8080/fhir
     - SINK_USERNAME=hapi
     - SINK_PASSWORD=hapi
@@ -314,6 +318,7 @@ steps:
   env:
     - JDBC_MODE_ENABLED=true
     - PARQUET_PATH=/workspace/e2e-tests/JDBC_OPENMRS
+    - OUTPUT_PARQUET_VIEW_PATH=/workspace/e2e-tests/JDBC_OPENMRS/VIEWS_TIMESTAMP_1
     - SINK_PATH=http://sink-server-for-openmrs:8080/fhir
     - SINK_USERNAME=hapi
     - SINK_PASSWORD=hapi

--- a/docker/config/views/Condition_flat.sql
+++ b/docker/config/views/Condition_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Condition_flat AS
+CREATE OR REPLACE VIEW Condition_flat_view AS
 SELECT C.id AS id, C.subject.patientId AS patient_id,
   C.encounter.encounterId AS encounter_id, CCC.system, CCC.code,
   CCatC.code AS category, CClC.code AS clinical_status,

--- a/docker/config/views/DiagnosticReport_flat.sql
+++ b/docker/config/views/DiagnosticReport_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW DiagnosticReport_flat AS
+CREATE OR REPLACE VIEW DiagnosticReport_flat_view AS
 SELECT D.id AS id, D.subject.patientId AS patient_id,
   D.encounter.EncounterId AS encounter_id,
   DCC.system, DCC.code, DR.observationId AS result_obs_id,

--- a/docker/config/views/Encounter_flat.sql
+++ b/docker/config/views/Encounter_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Encounter_flat AS
+CREATE OR REPLACE VIEW Encounter_flat_view AS
 SELECT E.id AS id, E.status, ETC.system AS type_sys,
   ETC.code AS type_code, E.subject.PatientId AS patient_id,
   EP.individual.practitionerId AS practitioner_id,

--- a/docker/config/views/Immunization_flat.sql
+++ b/docker/config/views/Immunization_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Immunization_flat AS
+CREATE OR REPLACE VIEW Immunization_flat_view AS
 SELECT I.id AS id, I.patient.patientId AS patient_id,
   I.encounter.encounterId AS encounter_id, I.status,
   ISC.system AS statusReason_sys, ISC.code AS statusReason_code,

--- a/docker/config/views/Location_flat.sql
+++ b/docker/config/views/Location_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Location_flat AS
+CREATE OR REPLACE VIEW Location_flat_view AS
 SELECT L.id AS id, L.status, L.name, L.address.city,
   L.address.country, L.managingOrganization.organizationId AS org_id,
   L.position.longitude, L.position.latitude, L.position.altitude

--- a/docker/config/views/MedicationRequest_flat.sql
+++ b/docker/config/views/MedicationRequest_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW MedicationRequest_flat AS
+CREATE OR REPLACE VIEW MedicationRequest_flat_view AS
 SELECT M.id AS id, M.subject.patientId AS patient_id,
   M.encounter.encounterId AS encounter_id, M.status,
   MSC.system AS statusReason_sys, MSC.code AS statusReason_code,

--- a/docker/config/views/Observation_flat.sql
+++ b/docker/config/views/Observation_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Observation_flat AS
+CREATE OR REPLACE VIEW Observation_flat_view AS
 SELECT O.id AS id, O.subject.patientId AS patient_id,
   O.encounter.encounterId as encounter_id,
   O.status, OCC.code, OCC.`system` AS code_sys,

--- a/docker/config/views/Organization_flat.sql
+++ b/docker/config/views/Organization_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Organization_flat AS
+CREATE OR REPLACE VIEW Organization_flat_view AS
 SELECT O.id AS id, O.active, O.name, OA.city, OA.country,
   OTC.system, OTC.code
 FROM Organization AS O LATERAL VIEW OUTER explode(O.address) AS OA

--- a/docker/config/views/Patient_flat.sql
+++ b/docker/config/views/Patient_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Patient_flat AS
+CREATE OR REPLACE VIEW Patient_flat_view AS
 SELECT P.id AS id, P.active, PN.family, PNG AS given, P.gender,
   P.deceased.Boolean AS deceased,
   YEAR(current_date()) - YEAR(P.birthDate) AS age,

--- a/docker/config/views/Patient_flat_2.sql
+++ b/docker/config/views/Patient_flat_2.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Patient_flat_2 AS
+CREATE OR REPLACE VIEW Patient_flat_2_view AS
 SELECT P.id AS id, P.active, PN.family, PNG AS given, P.gender,
   P.deceased.Boolean AS deceased, P.birthDate,
   YEAR(current_date()) - YEAR(P.birthDate) AS age,

--- a/docker/config/views/PractitionerRole_flat.sql
+++ b/docker/config/views/PractitionerRole_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW PractitionerRole_flat AS
+CREATE OR REPLACE VIEW PractitionerRole_flat_view AS
 SELECT P.id AS id, P.practitioner.practitionerId as practitioner_id,
   P.active, P.organization.organizationId AS organization_id,
   PCC.system, PCC.code,

--- a/docker/config/views/Practitioner_flat.sql
+++ b/docker/config/views/Practitioner_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Practitioner_flat AS
+CREATE OR REPLACE VIEW Practitioner_flat_view AS
 SELECT P.id AS id, P.active, PN.family, PNG AS given, PA.city,
   PA.country, P.gender, PQCC.system AS qualification_system,
   PQCC.code AS qualification_code

--- a/docker/config/views/Procedure_flat.sql
+++ b/docker/config/views/Procedure_flat.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW Procedure_flat AS
+CREATE OR REPLACE VIEW Procedure_flat_view AS
 SELECT P.id AS id, P.subject.patientId AS patient_id,
   P.encounter.encounterId AS encounter_id, PCC.system, PCC.code,
   PP.actor.practitionerId AS practitioner_id,

--- a/docker/config/views/patient_flat_view.json
+++ b/docker/config/views/patient_flat_view.json
@@ -21,9 +21,19 @@
           "name": "gender"
         },
         {
-          "path": "deceased",
-          "name": "deceased",
+          "path": "birthDate",
+          "name": "birth_date",
+          "type": "date"
+        },
+        {
+          "path": "deceased.ofType(boolean)",
+          "name": "is_deceased",
           "type": "boolean"
+        },
+        {
+          "path": "deceased.ofType(dateTime)",
+          "name": "deceased_time",
+          "type": "dateTime"
         },
         {
           "path": "managingOrganization.getReferenceKey(Organization)",

--- a/e2e-tests/controller-spark/controller_spark_sql_validation.sh
+++ b/e2e-tests/controller-spark/controller_spark_sql_validation.sh
@@ -248,11 +248,11 @@ function check_parquet() {
     "${output}/*/Observation/" | awk '{print $3}')
 
     local total_patient_flat=$(java -Xms16g -Xmx16g -jar ./parquet-tools-1.11.1.jar rowcount \
-    "${output}/*/patient_flat/" | awk '{print $3}')
+    "${output}/*/VIEWS_TIMESTAMP_*/patient_flat/" | awk '{print $3}')
     local total_encounter_flat=$(java -Xms16g -Xmx16g -jar ./parquet-tools-1.11.1.jar rowcount \
-    "${output}/*/encounter_flat/" | awk '{print $3}')
+    "${output}/*/VIEWS_TIMESTAMP_*/encounter_flat/" | awk '{print $3}')
     local total_obs_flat=$(java -Xms16g -Xmx16g -jar ./parquet-tools-1.11.1.jar rowcount \
-     "${output}/*/observation_flat/" | awk '{print $3}')
+     "${output}/*/VIEWS_TIMESTAMP_*/observation_flat/" | awk '{print $3}')
 
     print_message "Total patients: $total_patients"
     print_message "Total encounters: $total_encounters"

--- a/e2e-tests/pipeline_validation.sh
+++ b/e2e-tests/pipeline_validation.sh
@@ -226,17 +226,21 @@ function test_parquet_sink() {
   if [[ ! (-n ${STREAMING}) ]]; then
     print_message "Parquet Sink Test Non-Streaming mode"
     local total_patient_flat=$(java -Xms16g -Xmx16g -jar \
-    ./controller-spark/parquet-tools-1.11.1.jar rowcount "${HOME_PATH}/${PARQUET_SUBDIR}/patient_flat/" | \
+    ./controller-spark/parquet-tools-1.11.1.jar rowcount \
+    "${HOME_PATH}/${PARQUET_SUBDIR}/VIEWS_TIMESTAMP_*/patient_flat/" | \
     awk '{print $3}')
     print_message "Total patient flat rows synced to parquet ---> ${total_patient_flat}"
 
     local total_encounter_flat=$(java -Xms16g -Xmx16g -jar \
-    ./controller-spark/parquet-tools-1.11.1.jar rowcount "${HOME_PATH}/${PARQUET_SUBDIR}/encounter_flat/" \
+    ./controller-spark/parquet-tools-1.11.1.jar rowcount \
+    "${HOME_PATH}/${PARQUET_SUBDIR}/VIEWS_TIMESTAMP_*/encounter_flat/" \
     | awk '{print $3}')
     print_message "Total encounter flat rows synced to parquet ---> ${total_encounter_flat}"
 
-    local total_obs_flat=$(java -Xms16g -Xmx16g -jar ./controller-spark/parquet-tools-1.11.1.jar \
-    rowcount "${HOME_PATH}/${PARQUET_SUBDIR}/observation_flat/" | awk '{print $3}')
+    local total_obs_flat=$(java -Xms16g -Xmx16g -jar \
+    ./controller-spark/parquet-tools-1.11.1.jar rowcount \
+    "${HOME_PATH}/${PARQUET_SUBDIR}/VIEWS_TIMESTAMP_*/observation_flat/" \
+    | awk '{print $3}')
     print_message "Total observation flat rows synced to parquet ---> ${total_obs_flat}"
 
     if (( total_patients_streamed == TOTAL_TEST_PATIENTS && total_encounters_streamed \

--- a/pipelines/batch/Dockerfile
+++ b/pipelines/batch/Dockerfile
@@ -48,7 +48,8 @@ ENV JDBC_MODE_HAPI=false
 ENV RUNNER="DirectRunner"
 ENV FHIR_FETCH_MODE="FHIR_SEARCH"
 ENV VIEW_DEFINITIONS_DIR="/workspace/docker/config/views/"
-ENV CREATE_PARQUET_VIEWS=true
+# This is to simulate a real controller scenario (this is assumed in e2e-tests).
+ENV OUTPUT_PARQUET_VIEW_PATH="/tmp/VIEWS_TIMESTAMP_1/"
 
 
 ENTRYPOINT java -jar /usr/src/Main/app.jar  \
@@ -60,4 +61,5 @@ ENTRYPOINT java -jar /usr/src/Main/app.jar  \
            --fhirDatabaseConfigPath=${FHIR_DATABASE_CONFIG_PATH} --jdbcInitialPoolSize=${JDBC_INITIAL_POOL_SIZE} \
            --jdbcFetchSize=${JDBC_FETCH_SIZE} --jdbcModeHapi=${JDBC_MODE_HAPI} --runner=${RUNNER} \
            --fhirFetchMode=${FHIR_FETCH_MODE} \
-           --viewDefinitionsDir=${VIEW_DEFINITIONS_DIR} --createParquetViews=${CREATE_PARQUET_VIEWS}
+           --viewDefinitionsDir=${VIEW_DEFINITIONS_DIR} \
+           --outputParquetViewPath=${OUTPUT_PARQUET_VIEW_PATH}

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/EtlUtils.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/EtlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.google.fhir.analytics;
 
-import ca.uhn.fhir.context.FhirContext;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
@@ -68,57 +69,63 @@ class EtlUtils {
    * @throws IOException if writing the timestamp file fails.
    */
   static List<PipelineResult> runMultiplePipelinesWithTimestamp(
-      List<Pipeline> pipelines, FhirEtlOptions options, FhirContext fhirContext)
-      throws IOException {
+      List<Pipeline> pipelines, FhirEtlOptions options) throws IOException {
     String dwhRoot = options.getOutputParquetPath();
-    if (dwhRoot != null && !dwhRoot.isEmpty()) {
+    String viewRoot = options.getOutputParquetViewPath();
+    if (!Strings.isNullOrEmpty(dwhRoot)) {
       // TODO write pipeline options too such that it  can be validated for incremental runs.
-      DwhFiles.forRoot(dwhRoot, fhirContext).writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
+      DwhFiles.writeTimestampFile(dwhRoot, DwhFiles.TIMESTAMP_FILE_START);
+    }
+    if (!Strings.isNullOrEmpty(viewRoot)) {
+      DwhFiles.writeTimestampFile(viewRoot, DwhFiles.TIMESTAMP_FILE_START);
     }
     List<PipelineResult> pipelineResults = runMultiplePipelines(pipelines);
-    if (dwhRoot != null && !dwhRoot.isEmpty()) {
-      DwhFiles.forRoot(dwhRoot, fhirContext).writeTimestampFile(DwhFiles.TIMESTAMP_FILE_END);
+    if (!Strings.isNullOrEmpty(viewRoot)) {
+      DwhFiles.writeTimestampFile(viewRoot, DwhFiles.TIMESTAMP_FILE_END);
+    }
+    if (!Strings.isNullOrEmpty(dwhRoot)) {
+      DwhFiles.writeTimestampFile(dwhRoot, DwhFiles.TIMESTAMP_FILE_END);
     }
     return pipelineResults;
   }
 
   /** Similar to {@link #runMultiplePipelinesWithTimestamp} but for the merge pipeline. */
   static List<PipelineResult> runMultipleMergerPipelinesWithTimestamp(
-      List<Pipeline> pipelines, ParquetMergerOptions options, FhirContext fhirContext)
-      throws IOException {
+      List<Pipeline> pipelines, ParquetMergerOptions options) throws IOException {
     mergeWithLatestTimestamp(
         options.getDwh1(),
         options.getDwh2(),
         options.getMergedDwh(),
-        DwhFiles.TIMESTAMP_FILE_START,
-        fhirContext);
+        DwhFiles.TIMESTAMP_FILE_START);
     // Transaction file exists for Batch Export mode, merge the timestamp file in this case
-    if (DwhFiles.forRoot(options.getDwh1(), fhirContext)
-        .doesTimestampFileExist(DwhFiles.TIMESTAMP_FILE_BULK_TRANSACTION_TIME)) {
+    if (DwhFiles.doesTimestampFileExist(
+        options.getDwh1(), DwhFiles.TIMESTAMP_FILE_BULK_TRANSACTION_TIME)) {
       mergeWithLatestTimestamp(
           options.getDwh1(),
           options.getDwh2(),
           options.getMergedDwh(),
-          DwhFiles.TIMESTAMP_FILE_BULK_TRANSACTION_TIME,
-          fhirContext);
+          DwhFiles.TIMESTAMP_FILE_BULK_TRANSACTION_TIME);
     }
     List<PipelineResult> pipelineResults = runMultiplePipelines(pipelines);
-    DwhFiles.forRoot(options.getMergedDwh(), fhirContext)
-        .writeTimestampFile(DwhFiles.TIMESTAMP_FILE_END);
+    DwhFiles.writeTimestampFile(options.getMergedDwh(), DwhFiles.TIMESTAMP_FILE_END);
+    if (!Strings.isNullOrEmpty(options.getViewDefinitionsDir())) {
+      ResourceId viewPath = DwhFiles.getLatestViewsPath(options.getMergedDwh());
+      if (viewPath != null) {
+        // Note in this function, we cannot write the start timestamp file under the VIEWS path
+        // because the exact value of that path is determined in ParquetMerger. Hence, writing
+        // the start timestamp is also done there.
+        DwhFiles.writeTimestampFile(viewPath.toString(), DwhFiles.TIMESTAMP_FILE_END);
+      }
+    }
     return pipelineResults;
   }
 
   private static void mergeWithLatestTimestamp(
-      String dwhRoot1,
-      String dwhRoot2,
-      String mergedDwhRoot,
-      String fileName,
-      FhirContext fhirContext)
-      throws IOException {
-    Instant instant1 = DwhFiles.forRoot(dwhRoot1, fhirContext).readTimestampFile(fileName);
-    Instant instant2 = DwhFiles.forRoot(dwhRoot2, fhirContext).readTimestampFile(fileName);
+      String dwhRoot1, String dwhRoot2, String mergedDwhRoot, String fileName) throws IOException {
+    Instant instant1 = DwhFiles.readTimestampFile(dwhRoot1, fileName);
+    Instant instant2 = DwhFiles.readTimestampFile(dwhRoot2, fileName);
     Instant mergedInstant = (instant1.compareTo(instant2) > 0) ? instant1 : instant2;
-    DwhFiles.forRoot(mergedDwhRoot, fhirContext).writeTimestampFile(mergedInstant, fileName);
+    DwhFiles.writeTimestampFile(mergedDwhRoot, mergedInstant, fileName);
   }
 
   /**

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -86,7 +86,11 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   protected final String stageIdentifier;
 
-  protected final String parquetFile;
+  protected final String outputParquetPath;
+
+  private final String inputParquetPath;
+
+  private final String outputParquetViewPath;
 
   protected final Boolean generateParquetFiles;
 
@@ -122,10 +126,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   protected AvroConversionUtil avroConversionUtil;
 
-  private final boolean createParquetViews;
-
   FetchSearchPageFn(FhirEtlOptions options, String stageIdentifier) {
-    this.createParquetViews = options.isCreateParquetViews();
+    this.outputParquetViewPath = options.getOutputParquetViewPath();
     this.sinkPath = options.getFhirSinkPath();
     this.sinkUsername = options.getSinkUserName();
     this.sinkPassword = options.getSinkPassword();
@@ -136,7 +138,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     this.oAuthClientId = options.getFhirServerOAuthClientId();
     this.oAuthClientSecret = options.getFhirServerOAuthClientSecret();
     this.stageIdentifier = stageIdentifier;
-    this.parquetFile = options.getOutputParquetPath();
+    this.outputParquetPath = options.getOutputParquetPath();
+    this.inputParquetPath = options.getParquetInputDwhRoot();
     this.generateParquetFiles = options.isGenerateParquetFiles();
     this.secondsToFlush = options.getSecondsToFlushParquetFiles();
     this.rowGroupSize = options.getRowGroupSizeForParquetFiles();
@@ -213,14 +216,18 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
             oAuthClientSecret,
             fhirContext);
     fhirSearchUtil = new FhirSearchUtil(fetchUtil);
-    if (generateParquetFiles && !Strings.isNullOrEmpty(parquetFile)) {
+    // TODO remove generateParquetFiles and instead rely on not setting outputParquetPath.
+    if (generateParquetFiles
+        && (!Strings.isNullOrEmpty(outputParquetPath)
+            || !Strings.isNullOrEmpty(outputParquetViewPath))) {
       parquetUtil =
           new ParquetUtil(
               fhirContext.getVersion().getVersion(),
               structureDefinitionsPath,
-              parquetFile,
+              outputParquetPath,
+              inputParquetPath,
               viewDefinitionsDir,
-              createParquetViews,
+              outputParquetViewPath,
               secondsToFlush,
               rowGroupSize,
               stageIdentifier + "_",

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtlOptions.java
@@ -23,7 +23,20 @@ import org.apache.beam.sdk.options.Validation.Required;
 public interface FhirEtlOptions extends BasePipelineOptions {
 
   @Description(
-      "Mode through which the FHIR resources have to be fetched from the source FHIR server")
+      "Mode through which the FHIR resources have to be fetched from the source FHIR server. "
+          + "Supported modes are:\n"
+          + "  FHIR_SEARCH: Reads resources through the FIHR Search API; "
+          + "--fhirServerUrl should be set in this mode.\n"
+          + "  PARQUET: Reads resources from input Parquet files; this is only intended for "
+          + "regenerating flat views or syncing resources with an external FHIR server.\n"
+          + "  JSON: Reads resources from input JSON files; --sourceJsonFilePattern should be set "
+          + "in this mode.\n"
+          + "  NDJSON: Reads resources from input ndjson files; --sourceNdjsonFilePattern "
+          + "should be set in this mode.\n"
+          + "  BULK_EXPORT: Reads resources through the FIHR Bulk Export API; "
+          + "--fhirServerUrl should be set in this mode.\n"
+          + "  HAPI_JDBC: Reads resources through a direct JDBC connection to the database of a "
+          + "HAPI server; --fhirDatabaseConfigPath should be set in this mode.\n")
   @Default.Enum("FHIR_SEARCH")
   FhirFetchMode getFhirFetchMode();
 
@@ -223,11 +236,12 @@ public interface FhirEtlOptions extends BasePipelineOptions {
   void setRecreateSinkTables(Boolean value);
 
   @Description(
-      "If set, flat Parquet files corresponding to input ViewDefinition are created as well.")
-  @Default.Boolean(false)
-  Boolean isCreateParquetViews();
+      "If set, flat Parquet files corresponding to input ViewDefinition are created and written\n"
+          + "in this directory. Each view will be in a sub-directory based on its `name` field.")
+  @Default.String("")
+  String getOutputParquetViewPath();
 
-  void setCreateParquetViews(Boolean value);
+  void setOutputParquetViewPath(String value);
 
   @Description(
       "The path to the data-warehouse directory of Parquet files to be read. The content of this "

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -96,13 +96,13 @@ public class ParquetMerger {
     // reshuffle operations by one.
     PCollection<ReadableFile> inputFiles1 =
         pipeline
-            .apply(Create.of(getParquetFilePaths(viewName, Arrays.asList(dwh1))))
+            .apply(Create.of(getParquetFilePaths(viewName, Arrays.asList(dwh1), true)))
             .apply(FileIO.matchAll())
             .apply(FileIO.readMatches());
 
     PCollection<ReadableFile> inputFiles2 =
         pipeline
-            .apply(Create.of(getParquetFilePaths(viewName, Arrays.asList(dwh2))))
+            .apply(Create.of(getParquetFilePaths(viewName, Arrays.asList(dwh2), true)))
             .apply(FileIO.matchAll())
             .apply(FileIO.readMatches());
 
@@ -148,7 +148,7 @@ public class ParquetMerger {
     // reshuffle operations by one.
     PCollection<ReadableFile> inputFiles =
         pipeline
-            .apply(Create.of(getParquetFilePaths(resourceType, dwhFilesList)))
+            .apply(Create.of(getParquetFilePaths(resourceType, dwhFilesList, false)))
             .apply(FileIO.matchAll())
             .apply(FileIO.readMatches());
 
@@ -180,11 +180,15 @@ public class ParquetMerger {
   }
 
   private static List<String> getParquetFilePaths(
-      String resourceType, List<DwhFiles> dwhFilesList) {
+      String resourceTypeOrViewName, List<DwhFiles> dwhFilesList, boolean isView) {
     List<String> parquetFilePaths = new ArrayList<>();
     if (dwhFilesList != null && !dwhFilesList.isEmpty()) {
       for (DwhFiles dwhFiles : dwhFilesList) {
-        parquetFilePaths.add(dwhFiles.getFilePattern(resourceType));
+        if (isView) {
+          parquetFilePaths.add(dwhFiles.getViewFilePattern(resourceTypeOrViewName));
+        } else {
+          parquetFilePaths.add(dwhFiles.getResourceFilePattern(resourceTypeOrViewName));
+        }
       }
     }
     return parquetFilePaths;
@@ -260,9 +264,19 @@ public class ParquetMerger {
     String dwh1 = options.getDwh1();
     String dwh2 = options.getDwh2();
     String mergedDwh = options.getMergedDwh();
-    DwhFiles dwhFiles1 = DwhFiles.forRoot(dwh1, avroConversionUtil.getFhirContext());
-    DwhFiles dwhFiles2 = DwhFiles.forRoot(dwh2, avroConversionUtil.getFhirContext());
-    DwhFiles mergedDwhFiles = DwhFiles.forRoot(mergedDwh, avroConversionUtil.getFhirContext());
+
+    // We are creating a new DWH, so we need a new view path under it. Instead of adding more flags
+    // for the location of view paths, we assume that they follow `DwhFiles` conventions. We also
+    // don't need to check if parquet view-generation is enabled because if it is not, we won't
+    // find any views in the two input DWHs.
+    String mergedDwhViewPath = DwhFiles.newViewsPath(mergedDwh).toString();
+    // We don't know the path of this merged view path outside ParquetMerger, hence we write the
+    // start timestamp file here.
+    DwhFiles.writeTimestampFile(mergedDwhViewPath.toString(), DwhFiles.TIMESTAMP_FILE_START);
+    DwhFiles dwhFiles1 = DwhFiles.forRootAndFindViewPath(dwh1, avroConversionUtil.getFhirContext());
+    DwhFiles dwhFiles2 = DwhFiles.forRootAndFindViewPath(dwh2, avroConversionUtil.getFhirContext());
+    DwhFiles mergedDwhFiles =
+        DwhFiles.forRoot(mergedDwh, mergedDwhViewPath, avroConversionUtil.getFhirContext());
 
     Set<String> resourceTypes1 = dwhFiles1.findNonEmptyResourceDirs();
     Set<String> resourceTypes2 = dwhFiles2.findNonEmptyResourceDirs();
@@ -281,10 +295,20 @@ public class ParquetMerger {
       }
       dwhViews1 = dwhFiles1.findNonEmptyViewDirs(viewManager);
       dwhViews2 = dwhFiles2.findNonEmptyViewDirs(viewManager);
-      copyDistinctResources(dwhViews1, dwhViews2, dwhFiles1, dwhFiles2, mergedDwhFiles);
+      copyDistinctResources(
+          dwhViews1,
+          dwhViews2,
+          dwhFiles1.getViewRoot().toString(),
+          dwhFiles2.getViewRoot().toString(),
+          mergedDwhFiles.getViewRoot().toString());
     }
 
-    copyDistinctResources(resourceTypes1, resourceTypes2, dwhFiles1, dwhFiles2, mergedDwhFiles);
+    copyDistinctResources(
+        resourceTypes1,
+        resourceTypes2,
+        dwhFiles1.getRoot(),
+        dwhFiles2.getRoot(),
+        mergedDwhFiles.getRoot());
     List<Pipeline> pipelines = new ArrayList<>();
     for (String type : resourceTypes1) {
       if (!resourceTypes2.contains(type)) {
@@ -353,8 +377,7 @@ public class ParquetMerger {
                         }
                       }))
               .setCoder(AvroCoder.of(schema));
-      writeToParquetSink(
-          options, merged, schema, mergedDwhFiles.getResourcePath(viewName).toString());
+      writeToParquetSink(options, merged, schema, mergedDwhFiles.getViewPath(viewName).toString());
     }
     return pipeline;
   }
@@ -414,13 +437,13 @@ public class ParquetMerger {
   }
 
   public static void copyDistinctResources(
-      Set<String> types1, Set<String> types2, DwhFiles dwh1, DwhFiles dwh2, DwhFiles mergedDwh)
+      Set<String> dirs1, Set<String> dirs2, String dwh1, String dwh2, String mergedDwh)
       throws IOException {
-    for (String type : Sets.difference(types1, types2)) {
-      dwh1.copyResourcesToDwh(type, mergedDwh);
+    for (String dir : Sets.difference(dirs1, dirs2)) {
+      DwhFiles.copyDirToDwh(dwh1, dir, mergedDwh);
     }
-    for (String type : Sets.difference(types2, types1)) {
-      dwh2.copyResourcesToDwh(type, mergedDwh);
+    for (String dir : Sets.difference(dirs2, dirs1)) {
+      DwhFiles.copyDirToDwh(dwh2, dir, mergedDwh);
     }
   }
 
@@ -456,8 +479,7 @@ public class ParquetMerger {
     }
 
     List<Pipeline> pipelines = createMergerPipelines(options, avroConversionUtil);
-    EtlUtils.runMultipleMergerPipelinesWithTimestamp(
-        pipelines, options, avroConversionUtil.getFhirContext());
+    EtlUtils.runMultipleMergerPipelinesWithTimestamp(pipelines, options);
     log.info("DONE!");
   }
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -273,8 +273,8 @@ public class ParquetMerger {
     // We don't know the path of this merged view path outside ParquetMerger, hence we write the
     // start timestamp file here.
     DwhFiles.writeTimestampFile(mergedDwhViewPath.toString(), DwhFiles.TIMESTAMP_FILE_START);
-    DwhFiles dwhFiles1 = DwhFiles.forRootAndFindViewPath(dwh1, avroConversionUtil.getFhirContext());
-    DwhFiles dwhFiles2 = DwhFiles.forRootAndFindViewPath(dwh2, avroConversionUtil.getFhirContext());
+    DwhFiles dwhFiles1 = DwhFiles.forRootWithLatestViewPath(dwh1, avroConversionUtil.getFhirContext());
+    DwhFiles dwhFiles2 = DwhFiles.forRootWithLatestViewPath(dwh2, avroConversionUtil.getFhirContext());
     DwhFiles mergedDwhFiles =
         DwhFiles.forRoot(mergedDwh, mergedDwhViewPath, avroConversionUtil.getFhirContext());
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -273,8 +273,10 @@ public class ParquetMerger {
     // We don't know the path of this merged view path outside ParquetMerger, hence we write the
     // start timestamp file here.
     DwhFiles.writeTimestampFile(mergedDwhViewPath.toString(), DwhFiles.TIMESTAMP_FILE_START);
-    DwhFiles dwhFiles1 = DwhFiles.forRootWithLatestViewPath(dwh1, avroConversionUtil.getFhirContext());
-    DwhFiles dwhFiles2 = DwhFiles.forRootWithLatestViewPath(dwh2, avroConversionUtil.getFhirContext());
+    DwhFiles dwhFiles1 =
+        DwhFiles.forRootWithLatestViewPath(dwh1, avroConversionUtil.getFhirContext());
+    DwhFiles dwhFiles2 =
+        DwhFiles.forRootWithLatestViewPath(dwh2, avroConversionUtil.getFhirContext());
     DwhFiles mergedDwhFiles =
         DwhFiles.forRoot(mergedDwh, mergedDwhViewPath, avroConversionUtil.getFhirContext());
 

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package com.google.fhir.analytics;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.DataFormatException;
-import com.google.api.client.util.Sets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.google.fhir.analytics.view.ViewManager;
 import java.io.BufferedReader;
 import java.io.File;
@@ -59,6 +59,16 @@ import org.slf4j.LoggerFactory;
 /**
  * The interface for working with the data-warehouse files. This is where all file-structure logic
  * should be implemented. This should support different file-systems, including distributed ones.
+ *
+ * The general structure of DWH files is as follows (note in some distributed file systems there
+ * is no notion of "directory", we just use the term to refer to segments between `/`):
+ * - Let's say the root path is DWH_ROOT.
+ * - Parquet files for each FHIR resource type, e.g., Patient, go under DWH_ROOT/Patient.
+ * - For a set of resource Parquet files, we may regenerate views multiple times (e.g., after
+ *   editing ViewDefinition files); each view set goes under a separate "dir" starting with VIEWS_,
+ *   e.g., for a view called `patient_flat` we may have DWH_ROOT/VIEWS_TIMESTAMP_1/patient_flat and
+ *   DWH_ROOT/VIEWS_TIMESTAMP_2/patient_flat.
+ * - For each incremental run, we create a new DWH_ROOT/incremental_run_TIMESTAMP "dir".
  */
 public class DwhFiles {
 
@@ -71,7 +81,9 @@ public class DwhFiles {
   public static final String TIMESTAMP_FILE_BULK_TRANSACTION_TIME =
       "timestamp_bulk_transaction_time.txt";
 
-  private static final String INCREMENTAL_DIR = "incremental_run";
+  private static final String VIEW_DIR_PREFIX = "VIEWS";
+
+  private static final String INCREMENTAL_DIR_PREFIX = "incremental_run";
 
   static final String TIMESTAMP_PREFIX = "_TIMESTAMP_";
 
@@ -86,6 +98,8 @@ public class DwhFiles {
   private final String dwhRoot;
 
   private final FhirContext fhirContext;
+
+  private final String viewRoot;
 
   /**
    * In order to interpret the file paths correctly the {@code dwhRoot} has to be represented in one
@@ -111,17 +125,37 @@ public class DwhFiles {
    *   <li>gs://TestBucket/TestRoot/SamplePrefix
    * </ul>
    *
-   * @param dwhRoot
+   * @param dwhRoot the root of the DWH
+   * @param viewRoot the root of the view dir under DWH; note this should be an absolute path, but
+   *     it is usually "under" `dwhRoot`.
    * @param fhirContext
    */
-  DwhFiles(String dwhRoot, FhirContext fhirContext) {
+  private DwhFiles(String dwhRoot, String viewRoot, FhirContext fhirContext) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(dwhRoot));
     this.dwhRoot = dwhRoot;
     this.fhirContext = fhirContext;
+    if (Strings.isNullOrEmpty(viewRoot)) {
+      // If viewRoot is not provided, we create a new one; with this we make sure that a sane
+      // value is set for this.viewRoot; this makes the logic of this class simpler.
+      this.viewRoot = newTimestampedPath(dwhRoot, VIEW_DIR_PREFIX).toString();
+    } else {
+      this.viewRoot = viewRoot;
+    }
   }
 
   static DwhFiles forRoot(String dwhRoot, FhirContext fhirContext) {
-    return new DwhFiles(dwhRoot, fhirContext);
+    return forRoot(dwhRoot, null, fhirContext);
+  }
+
+  static DwhFiles forRoot(String dwhRoot, String viewRoot, FhirContext fhirContext) {
+    return new DwhFiles(dwhRoot, viewRoot, fhirContext);
+  }
+
+  static DwhFiles forRootAndFindViewPath(String dwhRoot, FhirContext fhirContext)
+      throws IOException {
+    ResourceId latestViewPath = DwhFiles.getLatestViewsPath(dwhRoot);
+    String lastViewPath = latestViewPath == null ? null : latestViewPath.toString();
+    return new DwhFiles(dwhRoot, lastViewPath, fhirContext);
   }
 
   public static String safeTimestampSuffix() {
@@ -130,6 +164,10 @@ public class DwhFiles {
 
   public String getRoot() {
     return dwhRoot;
+  }
+
+  public String getViewRoot() {
+    return viewRoot;
   }
 
   /**
@@ -144,12 +182,36 @@ public class DwhFiles {
   }
 
   /**
+   * Similar to `getResourcePath` but returns the path for the given view. It is important to use
+   * this version for views because there might be multiple view "dirs" under the same DWH root.
+   *
+   * @param viewName the name of the view
+   * @return the path to the view dir
+   */
+  public ResourceId getViewPath(String viewName) {
+    // Note we cannot assume any view "dir" or even the DWH root already exists; also note the
+    // concept of "directory" is not well-defined on some cloud file-systems.
+    return FileSystems.matchNewResource(viewRoot, true)
+        .resolve(viewName, StandardResolveOptions.RESOLVE_DIRECTORY);
+  }
+
+  /**
    * @param resourceType the type of the FHIR resources
    * @return The file pattern for Parquet files of `resourceType` in this DWH.
    */
-  public String getFilePattern(String resourceType) {
+  public String getResourceFilePattern(String resourceType) {
     return String.format(
         "%s*%s", getResourcePath(resourceType).toString(), ParquetUtil.PARQUET_EXTENSION);
+  }
+
+  /**
+   * Similar to getResourceFilePattern but for views.
+   *
+   * @param viewName the name of the view (should match that in the ViewDefinition)
+   * @return The file pattern for Parquet files of `viewName` in this DWH.
+   */
+  public String getViewFilePattern(String viewName) {
+    return String.format("%s*%s", getViewPath(viewName).toString(), ParquetUtil.PARQUET_EXTENSION);
   }
 
   // TODO: Move this to a util class and make it non-static.
@@ -166,6 +228,21 @@ public class DwhFiles {
    * @throws IOException
    */
   static Set<ResourceId> getAllChildDirectories(String baseDir) throws IOException {
+    return getAllChildDirectories(baseDir, "");
+  }
+
+  /**
+   * Similar to the version with no `commonPrefix` with the difference that returns only directory
+   * names that start with {baseDir}/{commonPrefix}*. This is more efficient and should be preferred
+   * when there is a known common-prefix we are looking for.
+   *
+   * @param baseDir the baseDir of the DWH
+   * @param commonPrefix the prefix of directories under `baseDir` that we are looking for
+   * @return the list of found directory names.
+   * @throws IOException
+   */
+  static Set<ResourceId> getAllChildDirectories(String baseDir, String commonPrefix)
+      throws IOException {
     String fileSeparator = getFileSeparatorForDwhFiles(baseDir);
     // Avoid using ResourceId.resolve(..) method to resolve the files when the path contains glob
     // expressions with multiple special characters like **, */* etc as this api only supports
@@ -174,10 +251,11 @@ public class DwhFiles {
     List<MatchResult> matchResultList =
         FileSystems.match(
             List.of(
-                getPathEndingWithFileSeparator(baseDir, fileSeparator)
-                    + "*"
-                    + fileSeparator
-                    + "*"));
+                String.format(
+                    "%s%s*%s*",
+                    getPathEndingWithFileSeparator(baseDir, fileSeparator),
+                    commonPrefix,
+                    fileSeparator)));
     Set<ResourceId> childDirectories = new HashSet<>();
     for (MatchResult matchResult : matchResultList) {
       if (matchResult.status() == Status.OK && !matchResult.metadata().isEmpty()) {
@@ -195,20 +273,35 @@ public class DwhFiles {
   }
 
   /**
-   * Also see {@link #newIncrementalRunPath()}
+   * This function and {@link #newTimestampedPath(String, String)} complement each other.
    *
-   * @return the current incremental run path if one found; null otherwise.
+   * @param commonPrefix the common prefix for the timestamped directories to search.
+   * @return the latest directory with the `commonPrefix`.
+   * @throws IOException
    */
   @Nullable
-  public ResourceId getLatestIncrementalRunPath() throws IOException {
-    List<ResourceId> dirs =
-        getAllChildDirectories(getRoot()).stream()
-            .filter(dir -> dir.getFilename().contains(INCREMENTAL_DIR + TIMESTAMP_PREFIX))
-            .collect(Collectors.toList());
+  private static ResourceId getLatestPath(String dwhRoot, String commonPrefix) throws IOException {
+    List<ResourceId> dirs = new ArrayList<>();
+    dirs.addAll(getAllChildDirectories(dwhRoot, commonPrefix));
     if (dirs.isEmpty()) return null;
 
     Collections.sort(dirs, Comparator.comparing(ResourceId::toString));
     return dirs.get(dirs.size() - 1);
+  }
+
+  private static ResourceId newTimestampedPath(String dwhRoot, String commonPrefix) {
+    return FileSystems.matchNewResource(dwhRoot, true)
+        .resolve(
+            String.format("%s%s%s", commonPrefix, TIMESTAMP_PREFIX, safeTimestampSuffix()),
+            StandardResolveOptions.RESOLVE_DIRECTORY);
+  }
+
+  /**
+   * @return the current incremental run path if one found; null otherwise.
+   */
+  @Nullable
+  public static ResourceId getLatestIncrementalRunPath(String dwhRoot) throws IOException {
+    return getLatestPath(dwhRoot, INCREMENTAL_DIR_PREFIX);
   }
 
   /**
@@ -218,10 +311,29 @@ public class DwhFiles {
    * @return a new incremental run path based on the current timestamp.
    */
   public ResourceId newIncrementalRunPath() {
-    return FileSystems.matchNewResource(getRoot(), true)
-        .resolve(
-            String.format("%s%s%s", INCREMENTAL_DIR, TIMESTAMP_PREFIX, safeTimestampSuffix()),
-            StandardResolveOptions.RESOLVE_DIRECTORY);
+    return newTimestampedPath(getRoot(), INCREMENTAL_DIR_PREFIX);
+  }
+
+  /**
+   * Similar to {@link #getLatestIncrementalRunPath(String)} but for views sub-dir.
+   *
+   * @return the current views path if one found; null otherwise.
+   */
+  @Nullable
+  public static ResourceId getLatestViewsPath(String dwhRoot) throws IOException {
+    return getLatestPath(dwhRoot, VIEW_DIR_PREFIX);
+  }
+
+  /**
+   * This returns a new views sud-dir path based on the current timestamp. Note that views are
+   * generated from main FHIR resources, hence we put this view directory under the DWH root; there
+   * might be multiple views sets under the same DWH root (e.g., when we regenerate).
+   *
+   * @param dwhRoot the given root of DWH.
+   * @return the path to the view sub-dir under `dwhRoot` to be used for a new run.
+   */
+  public static ResourceId newViewsPath(String dwhRoot) {
+    return newTimestampedPath(dwhRoot, VIEW_DIR_PREFIX);
   }
 
   public Set<String> findNonEmptyResourceDirs() throws IOException {
@@ -233,8 +345,7 @@ public class DwhFiles {
   }
 
   /**
-   * This method returns the list of non-empty directories which contains at least one file under
-   * it.
+   * Returns the list of non-empty directories which contains at least one file under it.
    *
    * @param viewManager Used to verify if non-empty directory is a valid View Definition. If null,
    *     the views returned will be valid FHIR Resource Types. Otherwise, the views will be valid
@@ -247,11 +358,12 @@ public class DwhFiles {
     //  response. This issue https://github.com/google/fhir-data-pipes/issues/288 helps in
     //  maintaining the number of file to an optimum value.
     String fileType = viewManager == null ? "Resource types" : "Views";
-    String fileSeparator = getFileSeparatorForDwhFiles(dwhRoot);
+    String searchRoot = viewManager == null ? dwhRoot : viewRoot;
+    String fileSeparator = getFileSeparatorForDwhFiles(searchRoot);
     List<MatchResult> matchedChildResultList =
         FileSystems.match(
             List.of(
-                getPathEndingWithFileSeparator(dwhRoot, fileSeparator)
+                getPathEndingWithFileSeparator(searchRoot, fileSeparator)
                     + "*"
                     + fileSeparator
                     + "*"));
@@ -262,8 +374,8 @@ public class DwhFiles {
           fileSet.add(metadata.resourceId().getCurrentDirectory().getFilename());
         }
       } else if (matchResult.status() == Status.ERROR) {
-        log.error("Error matching {} under {} ", fileType, dwhRoot);
-        throw new IOException(String.format("Error matching %s under %s", fileType, dwhRoot));
+        log.error("Error matching {} under {} ", fileType, searchRoot);
+        throw new IOException(String.format("Error matching %s under %s", fileType, searchRoot));
       }
     }
 
@@ -282,7 +394,7 @@ public class DwhFiles {
         }
       }
     }
-    log.info("{} under {} are {}", fileType, dwhRoot, typeSet);
+    log.info("{} under {} are {}", fileType, searchRoot, typeSet);
     return typeSet;
   }
 
@@ -290,16 +402,18 @@ public class DwhFiles {
    * This method copies all the files under the directory (getRoot() + resourceType) into the
    * destination DwhFiles under the similar directory.
    *
-   * @param resourceType The resource or view directory to be copied
-   * @param destDwh The output Dwh to copy files to
+   * @param srcDwh the source DWH to copy files from
+   * @param dirName the resource or view "directory" (under `srcDwh`) to be copied
+   * @param destDwh the output DWH to copy files to
    */
-  public void copyResourcesToDwh(String resourceType, DwhFiles destDwh) throws IOException {
-    String fileSeparator = getFileSeparatorForDwhFiles(dwhRoot);
+  public static void copyDirToDwh(String srcDwh, String dirName, String destDwh)
+      throws IOException {
+    String fileSeparator = getFileSeparatorForDwhFiles(srcDwh);
     List<MatchResult> sourceMatchResultList =
         FileSystems.match(
             List.of(
-                getPathEndingWithFileSeparator(dwhRoot, fileSeparator)
-                    + resourceType
+                getPathEndingWithFileSeparator(srcDwh, fileSeparator)
+                    + dirName
                     + fileSeparator
                     + "*"));
     List<ResourceId> sourceResourceIdList = new ArrayList<>();
@@ -322,21 +436,22 @@ public class DwhFiles {
         .forEach(
             resourceId -> {
               ResourceId destResourceId =
-                  FileSystems.matchNewResource(destDwh.getRoot(), true)
-                      .resolve(resourceType, StandardResolveOptions.RESOLVE_DIRECTORY)
+                  FileSystems.matchNewResource(destDwh, true)
+                      .resolve(dirName, StandardResolveOptions.RESOLVE_DIRECTORY)
                       .resolve(resourceId.getFilename(), StandardResolveOptions.RESOLVE_FILE);
               destResourceIdList.add(destResourceId);
             });
     FileSystems.copy(sourceResourceIdList, destResourceIdList);
   }
 
-  public void writeTimestampFile(String fileName) throws IOException {
-    writeTimestampFile(Instant.now(), fileName);
+  public static void writeTimestampFile(String dwhRoot, String fileName) throws IOException {
+    writeTimestampFile(dwhRoot, Instant.now(), fileName);
   }
 
-  public void writeTimestampFile(Instant instant, String fileName) throws IOException {
+  public static void writeTimestampFile(String dwhRoot, Instant instant, String fileName)
+      throws IOException {
     ResourceId resourceId =
-        FileSystems.matchNewResource(getRoot(), true)
+        FileSystems.matchNewResource(dwhRoot, true)
             .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
     List<MatchResult> matches = FileSystems.matchResources(Collections.singletonList(resourceId));
     MatchResult matchResult = Iterables.getOnlyElement(matches);
@@ -345,7 +460,7 @@ public class DwhFiles {
       String errorMessage =
           String.format(
               "Attempting to write to the timestamp file %s which already exists",
-              getRoot() + "/" + fileName);
+              dwhRoot + "/" + fileName);
       log.error(errorMessage);
       throw new FileAlreadyExistsException(errorMessage);
     } else if (matchResult.status() == Status.NOT_FOUND) {
@@ -357,15 +472,19 @@ public class DwhFiles {
       String errorMessage =
           String.format(
               "Error matching file spec %s: status %s",
-              getRoot() + "/" + fileName, matchResult.status());
+              dwhRoot + "/" + fileName, matchResult.status());
       log.error(errorMessage);
       throw new IOException(errorMessage);
     }
   }
 
   public Instant readTimestampFile(String fileName) throws IOException {
+    return readTimestampFile(getRoot(), fileName);
+  }
+
+  public static Instant readTimestampFile(String dwhRoot, String fileName) throws IOException {
     ResourceId resourceId =
-        FileSystems.matchNewResource(getRoot(), true)
+        FileSystems.matchNewResource(dwhRoot, true)
             .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
     List<String> result = new ArrayList<>();
     ReadableByteChannel channel = FileSystems.open(resourceId);
@@ -379,7 +498,7 @@ public class DwhFiles {
     }
     if (result.isEmpty()) {
       String errorMessage =
-          String.format("The timestamp file %s is empty", getRoot() + "/" + fileName);
+          String.format("The timestamp file %s is empty", dwhRoot + "/" + fileName);
       log.error(errorMessage);
       throw new IllegalStateException(errorMessage);
     }
@@ -387,9 +506,9 @@ public class DwhFiles {
   }
 
   /** Checks if the given file exists in the data-warehouse at the root location */
-  public boolean doesTimestampFileExist(String fileName) throws IOException {
+  public static boolean doesTimestampFileExist(String dwhRoot, String fileName) throws IOException {
     ResourceId resourceId =
-        FileSystems.matchNewResource(getRoot(), true)
+        FileSystems.matchNewResource(dwhRoot, true)
             .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
     List<MatchResult> matchResultList =
         FileSystems.matchResources(Collections.singletonList(resourceId));
@@ -406,9 +525,10 @@ public class DwhFiles {
     }
   }
 
-  public void overwriteFile(String fileName, byte[] content) throws IOException {
+  public static void overwriteFile(String dwhRoot, String fileName, byte[] content)
+      throws IOException {
     ResourceId resourceId =
-        FileSystems.matchNewResource(getRoot(), true)
+        FileSystems.matchNewResource(dwhRoot, true)
             .resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
 
     List<MatchResult> matches = FileSystems.matchResources(Collections.singletonList(resourceId));
@@ -416,7 +536,7 @@ public class DwhFiles {
 
     if (matchResult.status() == Status.OK) {
       String warnMessage =
-          String.format("Overwriting the existing file %s", getRoot() + "/" + fileName);
+          String.format("Overwriting the existing file %s", dwhRoot + "/" + fileName);
       log.warn(warnMessage);
       FileSystems.delete(List.of(resourceId));
     }
@@ -429,7 +549,7 @@ public class DwhFiles {
       String errorMessage =
           String.format(
               "Error matching file spec %s: status %s",
-              getRoot() + "/" + fileName, matchResult.status());
+              dwhRoot + "/" + fileName, matchResult.status());
       log.error(errorMessage);
       throw new IOException(errorMessage);
     }

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -151,7 +151,7 @@ public class DwhFiles {
     return new DwhFiles(dwhRoot, viewRoot, fhirContext);
   }
 
-  static DwhFiles forRootAndFindViewPath(String dwhRoot, FhirContext fhirContext)
+  static DwhFiles forRootWithLatestViewPath(String dwhRoot, FhirContext fhirContext)
       throws IOException {
     ResourceId latestViewPath = DwhFiles.getLatestViewsPath(dwhRoot);
     String lastViewPath = latestViewPath == null ? null : latestViewPath.toString();

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/DwhFiles.java
@@ -60,15 +60,14 @@ import org.slf4j.LoggerFactory;
  * The interface for working with the data-warehouse files. This is where all file-structure logic
  * should be implemented. This should support different file-systems, including distributed ones.
  *
- * The general structure of DWH files is as follows (note in some distributed file systems there
- * is no notion of "directory", we just use the term to refer to segments between `/`):
- * - Let's say the root path is DWH_ROOT.
- * - Parquet files for each FHIR resource type, e.g., Patient, go under DWH_ROOT/Patient.
- * - For a set of resource Parquet files, we may regenerate views multiple times (e.g., after
- *   editing ViewDefinition files); each view set goes under a separate "dir" starting with VIEWS_,
- *   e.g., for a view called `patient_flat` we may have DWH_ROOT/VIEWS_TIMESTAMP_1/patient_flat and
- *   DWH_ROOT/VIEWS_TIMESTAMP_2/patient_flat.
- * - For each incremental run, we create a new DWH_ROOT/incremental_run_TIMESTAMP "dir".
+ * <p>The general structure of DWH files is as follows (note in some distributed file systems there
+ * is no notion of "directory", we just use the term to refer to segments between `/`): - Let's say
+ * the root path is DWH_ROOT. - Parquet files for each FHIR resource type, e.g., Patient, go under
+ * DWH_ROOT/Patient. - For a set of resource Parquet files, we may regenerate views multiple times
+ * (e.g., after editing ViewDefinition files); each view set goes under a separate "dir" starting
+ * with VIEWS_, e.g., for a view called `patient_flat` we may have
+ * DWH_ROOT/VIEWS_TIMESTAMP_1/patient_flat and DWH_ROOT/VIEWS_TIMESTAMP_2/patient_flat. - For each
+ * incremental run, we create a new DWH_ROOT/incremental_run_TIMESTAMP "dir".
  */
 public class DwhFiles {
 

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/ParquetUtil.java
@@ -264,7 +264,7 @@ public class ParquetUtil {
       String resourceType = resource.fhirType();
       WriterWithCache writer = writerMap.get(resourceType);
       if (writer == null) {
-        createWriter(resourceType, null);
+        writer = createWriter(resourceType, null);
       }
       GenericRecord record = conversionUtil.convertToAvro(resource);
       if (record != null) {
@@ -314,7 +314,7 @@ public class ParquetUtil {
     WriterWithCache writer = viewWriterMap.get(viewName);
     if (writer != null && writer.getDataSize() > 0) {
       writer.close();
-      writerMap.put(viewName, null);
+      viewWriterMap.put(viewName, null);
     }
   }
 

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/view/ViewSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,6 +289,14 @@ public class ViewSchema {
               "uri",
               "url",
               "uuid" -> schemaFields.optionalString(colName);
+          default -> {
+            log.error(
+                "Unknown type {} for column {} of ViewDefinition {}; using string!",
+                columnType,
+                colName,
+                view.getName());
+            schemaFields.optionalString(colName);
+          }
         }
       } else {
         if (entry.getValue().isCollection()) {

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/GcsDwhFilesTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/GcsDwhFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,14 +79,16 @@ public class GcsDwhFilesTest {
 
   @Test
   public void getResourcePathTest() {
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
+    DwhFiles dwhFiles =
+        DwhFiles.forRoot("gs://testbucket/testdirectory", FhirContext.forR4Cached());
     ResourceId resourceId = dwhFiles.getResourcePath("Patient");
     assertThat(resourceId.toString(), equalTo("gs://testbucket/testdirectory/Patient/"));
   }
 
   @Test
   public void newIncrementalRunPathTest() throws IOException {
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
+    DwhFiles dwhFiles =
+        DwhFiles.forRoot("gs://testbucket/testdirectory", FhirContext.forR4Cached());
 
     List<StorageObjectOrIOException> items = new ArrayList<>();
     items.add(StorageObjectOrIOException.create(new FileNotFoundException()));
@@ -116,7 +118,8 @@ public class GcsDwhFilesTest {
                 Mockito.eq("testbucket"), Mockito.anyString(), Mockito.isNull(String.class)))
         .thenReturn(modelObjects);
 
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
+    DwhFiles dwhFiles =
+        DwhFiles.forRoot("gs://testbucket/testdirectory", FhirContext.forR4Cached());
     Set<String> resourceTypes = dwhFiles.findNonEmptyResourceDirs();
     assertThat("Could not find Patient", resourceTypes.contains("Patient"));
     assertThat("Could not find Observation", resourceTypes.contains("Observation"));
@@ -132,7 +135,8 @@ public class GcsDwhFilesTest {
                 Mockito.eq("testbucket"), Mockito.anyString(), Mockito.isNull(String.class)))
         .thenReturn(modelObjects);
 
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
+    DwhFiles dwhFiles =
+        DwhFiles.forRoot("gs://testbucket/testdirectory", FhirContext.forR4Cached());
     Set<String> resourceTypes = dwhFiles.findNonEmptyResourceDirs();
     assertThat(resourceTypes.size(), equalTo(0));
   }
@@ -141,9 +145,9 @@ public class GcsDwhFilesTest {
   public void copyResourceTypeTest() throws IOException {
 
     DwhFiles sourceDwhFiles =
-        new DwhFiles("gs://testbucket/source-test-directory", FhirContext.forR4Cached());
+        DwhFiles.forRoot("gs://testbucket/source-test-directory", FhirContext.forR4Cached());
     DwhFiles destDwhFiles =
-        new DwhFiles("gs://testbucket/dest-test-directory", FhirContext.forR4Cached());
+        DwhFiles.forRoot("gs://testbucket/dest-test-directory", FhirContext.forR4Cached());
     Objects modelObjects = new Objects();
     List<StorageObject> items = new ArrayList<>();
     // Files within the directory
@@ -156,7 +160,7 @@ public class GcsDwhFilesTest {
             mockGcsUtil.listObjects(
                 Mockito.eq("testbucket"), Mockito.anyString(), Mockito.isNull(String.class)))
         .thenReturn(modelObjects);
-    sourceDwhFiles.copyResourcesToDwh("Patient", destDwhFiles);
+    DwhFiles.copyDirToDwh(sourceDwhFiles.getRoot(), "Patient", destDwhFiles.getRoot());
 
     Mockito.verify(mockGcsUtil, Mockito.times(1))
         .copy(
@@ -175,10 +179,11 @@ public class GcsDwhFilesTest {
         StorageObjectOrIOException.create(createStorageObject(gcsFileName, 1L /* fileSize */)));
     Mockito.when(mockGcsUtil.getObjects(List.of(GcsPath.fromUri(gcsFileName)))).thenReturn(items);
 
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
     Assertions.assertThrows(
         FileAlreadyExistsException.class,
-        () -> dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START));
+        () ->
+            DwhFiles.writeTimestampFile(
+                "gs://testbucket/testdirectory", DwhFiles.TIMESTAMP_FILE_START));
   }
 
   @Test
@@ -196,8 +201,7 @@ public class GcsDwhFilesTest {
                 CreateOptions.builder().setContentType(MimeTypes.BINARY).build()))
         .thenReturn(writableByteChannel);
 
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
-    dwhFiles.writeTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
+    DwhFiles.writeTimestampFile("gs://testbucket/testdirectory", DwhFiles.TIMESTAMP_FILE_START);
 
     Mockito.verify(mockGcsUtil, Mockito.times(1)).getObjects(List.of(GcsPath.fromUri(gcsFileName)));
     Mockito.verify(mockGcsUtil, Mockito.times(1))
@@ -212,8 +216,8 @@ public class GcsDwhFilesTest {
     Instant currentInstant = Instant.now();
     mockFileRead(gcsFileName, currentInstant);
 
-    DwhFiles dwhFiles = new DwhFiles("gs://testbucket/testdirectory", FhirContext.forR4Cached());
-    Instant actualInstant = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_START);
+    Instant actualInstant =
+        DwhFiles.readTimestampFile("gs://testbucket/testdirectory", DwhFiles.TIMESTAMP_FILE_START);
 
     Assertions.assertEquals(currentInstant.getEpochSecond(), actualInstant.getEpochSecond());
     Mockito.verify(mockGcsUtil, Mockito.times(1)).open(GcsPath.fromUri(gcsFileName));

--- a/pipelines/controller/config/application.yaml
+++ b/pipelines/controller/config/application.yaml
@@ -110,7 +110,9 @@ fhirdata:
   # number of cores in the machine, whereas in the remote mode (cluster) only 1 thread is used.
   # If set to a positive value, then in both the modes the pipeline uses these many threads combined
   # across all the workers.
-  numThreads: -1
+  # numThreads: -1
+  # For test purposes in the dev env. we set number of threads to one.
+  numThreads: 1
 
   # In case of Flink local execution mode (which is the default currently), generate Flink
   # configuration file `flink-conf.yaml` automatically based on the parallelism set via the
@@ -167,6 +169,9 @@ fhirdata:
   # `.json` is assumed to be a single ViewDefinition. To output these views to a
   # relational database, the next sinkDbConfigPath should also be set.
   viewDefinitionsDir: "config/views"
+
+  # Whether to generate Parquet materialized views or not.
+  createParquetViews: true
 
   # The configuration file for the sink database. If `viewDefinitionsDir` is set
   # then the generated views are materialized and written to this DB. If not,

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/DataProperties.java
@@ -167,6 +167,9 @@ public class DataProperties {
         dwhRoot);
     options.setFhirFetchMode(FhirFetchMode.PARQUET);
     options.setParquetInputDwhRoot(dwhRoot);
+    if (createParquetViews) {
+      options.setOutputParquetViewPath(DwhFiles.newViewsPath(dwhRoot).toString());
+    }
     options.setViewDefinitionsDir(viewDefinitionsDir);
     options.setSinkDbConfigPath(sinkDbConfigPath);
     options.setRecreateSinkTables(true);
@@ -198,7 +201,6 @@ public class DataProperties {
     if (resourceList != null) {
       options.setResourceList(resourceList);
     }
-    options.setCreateParquetViews(createParquetViews);
     options.setViewDefinitionsDir(Strings.nullToEmpty(viewDefinitionsDir));
     options.setSinkDbConfigPath(Strings.nullToEmpty(sinkDbConfigPath));
     options.setStructureDefinitionsPath(Strings.nullToEmpty(structureDefinitionsPath));
@@ -216,9 +218,14 @@ public class DataProperties {
 
     // Using underscore for suffix as hyphens are discouraged in hive table names.
     String timestampSuffix = DwhFiles.safeTimestampSuffix();
-    options.setOutputParquetPath(dwhRootPrefix + DwhFiles.TIMESTAMP_PREFIX + timestampSuffix);
+    String newDwhRoot = dwhRootPrefix + DwhFiles.TIMESTAMP_PREFIX + timestampSuffix;
+    options.setOutputParquetPath(newDwhRoot);
 
     options.setGenerateParquetFiles(generateParquetFiles);
+
+    if (createParquetViews) {
+      options.setOutputParquetViewPath(DwhFiles.newViewsPath(newDwhRoot).toString());
+    }
 
     PipelineConfig.PipelineConfigBuilder pipelineConfigBuilder = addFlinkOptions(options);
 

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -239,7 +239,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         String currentDwhRoot = resourceId.toString();
         // TODO: If there are errors from the last VIEW run, expose them in the UI.
         currentDwh =
-            DwhFiles.forRootAndFindViewPath(currentDwhRoot, avroConversionUtil.getFhirContext());
+            DwhFiles.forRootWithLatestViewPath(currentDwhRoot, avroConversionUtil.getFhirContext());
         // There exists a DWH from before, so we set the scheduler to continue updating the DWH.
         lastRunEnd = LocalDateTime.now();
       } catch (IOException e) {
@@ -615,7 +615,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
   }
 
   private synchronized void updateDwh(String newRoot) throws IOException {
-    currentDwh = DwhFiles.forRootAndFindViewPath(newRoot, avroConversionUtil.getFhirContext());
+    currentDwh = DwhFiles.forRootWithLatestViewPath(newRoot, avroConversionUtil.getFhirContext());
   }
 
   private static class PipelineThread extends Thread {

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Google LLC
+ * Copyright 2020-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,12 +232,20 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
       lastRunEnd = null;
     } else {
       logger.info("Initializing with most recent DWH {}", lastCompletedDwh);
-      ResourceId resourceId =
-          FileSystems.matchNewResource(baseDir, true)
-              .resolve(lastCompletedDwh, StandardResolveOptions.RESOLVE_DIRECTORY);
-      currentDwh = DwhFiles.forRoot(resourceId.toString(), avroConversionUtil.getFhirContext());
-      // There exists a DWH from before, so we set the scheduler to continue updating the DWH.
-      lastRunEnd = LocalDateTime.now();
+      try {
+        ResourceId resourceId =
+            FileSystems.matchNewResource(baseDir, true)
+                .resolve(lastCompletedDwh, StandardResolveOptions.RESOLVE_DIRECTORY);
+        String currentDwhRoot = resourceId.toString();
+        // TODO: If there are errors from the last VIEW run, expose them in the UI.
+        currentDwh =
+            DwhFiles.forRootAndFindViewPath(currentDwhRoot, avroConversionUtil.getFhirContext());
+        // There exists a DWH from before, so we set the scheduler to continue updating the DWH.
+        lastRunEnd = LocalDateTime.now();
+      } catch (IOException e) {
+        logger.error("IOException while initializing DWH: ", e);
+        throw new RuntimeException(e);
+      }
     }
     if (!lastDwh.isEmpty()) {
       initialiseLastRunDetails(baseDir, lastDwh);
@@ -267,9 +275,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
       ResourceId dwhDirectoryPath =
           FileSystems.matchNewResource(baseDir, true)
               .resolve(dwhDirectory, StandardResolveOptions.RESOLVE_DIRECTORY);
-      DwhFiles dwhFiles =
-          DwhFiles.forRoot(dwhDirectoryPath.toString(), avroConversionUtil.getFhirContext());
-      ResourceId incPath = dwhFiles.getLatestIncrementalRunPath();
+      ResourceId incPath = DwhFiles.getLatestIncrementalRunPath(dwhDirectoryPath.toString());
       if (incPath != null) {
         updateLastRunDetails(incPath);
         return;
@@ -433,6 +439,10 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     String finalDwhRoot = options.getOutputParquetPath();
     String incrementalDwhRoot = currentDwh.newIncrementalRunPath().toString();
     options.setOutputParquetPath(incrementalDwhRoot);
+    String incrementalViewPath = DwhFiles.newViewsPath(incrementalDwhRoot).toString();
+    if (dataProperties.isCreateParquetViews()) {
+      options.setOutputParquetViewPath(incrementalViewPath);
+    }
     String since = fetchSinceTimestamp(options);
     options.setSince(since);
     FlinkPipelineOptions flinkOptionsForBatch = options.as(FlinkPipelineOptions.class);
@@ -604,8 +614,8 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     return hiveTableManager;
   }
 
-  private synchronized void updateDwh(String newRoot) throws ProfileException {
-    currentDwh = DwhFiles.forRoot(newRoot, avroConversionUtil.getFhirContext());
+  private synchronized void updateDwh(String newRoot) throws IOException {
+    currentDwh = DwhFiles.forRootAndFindViewPath(newRoot, avroConversionUtil.getFhirContext());
   }
 
   private static class PipelineThread extends Thread {
@@ -693,7 +703,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
         }
 
         List<PipelineResult> pipelineResults =
-            EtlUtils.runMultiplePipelinesWithTimestamp(pipelines, options, fhirContext);
+            EtlUtils.runMultiplePipelinesWithTimestamp(pipelines, options);
         // Remove the metrics of the previous pipeline and register the new metrics
         manager.removePipelineMetrics();
         pipelineResults.stream()
@@ -711,8 +721,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
               ParquetMerger.createMergerPipelines(mergerOptions, avroConversionUtil);
           logger.info("Merger options are {}", mergerOptions);
           List<PipelineResult> mergerPipelineResults =
-              EtlUtils.runMultipleMergerPipelinesWithTimestamp(
-                  mergerPipelines, mergerOptions, fhirContext);
+              EtlUtils.runMultipleMergerPipelinesWithTimestamp(mergerPipelines, mergerOptions);
           mergerPipelineResults.stream()
               .forEach(pipelineResult -> manager.publishPipelineMetrics(pipelineResult.metrics()));
           manager.updateDwh(currentDwhRoot);
@@ -760,8 +769,8 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     try {
       if (!Strings.isNullOrEmpty(dwhRoot)) {
         String stackTrace = ExceptionUtils.getStackTrace(e);
-        DwhFiles.forRoot(dwhRoot, fhirContext)
-            .overwriteFile(ERROR_FILE_NAME, stackTrace.getBytes(StandardCharsets.UTF_8));
+        DwhFiles.overwriteFile(
+            dwhRoot, ERROR_FILE_NAME, stackTrace.getBytes(StandardCharsets.UTF_8));
       }
     } catch (IOException ex) {
       logger.error("Error while capturing error to a file", ex);
@@ -772,11 +781,12 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
   void setLastRunDetails(String dwhRoot, String status) {
     DwhRunDetails dwhRunDetails = new DwhRunDetails();
     try {
-      DwhFiles dwhFiles = DwhFiles.forRoot(dwhRoot, avroConversionUtil.getFhirContext());
-      String startTime = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_START).toString();
+      String startTime =
+          DwhFiles.readTimestampFile(dwhRoot, DwhFiles.TIMESTAMP_FILE_START).toString();
       dwhRunDetails.setStartTime(startTime);
       if (!Strings.isNullOrEmpty(status) && status.equalsIgnoreCase(SUCCESS)) {
-        String endTime = dwhFiles.readTimestampFile(DwhFiles.TIMESTAMP_FILE_END).toString();
+        String endTime =
+            DwhFiles.readTimestampFile(dwhRoot, DwhFiles.TIMESTAMP_FILE_END).toString();
         dwhRunDetails.setEndTime(endTime);
       } else {
         String fileSeparator = DwhFiles.getFileSeparatorForDwhFiles(dwhRoot);


### PR DESCRIPTION
## Description of what I changed

Fixes #1334.
The fix is actually a little involved because we need to be able to support multiple view-sets for the same
set of FHIR resource Parquet files. So the idea is that if the use makes changes in a ViewDefinition and
try "Regenarate Views" we should create fresh set of views (instead of trying to overwrite old ones).
See the `DwhFiles` class description for the changes in the data-warehouse file structure.

This also fixes an issue in the `patient_flat` ViewDefinition; this change actually led to the discovery of bug #1334 and #1335.

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Beside new unit-tests, ran the controller docker image locally and tested various scenarios, e.g.,
- "Regenarate Views" with parquet views.
- Add new resources and "Run Incremental" then check the merged views.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
