### PR TITLE
Configure the Spotless plugin for project submodules

### DIFF
--- a/bunsen/pom.xml
+++ b/bunsen/pom.xml
@@ -187,12 +187,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-
     </plugins>
 
     <pluginManagement>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -377,10 +377,6 @@
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -71,88 +71,6 @@
             </execution>
           </executions>
         </plugin>
-
-        <!-- Code formatter -->
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.46.1</version>
-          <configuration>
-            <pom>
-              <sortPom>
-                <expandEmptyElements>false</expandEmptyElements>
-              </sortPom>
-              <trimTrailingWhitespace/>
-              <endWithNewline/>
-              <indent>
-                <spaces>true</spaces>
-              </indent>
-            </pom>
-            <formats>
-              <!-- you can define as many formats as you want, each is independent -->
-              <format>
-                <!-- define the files to apply to -->
-                <includes>
-                  <include>**/*.sh</include>
-                  <include>**/*.xml</include>
-                  <include>.gitignore</include>
-                </includes>
-                <!-- ignore build files -->
-                <excludes>
-                  <exclude>.idea/**</exclude>
-                  <exclude>.settings/**</exclude>
-                  <exclude>**/target/**</exclude>
-                  <exclude>bin/**</exclude>
-                  <exclude>tmp/**</exclude>
-                </excludes>
-                <trimTrailingWhitespace/>
-                <endWithNewline/>
-                <indent>
-                  <spaces>true</spaces>
-                </indent>
-              </format>
-              <format>
-                <includes>
-                  <include>**/*.md</include>
-                </includes>
-                <excludes>
-                  <exclude>**/target/**</exclude>
-                </excludes>
-                <prettier>
-                  <!-- Formatter that Spotless supports and can format Markdown:
-                       https://github.com/diffplug/spotless/tree/main/plugin-maven#prettier
-                     Only Spotless-supported formatter that can be configured to
-                     force line wrap -->
-                  <config>
-                    <proseWrap>always</proseWrap>
-                  </config>
-                </prettier>
-              </format>
-            </formats>
-            <!-- define a language-specific format -->
-            <java>
-              <importOrder/>
-              <!-- standard import order -->
-
-              <removeUnusedImports/>
-
-              <!-- apply a specific flavor of google-java-format and reflow long strings -->
-              <googleJavaFormat>
-                <version>1.17.0</version>
-                <style>GOOGLE</style>
-                <reflowLongStrings>true</reflowLongStrings>
-              </googleJavaFormat>
-            </java>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>apply</goal>
-              </goals>
-              <phase>compile</phase>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -160,6 +78,88 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+
+      <!-- Code formatter -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.46.1</version>
+        <configuration>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+            </sortPom>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+            <indent>
+              <spaces>true</spaces>
+            </indent>
+          </pom>
+          <formats>
+            <!-- you can define as many formats as you want, each is independent -->
+            <format>
+              <!-- define the files to apply to -->
+              <includes>
+                <include>**/*.sh</include>
+                <include>**/*.xml</include>
+                <include>.gitignore</include>
+              </includes>
+              <!-- ignore build files -->
+              <excludes>
+                <exclude>.idea/**</exclude>
+                <exclude>.settings/**</exclude>
+                <exclude>**/target/**</exclude>
+                <exclude>bin/**</exclude>
+                <exclude>tmp/**</exclude>
+              </excludes>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+              <indent>
+                <spaces>true</spaces>
+              </indent>
+            </format>
+            <format>
+              <includes>
+                <include>**/*.md</include>
+              </includes>
+              <excludes>
+                <exclude>**/target/**</exclude>
+              </excludes>
+              <prettier>
+                <!-- Formatter that Spotless supports and can format Markdown:
+                     https://github.com/diffplug/spotless/tree/main/plugin-maven#prettier
+                   Only Spotless-supported formatter that can be configured to
+                   force line wrap -->
+                <config>
+                  <proseWrap>always</proseWrap>
+                </config>
+              </prettier>
+            </format>
+          </formats>
+          <!-- define a language-specific format -->
+          <java>
+            <importOrder/>
+            <!-- standard import order -->
+
+            <removeUnusedImports/>
+
+            <!-- apply a specific flavor of google-java-format and reflow long strings -->
+            <googleJavaFormat>
+              <version>1.17.0</version>
+              <style>GOOGLE</style>
+              <reflowLongStrings>true</reflowLongStrings>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>apply</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
## Description of what I changed

Running `mvn clean package` from root doesn't format certain submodules. This PR addresses this issue.

## E2E test

N/A

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the
      [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review
  [Java](https://google.github.io/styleguide/javaguide.html) and
  [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google
      [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? ->
  [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing
      code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
      added all formatting changes to my commit.
- [x] If I made any Python code changes, I ran `black .` and `pylint .` right
      before creating this pull request and added all formatting changes to my
      commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
