### PR TITLE
#1336 : poc-logger-suppress

### DIFF
--- a/pipelines/batch/README.md
+++ b/pipelines/batch/README.md
@@ -76,6 +76,7 @@ These parameters are used regardless of other pipeline options.
   See also
   [A note about Beam runners](pipelines/batch/README.md#a-note-about-beam-runners).
   Default: `DirectRunner`
+- `quietMode` - When true, suppresses noisy pipeline INFO logs. Default: `false`
 
 ### FHIR-Search input parameters
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/BasePipelineOptions.java
@@ -84,4 +84,10 @@ public interface BasePipelineOptions extends PipelineOptions {
   Integer getRecursiveDepth();
 
   void setRecursiveDepth(Integer value);
+
+  @Description("When true, suppress noisy pipeline INFO logs (WARN/ERROR only).")
+  @Default.Boolean(false)
+  boolean getQuietMode();
+
+  void setQuietMode(boolean value);
 }

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchResources.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchResources.java
@@ -84,9 +84,9 @@ public class FetchResources
       }
       if (values.size() > 1) {
         log.warn(
-            String.format(
-                "Unexpected multiple values for subject of %s with id %s",
-                resource.getResourceType(), resource.getId()));
+            "Unexpected multiple values for subject of {} with id {}",
+            resource.getResourceType(),
+            resource.getId());
       }
     }
     if (patientId == null) {
@@ -139,11 +139,10 @@ public class FetchResources
         throws IOException, SQLException, ViewApplicationException, ProfileException {
       String searchUrl = segment.searchUrl();
       log.info(
-          String.format(
-              "Fetching %d resources for state %s; URL= %s",
-              segment.count(),
-              this.stageIdentifier,
-              searchUrl.substring(0, Math.min(200, searchUrl.length()))));
+          "Fetching {} resources for state {}; URL={}",
+          segment.count(),
+          this.stageIdentifier,
+          searchUrl.substring(0, Math.min(200, searchUrl.length())));
       long fetchStartTime = System.currentTimeMillis();
       Bundle pageBundle = fhirSearchUtil.searchByUrl(searchUrl, segment.count(), SummaryEnum.DATA);
       addFetchTime(System.currentTimeMillis() - fetchStartTime);

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FetchSearchPageFn.java
@@ -105,6 +105,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   private final int recursiveDepth;
 
+  private final boolean quietMode;
+
   @Nullable protected final DataSourceConfig sinkDbConfig;
 
   protected final String viewDefinitionsDir;
@@ -160,6 +162,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
     this.structureDefinitionsPath = options.getStructureDefinitionsPath();
     this.fhirVersionEnum = options.getFhirVersion();
     this.recursiveDepth = options.getRecursiveDepth();
+    this.quietMode = options.getQuietMode();
     if (options.getSinkDbConfigPath().isEmpty()) {
       this.sinkDbConfig = null;
     } else {
@@ -194,7 +197,8 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 
   @Setup
   public void setup() throws SQLException, ProfileException {
-    log.debug("Starting setup for stage " + stageIdentifier);
+    LoggingConfigurator.applyQuietMode(quietMode);
+    log.debug("Starting setup for stage {}", stageIdentifier);
     avroConversionUtil =
         AvroConversionUtil.getInstance(fhirVersionEnum, structureDefinitionsPath, recursiveDepth);
     FhirContext fhirContext = avroConversionUtil.getFhirContext();
@@ -223,6 +227,7 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
             oAuthClientId,
             oAuthClientSecret,
             checkPatientEndpoint,
+            quietMode,
             fhirContext);
     Preconditions.checkNotNull(fetchUtil);
     fhirSearchUtil = new FhirSearchUtil(fetchUtil);

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ParquetMerger.java
@@ -483,7 +483,8 @@ public class ParquetMerger {
     PipelineOptionsFactory.register(ParquetMergerOptions.class);
     ParquetMergerOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(ParquetMergerOptions.class);
-    log.info("Flags: " + options);
+    LoggingConfigurator.applyQuietMode(options.getQuietMode());
+    log.info("Flags: {}", options);
     AvroConversionUtil avroConversionUtil =
         AvroConversionUtil.getInstance(
             options.getFhirVersion(),

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/FetchUtil.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/FetchUtil.java
@@ -73,6 +73,8 @@ public class FetchUtil {
 
   private final boolean checkPatientEndpoint;
 
+  private final boolean quietMode;
+
   private final FhirContext fhirContext;
 
   @Nullable private final IClientInterceptor authInterceptor;
@@ -85,6 +87,7 @@ public class FetchUtil {
       String oAuthClientId,
       String oAuthClientSecret,
       boolean checkPatientEndpoint,
+      boolean quietMode,
       FhirContext fhirContext) {
     this.fhirUrl = sourceFhirUrl;
     this.sourceUser = Strings.nullToEmpty(sourceUser);
@@ -92,6 +95,7 @@ public class FetchUtil {
     this.oAuthClientId = Strings.nullToEmpty(oAuthClientId);
     this.oAuthClientSecret = Strings.nullToEmpty(oAuthClientSecret);
     this.checkPatientEndpoint = checkPatientEndpoint;
+    this.quietMode = quietMode;
     this.fhirContext = fhirContext;
     Preconditions.checkState(
         this.oAuthTokenEndpoint.isEmpty()
@@ -214,7 +218,7 @@ public class FetchUtil {
       client.registerInterceptor(authInterceptor);
     }
 
-    if (enableRequestLogging) {
+    if (enableRequestLogging && !quietMode) {
       LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
       loggingInterceptor.setLogger(log);
       loggingInterceptor.setLogRequestSummary(true);

--- a/pipelines/common/src/main/java/com/google/fhir/analytics/LoggingConfigurator.java
+++ b/pipelines/common/src/main/java/com/google/fhir/analytics/LoggingConfigurator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020-2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.analytics;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+/** Helper for runtime logger-level configuration. */
+public final class LoggingConfigurator {
+
+  private static final String LOGGER_CONTEXT_CLASS = "ch.qos.logback.classic.LoggerContext";
+  private static final String LOGGER_CLASS = "ch.qos.logback.classic.Logger";
+  private static final String LEVEL_CLASS = "ch.qos.logback.classic.Level";
+  private static final String WARN_LEVEL = "WARN";
+
+  private static final String[] QUIET_LOGGERS =
+      new String[] {"com.google.fhir.analytics", "ca.uhn.fhir", "com.cerner.bunsen"};
+
+  private static final AtomicBoolean QUIET_MODE_APPLIED = new AtomicBoolean(false);
+
+  private LoggingConfigurator() {}
+
+  /** Applies runtime quiet mode (WARN/ERROR) for known noisy logger categories. */
+  public static void applyQuietMode(boolean quietMode) {
+    if (!quietMode || !QUIET_MODE_APPLIED.compareAndSet(false, true)) {
+      return;
+    }
+    ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+    if (!LOGGER_CONTEXT_CLASS.equals(loggerFactory.getClass().getName())) {
+      return;
+    }
+    try {
+      Class<?> loggerContextClass = Class.forName(LOGGER_CONTEXT_CLASS);
+      Class<?> loggerClass = Class.forName(LOGGER_CLASS);
+      Class<?> levelClass = Class.forName(LEVEL_CLASS);
+      Method getLoggerMethod = loggerContextClass.getMethod("getLogger", String.class);
+      Method setLevelMethod = loggerClass.getMethod("setLevel", levelClass);
+      Field warnField = levelClass.getField(WARN_LEVEL);
+      Object warnLevel = warnField.get(null);
+      for (String loggerName : QUIET_LOGGERS) {
+        Object logger = getLoggerMethod.invoke(loggerFactory, loggerName);
+        setLevelMethod.invoke(logger, warnLevel);
+      }
+    } catch (ReflectiveOperationException ignored) {
+      return;
+    }
+  }
+}

--- a/pipelines/common/src/test/java/com/google/fhir/analytics/FetchUtilTest.java
+++ b/pipelines/common/src/test/java/com/google/fhir/analytics/FetchUtilTest.java
@@ -64,6 +64,7 @@ public class FetchUtilTest {
             "someOAuthClient",
             "someOAuthSecret",
             true,
+            false,
             fhirContext);
 
     doNothing().when(clientFactory).setSocketTimeout(any(Integer.class));

--- a/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
+++ b/pipelines/controller/src/main/java/com/google/fhir/analytics/PipelineManager.java
@@ -346,6 +346,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
   }
 
   private void validateFhirServerParams(FhirEtlOptions options) {
+    LoggingConfigurator.applyQuietMode(options.getQuietMode());
     FetchUtil fetchUtil =
         new FetchUtil(
             options.getFhirServerUrl(),
@@ -355,6 +356,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
             options.getFhirServerOAuthClientId(),
             options.getFhirServerOAuthClientSecret(),
             options.getCheckPatientEndpoint(),
+            options.getQuietMode(),
             avroConversionUtil.getFhirContext());
     fetchUtil.testFhirConnection();
   }
@@ -472,6 +474,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
     mergerOptions.setMergedDwh(finalDwhRoot);
     mergerOptions.setRunner(FlinkRunner.class);
     mergerOptions.setViewDefinitionsDir(options.getViewDefinitionsDir());
+    mergerOptions.setQuietMode(options.getQuietMode());
     // The number of shards is set based on the parallelism available for the FlinkRunner
     // Pipeline
     // TODO: For Flink non-local mode, refactor this to be not dependent on the
@@ -717,6 +720,7 @@ public class PipelineManager implements ApplicationListener<ApplicationReadyEven
 
     @Override
     public void run() {
+      LoggingConfigurator.applyQuietMode(options.getQuietMode());
       long start = System.currentTimeMillis();
       // The number of threads may increase after a few runs, but it should eventually go down.
       logger.info(


### PR DESCRIPTION
This PR adds a new flag --quietMode (default false) to reduce noisy production logs without changing default behavior.
When --quietMode=true, logging for noisy packages is set to WARN at runtime and HAPI request-summary logging is disabled, so URL/per-request INFO chatter is suppressed while WARN/ERROR remains visible.
It is applied in both launcher and worker paths (FhirEtl, ParquetMerger, FetchSearchPageFn setup, and controller pipeline paths), so it works for distributed Beam execution too.
I also propagated quiet mode to incremental merger options from the controller.

About String.format changes: correctness does not depend on this, but it is useful in hot INFO paths.
[String.format(...)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Pratik/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#) builds the string even when INFO is disabled; SLF4J placeholder style ("{}") defers formatting unless that log level is enabled.
So in quiet mode it avoids unnecessary formatting overhead.
If you want minimal diff, we can keep this only for high-frequency INFO logs and revert the rest.

I validated with targeted tests: FetchUtilTest, FetchResourcesTest, and FhirSearchUtilTest passed.


closes #1336

will extend this other modules also.. if the way of suppressing is approved

thanks