### PR TITLE
Support fhir_id column in hfj_resource for HAPI 7.2.0+

### DIFF
--- a/pipelines/batch/pom.xml
+++ b/pipelines/batch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2025 Google LLC
+    Copyright 2020-2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/ConvertResourceFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
   public void writeResource(HapiRowDescriptor element)
       throws IOException, ParseException, SQLException, ViewApplicationException, ProfileException {
     String resourceId = element.resourceId();
-    String forcedId = element.forcedId();
+    String fhirId = element.fhirId();
     String resourceType = element.resourceType();
     Meta meta =
         new Meta()
@@ -135,10 +135,10 @@ public class ConvertResourceFn extends FetchSearchPageFn<HapiRowDescriptor> {
       }
     }
     incrementElapsedTimeCounter(totalParseTimeMillisMap, resourceType, startTime);
-    if (forcedId == null || forcedId.isEmpty()) {
+    if (fhirId == null || fhirId.isEmpty()) {
       resource.setId(resourceId);
     } else {
-      resource.setId(forcedId);
+      resource.setId(fhirId);
     }
     resource.setMeta(meta);
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/FhirEtl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,6 +326,7 @@ public class FhirEtl {
     DataSource jdbcSource = createJdbcPooledDataSource(options, dbConfig);
 
     JdbcFetchHapi jdbcFetchHapi = new JdbcFetchHapi(jdbcSource);
+    boolean hasFhirIdColumn = jdbcFetchHapi.hasFhirIdColumn();
     Map<String, Integer> resourceCount =
         jdbcFetchHapi.searchResourceCounts(options.getResourceList(), options.getSince());
 
@@ -353,7 +354,8 @@ public class FhirEtl {
               new JdbcFetchHapi.FetchRowsJdbcIo(
                   options.getResourceList(),
                   JdbcIO.DataSourceConfiguration.create(jdbcSource),
-                  options.getSince()));
+                  options.getSince(),
+                  hasFhirIdColumn));
 
       payload.apply(
           "Convert to parquet for " + resourceType,

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/HapiRowDescriptor.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/HapiRowDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,26 +32,20 @@ abstract class HapiRowDescriptor implements Serializable {
 
   static HapiRowDescriptor create(
       String resourceId,
-      String forcedId,
+      String fhirId,
       String resourceType,
       String lastUpdated,
       String fhirVersion,
       String resourceVersion,
       String jsonResource) {
     return new AutoValue_HapiRowDescriptor(
-        resourceId,
-        forcedId,
-        resourceType,
-        lastUpdated,
-        fhirVersion,
-        resourceVersion,
-        jsonResource);
+        resourceId, fhirId, resourceType, lastUpdated, fhirVersion, resourceVersion, jsonResource);
   }
 
   abstract String resourceId();
 
   @Nullable
-  abstract String forcedId();
+  abstract String fhirId();
 
   abstract String resourceType();
 

--- a/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
+++ b/pipelines/batch/src/main/java/com/google/fhir/analytics/JdbcFetchHapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,26 @@ public class JdbcFetchHapi {
   }
 
   /**
+   * Detects whether the HAPI FHIR database has a fhir_id column on hfj_resource (HAPI 7.2.0+) by
+   * querying information_schema. Returns true if the column exists, false otherwise.
+   */
+  boolean hasFhirIdColumn() throws SQLException {
+    try (Connection connection = jdbcSource.getConnection();
+        PreparedStatement stmt =
+            connection.prepareStatement(
+                "SELECT COUNT(*) FROM information_schema.columns"
+                    + " WHERE table_name = 'hfj_resource' AND column_name = 'fhir_id'");
+        ResultSet rs = stmt.executeQuery()) {
+      rs.next();
+      boolean found = rs.getInt(1) > 0;
+      log.info(
+          "HAPI FHIR schema detection: hfj_resource.fhir_id column {}.",
+          found ? "found" : "not found");
+      return found;
+    }
+  }
+
+  /**
    * RowMapper class implementation for JdbcIo direct fetch with HAPI as the source FHIR server.
    * Each element in the ResultSet returned by the query maps to a List of String objects
    * corresponding to the column values in the query result.
@@ -95,7 +115,7 @@ public class JdbcFetchHapi {
           };
 
       String resourceId = resultSet.getString("res_id");
-      String forcedId = resultSet.getString("forced_id");
+      String fhirId = resultSet.getString("fhir_id");
       String resourceType = resultSet.getString("res_type");
       String lastUpdated = resultSet.getString("res_updated");
       String fhirVersion = resultSet.getString("res_version");
@@ -104,7 +124,7 @@ public class JdbcFetchHapi {
         numMappedResourcesMap.get(resourceType).inc();
       return HapiRowDescriptor.create(
           resourceId,
-          forcedId,
+          fhirId,
           resourceType,
           lastUpdated,
           fhirVersion,
@@ -147,18 +167,40 @@ public class JdbcFetchHapi {
     private final String tagQuery;
 
     public FetchRowsJdbcIo(
-        String resourceList, JdbcIO.DataSourceConfiguration dataSourceConfig, String since) {
+        String resourceList,
+        JdbcIO.DataSourceConfiguration dataSourceConfig,
+        String since,
+        boolean hasFhirIdColumn) {
       this.resourceList = resourceList;
       this.dataSourceConfig = dataSourceConfig;
       // Note the constraint on `res.res_ver` ensures we only pick the latest version.
-      StringBuilder builder =
-          new StringBuilder(
-              "SELECT res.res_id, hfi.forced_id, res.res_type, res.res_updated, res.res_ver,"
-                  + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc "
-                  + " FROM hfj_resource res JOIN"
-                  + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver "
-                  + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid "
-                  + " WHERE res.res_type = ? AND res.res_id % ? = ?");
+      StringBuilder builder;
+      if (hasFhirIdColumn) {
+        // HAPI 7.2.0+: prefer res.fhir_id, fall back to hfj_forced_id via subquery (no JOIN).
+        builder =
+            new StringBuilder(
+                "SELECT res.res_id,"
+                    + " CASE WHEN res.fhir_id IS NOT NULL THEN res.fhir_id"
+                    + " ELSE (SELECT hfi.forced_id FROM hfj_forced_id hfi"
+                    + " WHERE hfi.resource_pid = res.res_id)"
+                    + " END AS fhir_id,"
+                    + " res.res_type, res.res_updated, res.res_ver,"
+                    + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc "
+                    + " FROM hfj_resource res JOIN"
+                    + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver "
+                    + " WHERE res.res_type = ? AND res.res_id % ? = ?");
+      } else {
+        // Old HAPI: fhir_id column does not exist, use hfj_forced_id table.
+        builder =
+            new StringBuilder(
+                "SELECT res.res_id, hfi.forced_id AS fhir_id,"
+                    + " res.res_type, res.res_updated, res.res_ver,"
+                    + " res.res_version, ver.res_encoding, ver.res_text, ver.res_text_vc "
+                    + " FROM hfj_resource res JOIN"
+                    + " hfj_res_ver ver ON res.res_id = ver.res_id AND res.res_ver = ver.res_ver "
+                    + " LEFT JOIN hfj_forced_id hfi ON res.res_id = hfi.resource_pid "
+                    + " WHERE res.res_type = ? AND res.res_id % ? = ?");
+      }
       // TODO do date sanity-checking on `since` (note this is partly done by HAPI client call).
       if (since != null && !since.isEmpty()) {
         builder.append(" AND res.res_updated > '").append(since).append("'");

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/ConvertResourceFnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class ConvertResourceFnTest {
   }
 
   @Test
-  public void testProcessPatientResource_withoutForcedId()
+  public void testProcessPatientResource_withoutFhirId()
       throws IOException,
           java.text.ParseException,
           SQLException,
@@ -101,7 +101,7 @@ public class ConvertResourceFnTest {
   }
 
   @Test
-  public void testProcessPatientResource_withForcedId()
+  public void testProcessPatientResource_withFhirId()
       throws IOException,
           java.text.ParseException,
           SQLException,
@@ -114,19 +114,13 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123",
-            "forced-id-123",
-            "Patient",
-            "2020-09-19 12:09:23",
-            "R4",
-            "1",
-            patientResourceStr);
+            "123", "fhir-id-123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
     convertResourceFn.writeResource(element);
 
     // Verify the resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
+    assertThat(capturedResource.getId(), equalTo("fhir-id-123"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
     assertThat(
         capturedResource.getMeta().getLastUpdated(),
@@ -148,7 +142,7 @@ public class ConvertResourceFnTest {
     // Deleted Patient resource
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+            "123", "fhir-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
     // Verify that the ParquetUtil writer is not invoked for the deleted resource.
     verify(mockParquetUtil, times(0)).write(Mockito.any());
@@ -167,13 +161,13 @@ public class ConvertResourceFnTest {
     // Deleted Patient resource
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123", "forced-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
+            "123", "fhir-id-123", "Patient", "2020-09-19 12:09:23", "R4", "2", "");
     convertResourceFn.writeResource(element);
 
     // Verify the deleted resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
+    assertThat(capturedResource.getId(), equalTo("fhir-id-123"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("2"));
     assertThat(
         capturedResource
@@ -200,13 +194,7 @@ public class ConvertResourceFnTest {
         Resources.toString(Resources.getResource("patient.json"), StandardCharsets.UTF_8);
     HapiRowDescriptor element =
         HapiRowDescriptor.create(
-            "123",
-            "forced-id-123",
-            "Patient",
-            "2020-09-19 12:09:23",
-            "R4",
-            "1",
-            patientResourceStr);
+            "123", "fhir-id-123", "Patient", "2020-09-19 12:09:23", "R4", "1", patientResourceStr);
     // Set Tag of HAPI FHIR tag type 0
     Coding coding0 = new Coding("system0", "code0", "display0");
     ResourceTag tag0 = new ResourceTag(coding0, "123", 0);
@@ -222,7 +210,7 @@ public class ConvertResourceFnTest {
     // Verify the resource is sent to the writer.
     verify(mockParquetUtil).write(resourceCaptor.capture());
     Resource capturedResource = resourceCaptor.getValue();
-    assertThat(capturedResource.getId(), equalTo("forced-id-123"));
+    assertThat(capturedResource.getId(), equalTo("fhir-id-123"));
     assertThat(capturedResource.getMeta().getVersionId(), equalTo("1"));
     assertThat(
         capturedResource.getMeta().getLastUpdated(),

--- a/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchHapiTest.java
+++ b/pipelines/batch/src/test/java/com/google/fhir/analytics/JdbcFetchHapiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 Google LLC
+ * Copyright 2020-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package com.google.fhir.analytics;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.beans.PropertyVetoException;
 import java.io.IOException;
@@ -84,6 +86,7 @@ public class JdbcFetchHapiTest {
   public void testMapRow() throws Exception {
     Mockito.when(resultSet.getString("res_encoding")).thenReturn("DEL");
     Mockito.when(resultSet.getString("res_id")).thenReturn("101");
+    Mockito.when(resultSet.getString("fhir_id")).thenReturn("encounter-abc-123");
     Mockito.when(resultSet.getString("res_type")).thenReturn("Encounter");
     Mockito.when(resultSet.getString("res_updated")).thenReturn("2002-03-12 10:09:20");
     Mockito.when(resultSet.getString("res_ver")).thenReturn("1");
@@ -94,6 +97,7 @@ public class JdbcFetchHapiTest {
 
     assertNotNull(rowDescriptor);
     assertEquals("101", rowDescriptor.resourceId());
+    assertEquals("encounter-abc-123", rowDescriptor.fhirId());
     assertEquals("Encounter", rowDescriptor.resourceType());
     assertEquals("1", rowDescriptor.resourceVersion());
     assertEquals("2002-03-12 10:09:20", rowDescriptor.lastUpdated());
@@ -125,5 +129,43 @@ public class JdbcFetchHapiTest {
     assertThat(resourceCountMap.get("Patient"), equalTo(100));
     assertThat(resourceCountMap.get("Encounter"), equalTo(100));
     assertThat(resourceCountMap.get("Observation"), equalTo(100));
+  }
+
+  @Test
+  public void testHasFhirIdColumn_columnExists() throws SQLException {
+    Connection mockedConnection = Mockito.mock(Connection.class);
+    PreparedStatement mockedStmt = Mockito.mock(PreparedStatement.class);
+    ResultSet mockedResultSet = Mockito.mock(ResultSet.class);
+
+    Mockito.when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
+    Mockito.when(
+            mockedConnection.prepareStatement(
+                "SELECT COUNT(*) FROM information_schema.columns"
+                    + " WHERE table_name = 'hfj_resource' AND column_name = 'fhir_id'"))
+        .thenReturn(mockedStmt);
+    Mockito.when(mockedStmt.executeQuery()).thenReturn(mockedResultSet);
+    Mockito.when(mockedResultSet.next()).thenReturn(true);
+    Mockito.when(mockedResultSet.getInt(1)).thenReturn(1);
+
+    assertTrue(jdbcFetchHapi.hasFhirIdColumn());
+  }
+
+  @Test
+  public void testHasFhirIdColumn_columnDoesNotExist() throws SQLException {
+    Connection mockedConnection = Mockito.mock(Connection.class);
+    PreparedStatement mockedStmt = Mockito.mock(PreparedStatement.class);
+    ResultSet mockedResultSet = Mockito.mock(ResultSet.class);
+
+    Mockito.when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
+    Mockito.when(
+            mockedConnection.prepareStatement(
+                "SELECT COUNT(*) FROM information_schema.columns"
+                    + " WHERE table_name = 'hfj_resource' AND column_name = 'fhir_id'"))
+        .thenReturn(mockedStmt);
+    Mockito.when(mockedStmt.executeQuery()).thenReturn(mockedResultSet);
+    Mockito.when(mockedResultSet.next()).thenReturn(true);
+    Mockito.when(mockedResultSet.getInt(1)).thenReturn(0);
+
+    assertFalse(jdbcFetchHapi.hasFhirIdColumn());
   }
 }

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2025 Google LLC
+    Copyright 2020-2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2025 Google LLC
+    Copyright 2020-2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description of what I changed

This implements issue #1219 
by adding support for the `fhir_id` column on `hfj_resource` table to support the [newer versions 7.2.0+](https://hapifhir.io/hapi-fhir/docs/v/7.2.3/introduction/changelog.html#upgrade-instructions-2) of HAPI FHIR Server.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Started a HAPI server + PostgreSQL

```bash
docker compose -f docker/hapi-compose.yml up -d
```

Waited for HAPI server and the PostgreSQL to be ready.

Then created a sink DB.

```bash
docker exec -it hapi-fhir-db psql -U admin -d postgres -c "CREATE DATABASE views;"
```

Created temporary config files.

```bash
cat > /tmp/hapi-postgres-config-local.json << 'EOF'
{
  "jdbcDriverClass": "org.postgresql.Driver",
  "databaseService": "postgresql",
  "databaseHostName": "localhost",
  "databasePort": "5432",
  "databaseUser": "admin",
  "databasePassword": "admin",
  "databaseName": "hapi"
}
EOF

cat > /tmp/sink-db-config-local.json << 'EOF'
{
  "jdbcDriverClass": "org.postgresql.Driver",
  "databaseService": "postgresql",
  "databaseHostName": "localhost",
  "databasePort": "5432",
  "databaseUser": "admin",
  "databasePassword": "admin",
  "databaseName": "views"
}
EOF
```

Then populated the HAPI Server with test resources.

```bash
curl -X PUT http://localhost:8091/fhir/Patient/my-patient-abc \
  -H "Content-Type: application/fhir+json" \
  -d '{"resourceType":"Patient","id":"my-patient-abc","name":[{"family":"Test"}]}'

curl -X PUT http://localhost:8091/fhir/Patient/my-patient-xyz \
  -H "Content-Type: application/fhir+json" \
  -d '{"resourceType":"Patient","id":"my-patient-xyz","name":[{"family":"Test2"}]}'
```

Ran the pipeline

```bash
java -cp pipelines/batch/target/batch-bundled*.jar \
  com.google.fhir.analytics.FhirEtl \
  --fhirFetchMode=HAPI_JDBC \
  --resourceList=Patient \
  --fhirDatabaseConfigPath=/tmp/hapi-postgres-config-local.json \
  --sinkDbConfigPath=/tmp/sink-db-config-local.json
```

Verified correct resource id in sink DB.

```bash
docker exec -it hapi-fhir-db psql -U admin -d views -c \
  "SELECT id FROM patient;"
```

Found: `my-patient-abc` and `my-patient-xyz` (not numeric IDs). ✅

Cleaned up then repeated the test  with `hapiproject/hapi:v7.0.0` image instead of latest to validate backward compatibality.

```bash
docker compose -f docker/hapi-compose.yml down -v
```

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the
      [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review
  [Java](https://google.github.io/styleguide/javaguide.html) and
  [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google
      [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? ->
  [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing
      code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
      added all formatting changes to my commit.
- [x] If I made any Python code changes, I ran `black .`, `pylint .` and
      `pyright` . right before creating this pull request and added all
      formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
